### PR TITLE
Feature/scheduler

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,4 @@ EXECUTE_KEY=5KH8ugwV5A8fyUnc5P11GrVKtNP6PboPowjEEgSYnxACCkkwxxD
 #
 
 COMPILER=local 
+

--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,11 @@ TELOS_TESTNET_PRIVATE_KEY=5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3
 APPLICATION_KEY=5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3
 
 #
+# Permission private key for forum.seeds@execute on forum contract
+#
+EXECUTE_KEY=5KH8ugwV5A8fyUnc5P11GrVKtNP6PboPowjEEgSYnxACCkkwxxD
+
+#
 # Use compiler in docker container - e.g., eosio studio
 #
 

--- a/.eosproj
+++ b/.eosproj
@@ -1,8 +1,8 @@
 {
-  "main": "src/seeds.scheduler.cpp",
-  "contract": "scheduler",
+  "main": "src/seeds.organization.cpp",
+  "contract": "organization",
   "include": "",
-  "resource": "",
+  "resource": "resources",
   "cdt": "v1.6.3",
   "output": "",
   "scripts": {

--- a/include/seeds.forum.hpp
+++ b/include/seeds.forum.hpp
@@ -39,21 +39,6 @@ CONTRACT forum : public contract {
 
 
     private:
-        // symbol seeds_symbol = symbol("SEEDS", 4);
-
-        void send_summary(name a){
-            action(
-                //permission_level,
-                permission_level{get_self(),"active"_n},
-                //code,
-                get_self(),
-                //action,
-                a,
-                //data
-                std::make_tuple()
-            ).send();   
-        }
-
         TABLE postcomment_table {
             uint64_t id;
             uint64_t parent_id;
@@ -171,5 +156,4 @@ CONTRACT forum : public contract {
         int64_t pointsfunction(name account, int64_t points_left, uint64_t vbp, uint64_t rep, uint64_t cutoff, uint64_t cutoff_zero);
         uint64_t getdperiods(uint64_t timestamp);
         int64_t getdpoints(int64_t points, uint64_t periods);
-        bool isRdyToExec(name operation);
 };

--- a/include/seeds.scheduler.hpp
+++ b/include/seeds.scheduler.hpp
@@ -23,9 +23,6 @@ CONTRACT scheduler : public contract {
 
         ACTION confirm(name operation);
 
-        ACTION noop();
-
-        ACTION np();
 
     private:
         TABLE operations_table {

--- a/include/seeds.scheduler.hpp
+++ b/include/seeds.scheduler.hpp
@@ -27,6 +27,8 @@ CONTRACT scheduler : public contract {
 
         ACTION confirm(name operation);
 
+        ACTION cancelexec();
+
     private:
         TABLE operations_table {
             name id;

--- a/include/seeds.scheduler.hpp
+++ b/include/seeds.scheduler.hpp
@@ -19,18 +19,24 @@ CONTRACT scheduler : public contract {
 
         ACTION execute();
 
-        ACTION configop(name action, name contract, uint64_t period);
+        ACTION configop(name id, name action, name contract, uint64_t period);
+
+        ACTION removeop(name id);
+
+        ACTION pauseop(name id, uint8_t pause);
 
         ACTION confirm(name operation);
 
     private:
         TABLE operations_table {
+            name id;
             name operation;
             name contract;
+            uint8_t pause;
             uint64_t period;
             uint64_t timestamp;
 
-            uint64_t primary_key() const { return operation.value; }
+            uint64_t primary_key() const { return id.value; }
         };
 
         TABLE config_table {
@@ -44,6 +50,7 @@ CONTRACT scheduler : public contract {
 
         typedef eosio::multi_index <"config"_n, config_table> config_tables;
 
+        name seconds_to_execute = "secndstoexec"_n;
 
         operations_tables operations;
         config_tables config;

--- a/resources/forum.contracts.md
+++ b/resources/forum.contracts.md
@@ -1,0 +1,107 @@
+<h1 class="contract">reset</h1>
+
+---
+spec_version: "0.2.0"
+title: Reset
+summary: 'This action will reset all the tables'
+icon: https://joinseeds.com/assets/images/logos/seeds-app-Icon_190626.png#604c0741207bdc82b3214d575bc75cf705fa9cbc0cfa7c7553269ee0c550fd35
+---
+
+{{$action.authorization.[0].actor}} resets all the tables within this contract.
+
+
+<h1 class="contract">createpost</h1>
+
+---
+spec_version: "0.2.0"
+title: Create post
+summary: 'Create a new post'
+icon: https://joinseeds.com/assets/images/logos/seeds-app-Icon_190626.png#604c0741207bdc82b3214d575bc75cf705fa9cbc0cfa7c7553269ee0c550fd35
+---
+
+{{$action.authorization.[0].actor}} creates a new post with the following backend_id: {{backend_id}}, url: {{url}} and body: {{body}}.
+
+
+<h1 class="contract">createcomt</h1>
+
+---
+spec_version: "0.2.0"
+title: Create comment
+summary: 'Create a new comment'
+icon: https://joinseeds.com/assets/images/logos/seeds-app-Icon_190626.png#604c0741207bdc82b3214d575bc75cf705fa9cbc0cfa7c7553269ee0c550fd35
+---
+
+{{$action.authorization.[0].actor}} creates a new comment on the post with id: {{post_id}}. The comment has the following backend_id: {{backend_id}}, url: {{url}} and body: {{body}}.
+
+
+<h1 class="contract">upvotepost</h1>
+
+---
+spec_version: "0.2.0"
+title: Up vote post
+summary: 'Give points to the given post'
+icon: https://joinseeds.com/assets/images/logos/seeds-app-Icon_190626.png#604c0741207bdc82b3214d575bc75cf705fa9cbc0cfa7c7553269ee0c550fd35
+---
+
+{{$action.authorization.[0].actor}} gives positive points to the post with id: {{id}}.
+
+
+<h1 class="contract">upvotecomt</h1>
+
+---
+spec_version: "0.2.0"
+title: Up vote comment
+summary: 'Give points to the given post'
+icon: https://joinseeds.com/assets/images/logos/seeds-app-Icon_190626.png#604c0741207bdc82b3214d575bc75cf705fa9cbc0cfa7c7553269ee0c550fd35
+---
+
+{{$action.authorization.[0].actor}} gives positive points to the comment with id: {{comment_id}} on the post {{post_id}}.
+
+
+<h1 class="contract">downvotepost</h1>
+
+---
+spec_version: "0.2.0"
+title: Down vote post
+summary: 'Give negative points to the given post'
+icon: https://joinseeds.com/assets/images/logos/seeds-app-Icon_190626.png#604c0741207bdc82b3214d575bc75cf705fa9cbc0cfa7c7553269ee0c550fd35
+---
+
+{{$action.authorization.[0].actor}} gives negative points to the post with id: {{id}}.
+
+
+<h1 class="contract">downvotecomt</h1>
+
+---
+spec_version: "0.2.0"
+title: Down vote post
+summary: 'Give negative points to the given comment'
+icon: https://joinseeds.com/assets/images/logos/seeds-app-Icon_190626.png#604c0741207bdc82b3214d575bc75cf705fa9cbc0cfa7c7553269ee0c550fd35
+---
+
+{{$action.authorization.[0].actor}} gives negative points to the comment with id: {{comment_id}} on the post {{post_id}}.
+
+
+<h1 class="contract">onperiod</h1>
+
+---
+spec_version: "0.2.0"
+title: On period
+summary: 'Devaluate the forum reputation'
+icon: https://joinseeds.com/assets/images/logos/seeds-app-Icon_190626.png#604c0741207bdc82b3214d575bc75cf705fa9cbc0cfa7c7553269ee0c550fd35
+---
+
+{{$action.authorization.[0].actor}} devaluates the reputation of all the forums within this contract.
+
+
+<h1 class="contract">newday</h1>
+
+---
+spec_version: "0.2.0"
+title: New day
+summary: 'Drop all the vote power entries'
+icon: https://joinseeds.com/assets/images/logos/seeds-app-Icon_190626.png#604c0741207bdc82b3214d575bc75cf705fa9cbc0cfa7c7553269ee0c550fd35
+---
+
+{{$action.authorization.[0].actor}} drops all the vote power entries within this contract.
+

--- a/resources/organization.contracts.md
+++ b/resources/organization.contracts.md
@@ -1,0 +1,121 @@
+<h1 class="contract">reset</h1>
+
+---
+spec_version: "0.2.0"
+title: Reset
+summary: 'This action will reset all the tables'
+icon: https://joinseeds.com/assets/images/logos/seeds-app-Icon_190626.png#604c0741207bdc82b3214d575bc75cf705fa9cbc0cfa7c7553269ee0c550fd35
+---
+
+{{$action.authorization.[0].actor}} resets all the tables within this contract.
+
+
+<h1 class="contract">addmember</h1>
+
+---
+spec_version: "0.2.0"
+title: Add member
+summary: 'Add a new member'
+icon: https://joinseeds.com/assets/images/logos/seeds-app-Icon_190626.png#604c0741207bdc82b3214d575bc75cf705fa9cbc0cfa7c7553269ee0c550fd35
+---
+
+{{$action.authorization.[0].actor}} adds the new member {{account}} to the organization {{organization}} with role {{role}}.
+
+
+<h1 class="contract">removemember</h1>
+
+---
+spec_version: "0.2.0"
+title: Remove member
+summary: 'Remove an existing member'
+icon: https://joinseeds.com/assets/images/logos/seeds-app-Icon_190626.png#604c0741207bdc82b3214d575bc75cf705fa9cbc0cfa7c7553269ee0c550fd35
+---
+
+{{$action.authorization.[0].actor}} removes the member {{account}} from the organization {{organization}}.
+
+
+<h1 class="contract">changerole</h1>
+
+---
+spec_version: "0.2.0"
+title: Change role
+summary: 'Assign a new role'
+icon: https://joinseeds.com/assets/images/logos/seeds-app-Icon_190626.png#604c0741207bdc82b3214d575bc75cf705fa9cbc0cfa7c7553269ee0c550fd35
+---
+
+{{$action.authorization.[0].actor}} assigns the role {{new_role}} to {{account}} in the organization {{organization}}.
+
+
+<h1 class="contract">changeowner</h1>
+
+---
+spec_version: "0.2.0"
+title: Change owner
+summary: 'Set a new owner for the given organization'
+icon: https://joinseeds.com/assets/images/logos/seeds-app-Icon_190626.png#604c0741207bdc82b3214d575bc75cf705fa9cbc0cfa7c7553269ee0c550fd35
+---
+
+{{$action.authorization.[0].actor}} gives to {{account}} the ownership of the organization {{organization}}.
+
+
+<h1 class="contract">addregen</h1>
+
+---
+spec_version: "0.2.0"
+title: Add regen points
+summary: 'Give positive regen points to the given organization'
+icon: https://joinseeds.com/assets/images/logos/seeds-app-Icon_190626.png#604c0741207bdc82b3214d575bc75cf705fa9cbc0cfa7c7553269ee0c550fd35
+---
+
+{{$action.authorization.[0].actor}} gives positive regen points to the organization {{organization}}.
+
+
+<h1 class="contract">subregen</h1>
+
+---
+spec_version: "0.2.0"
+title: Substract regen points
+summary: 'Give negative regen points to the given organization'
+icon: https://joinseeds.com/assets/images/logos/seeds-app-Icon_190626.png#604c0741207bdc82b3214d575bc75cf705fa9cbc0cfa7c7553269ee0c550fd35
+---
+
+{{$action.authorization.[0].actor}} gives negative regen points to the organization {{organization}}.
+
+
+<h1 class="contract">create</h1>
+
+---
+spec_version: "0.2.0"
+title: Create
+summary: 'Create a new organization'
+icon: https://joinseeds.com/assets/images/logos/seeds-app-Icon_190626.png#604c0741207bdc82b3214d575bc75cf705fa9cbc0cfa7c7553269ee0c550fd35
+---
+
+{{$action.authorization.[0].actor}} creates a new organization called {{orgname}}.
+
+
+<h1 class="contract">destroy</h1>
+
+---
+spec_version: "0.2.0"
+title: Destroy
+summary: 'Destroy the given organization'
+icon: https://joinseeds.com/assets/images/logos/seeds-app-Icon_190626.png#604c0741207bdc82b3214d575bc75cf705fa9cbc0cfa7c7553269ee0c550fd35
+---
+
+{{$action.authorization.[0].actor}} destroys its organization {{orgname}}.
+
+
+<h1 class="contract">refund</h1>
+
+---
+spec_version: "0.2.0"
+title: Refund
+summary: 'Withdraw the given quantity'
+icon: https://joinseeds.com/assets/images/logos/seeds-app-Icon_190626.png#604c0741207bdc82b3214d575bc75cf705fa9cbc0cfa7c7553269ee0c550fd35
+---
+
+{{$action.authorization.[0].actor}} withdraws {{quantity}} from this contract.
+
+
+

--- a/resources/scheduler.contracts.md
+++ b/resources/scheduler.contracts.md
@@ -1,0 +1,52 @@
+<h1 class="contract">reset</h1>
+
+---
+spec_version: "0.2.0"
+title: Reset
+summary: 'This action will reset all the tables'
+icon: https://joinseeds.com/assets/images/logos/seeds-app-Icon_190626.png#604c0741207bdc82b3214d575bc75cf705fa9cbc0cfa7c7553269ee0c550fd35
+---
+
+{{$action.authorization.[0].actor}} resets all the tables within this contract.
+
+
+<h1 class="contract">execute</h1>
+
+---
+spec_version: "0.2.0"
+title: Execute
+summary: 'Execute pending functions'
+icon: https://joinseeds.com/assets/images/logos/seeds-app-Icon_190626.png#604c0741207bdc82b3214d575bc75cf705fa9cbc0cfa7c7553269ee0c550fd35
+---
+
+{{$action.authorization.[0].actor}} executes the first pending function defined in this contract.
+
+
+<h1 class="contract">configop</h1>
+
+---
+spec_version: "0.2.0"
+title: Config operation
+summary: 'Set a new or an existing operation'
+icon: https://joinseeds.com/assets/images/logos/seeds-app-Icon_190626.png#604c0741207bdc82b3214d575bc75cf705fa9cbc0cfa7c7553269ee0c550fd35
+---
+
+{{$action.authorization.[0].actor}} creates or edits an operation with the values action: {{action}}, contract: {{contract}} and period: {{period}}.
+
+
+<h1 class="contract">confirm</h1>
+
+---
+spec_version: "0.2.0"
+title: Confirm action
+summary: 'Set a new or an existing operation'
+icon: https://joinseeds.com/assets/images/logos/seeds-app-Icon_190626.png#604c0741207bdc82b3214d575bc75cf705fa9cbc0cfa7c7553269ee0c550fd35
+---
+
+{{$action.authorization.[0].actor}} confirms the successful execution of the action {{operation}}.
+
+
+
+
+
+

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -360,6 +360,36 @@ var permissions = [{
   target: `${accounts.forum.account}@execute`,
   action: 'newday'
 }, {
+  target: `${accounts.harvest.account}@execute`,
+  key: execPublicKey,
+  parent: 'active'
+}, {
+  target: `${accounts.harvest.account}@execute`,
+  actor: `${accounts.scheduler.account}@active`
+}, {
+  target: `${accounts.harvest.account}@execute`,
+  action: 'calcplanted'
+}, {
+  target: `${accounts.harvest.account}@execute`,
+  action: 'calctrx'
+}, {
+  target: `${accounts.harvest.account}@execute`,
+  action: 'calcrep'
+}, {
+  target: `${accounts.referendums.account}@execute`,
+  key: execPublicKey,
+  parent: 'active'
+}, {
+  target: `${accounts.referendums.account}@execute`,
+  actor: `${accounts.scheduler.account}@active`
+}, {
+  target: `${accounts.proposals.account}@execute`,
+  key: execPublicKey,
+  parent: 'active'
+}, {
+  target: `${accounts.proposals.account}@execute`,
+  actor: `${accounts.scheduler.account}@active`
+}, {
   target: `${accounts.onboarding.account}@application`,
   action: 'acceptnew'
 }, {

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -80,6 +80,13 @@ const applicationKeys = {
 }
 const applicationPublicKey = applicationKeys[chainId]
 
+const executePublicKeys = {
+  [networks.local]: 'EOS5dLm4DBjUxbczCwi7HzYR42DFhjh1AMZERYaxDkK8qAJxZUvbZ',
+  [networks.telosMainnet]: 'EOS5dLm4DBjUxbczCwi7HzYR42DFhjh1AMZERYaxDkK8qAJxZUvbZ',
+  [networks.telosTestnet]: 'EOS5dLm4DBjUxbczCwi7HzYR42DFhjh1AMZERYaxDkK8qAJxZUvbZ'
+}
+const execPublicKey = executePublicKeys[chainId]
+
 const freePublicKey = 'EOS8UAPG5qSWetotJjZizQKbXm8dkRF2BGFyZdub8GbeRbeXeDrt9'
 
 const account = (accountName, quantity = '0.0000 SEEDS', pubkey = activePublicKey) => ({
@@ -330,6 +337,19 @@ const permissions = [{
   target: `${accounts.forum.account}@active`,
   actor: `${accounts.forum.account}@eosio.code`
 }, {
+  target: `${accounts.forum.account}@execute`,
+  key: execPublicKey,
+  parent: 'active'
+}, {
+  target: `${accounts.forum.account}@execute`,
+  actor: `${accounts.scheduler.account}@active`
+}, {
+  target: `${accounts.forum.account}@execute`,
+  action: 'onperiod'
+}, {
+  target: `${accounts.forum.account}@execute`,
+  action: 'newday'
+}, {
   target: `${accounts.onboarding.account}@application`,
   action: 'acceptnew'
 }, {
@@ -348,9 +368,9 @@ const permissions = [{
 }]
 
 const keyProviders = {
-  [networks.local]: [process.env.LOCAL_PRIVATE_KEY, process.env.LOCAL_PRIVATE_KEY, process.env.APPLICATION_KEY],
-  [networks.telosMainnet]: [process.env.TELOS_MAINNET_OWNER_KEY, process.env.TELOS_MAINNET_ACTIVE_KEY, process.env.APPLICATION_KEY],
-  [networks.telosTestnet]: [process.env.TELOS_TESTNET_OWNER_KEY, process.env.TELOS_TESTNET_ACTIVE_KEY, process.env.APPLICATION_KEY]
+  [networks.local]: [process.env.LOCAL_PRIVATE_KEY, process.env.LOCAL_PRIVATE_KEY, process.env.APPLICATION_KEY, process.env.EXECUTE_KEY],
+  [networks.telosMainnet]: [process.env.TELOS_MAINNET_OWNER_KEY, process.env.TELOS_MAINNET_ACTIVE_KEY, process.env.APPLICATION_KEY, process.env.EXECUTE_KEY],
+  [networks.telosTestnet]: [process.env.TELOS_TESTNET_OWNER_KEY, process.env.TELOS_TESTNET_ACTIVE_KEY, process.env.APPLICATION_KEY, process.env.EXECUTE_KEY]
 }
 
 const keyProvider = keyProviders[chainId]

--- a/src/seeds.forum.cpp
+++ b/src/seeds.forum.cpp
@@ -167,22 +167,6 @@ uint64_t forum::getdperiods(uint64_t timestamp) {
 }
 
 
-bool forum::isRdyToExec(name operation){
-    auto itr = operations.find(operation.value);
-    check(itr != operations.end(), "The operation does not exist.");
-    uint64_t timestamp = eosio::current_time_point().sec_since_epoch();
-    uint64_t periods = 0;
-
-    periods = ((timestamp - itr -> timestamp) * 10000) / itr -> period;
-
-
-    if(periods > 0) return true;
-
-    check(false, std::to_string(timestamp) + ", t = " + std::to_string(itr -> timestamp));
-    return false;
-}
-
-
 ACTION forum::reset() {
     require_auth(_self);
 
@@ -314,12 +298,7 @@ ACTION forum::downvotecomt(name account, uint64_t post_id, uint64_t comment_id) 
 
 
 ACTION forum::onperiod() {
-    //require_auth(permission_level(contracts::forum, "period"_n));
-    //require_auth(permission_level(contracts::scheduler, "scheduled"_n));
-
-    if(!isRdyToExec(name("onperiod"))){
-        check(false, "onperiod is not ready to be executed.");
-    }
+    require_auth(permission_level(contracts::forum, "execute"_n));
 
     auto ditr = config.get(depreciation.value, "Depreciation factor is not configured.");
     uint64_t depreciation = ditr.value;
@@ -331,22 +310,16 @@ ACTION forum::onperiod() {
         });
         itr++;
     }
-
 }
 
 
 ACTION forum::newday() {
-    //require_auth(contracts::scheduler);
-
-    if(!isRdyToExec(name("newday"))){
-        check(false, "newday is not ready to be executed.");
-    }
+    require_auth(permission_level(contracts::forum, "execute"_n));
 
     auto itr = votespower.begin();
     while(itr != votespower.end()){
         itr = votespower.erase(itr);
     }
-
 }
 
 

--- a/src/seeds.harvest.cpp
+++ b/src/seeds.harvest.cpp
@@ -265,15 +265,7 @@ void harvest::calcrep() {
     uitr++;
   }
 
-  transaction trx{};
-  trx.actions.emplace_back(
-    permission_level(_self, "active"_n),
-    _self,
-    "calcrep"_n,
-    std::make_tuple()
-  );
-  trx.delay_sec = 60;
-  trx.send(eosio::current_time_point().sec_since_epoch() + 10, _self);
+  print("HARVEST: calcrep executed");
 }
 
 void harvest::calctrx() {
@@ -312,15 +304,7 @@ void harvest::calctrx() {
     uitr++;
   }
 
-  transaction trx{};
-  trx.actions.emplace_back(
-    permission_level(_self, "active"_n),
-    _self,
-    "calctrx"_n,
-    std::make_tuple()
-  );
-  trx.delay_sec = 60;
-  trx.send(eosio::current_time_point().sec_since_epoch() + 20, _self);
+  print("HARVEST: calctrx executed");
 
 }
 
@@ -387,15 +371,8 @@ void harvest::calcplanted() {
     uitr++;
   }
 
-  transaction trx{};
-  trx.actions.emplace_back(
-    permission_level(_self, "active"_n),
-    _self,
-    "calcplanted"_n,
-    std::make_tuple()
-  );
-  trx.delay_sec = 60;
-  trx.send(eosio::current_time_point().sec_since_epoch() + 30, _self);
+  print("HARVEST: calcplanted executed");
+
 }
 
 void harvest::claimreward(name from) {

--- a/src/seeds.scheduler.cpp
+++ b/src/seeds.scheduler.cpp
@@ -7,11 +7,21 @@
 
 bool scheduler::isRdyToExec(name operation){
     auto itr = operations.find(operation.value);
-    check(itr != operations.end(), "The operation does not exist.");
+
+    if (itr == operations.end()) {
+        return false;
+    }
+    if(itr -> pause > 0) {
+        print("transaction " + operation.to_string() + " is paused");
+        return false;
+    }
+
     uint64_t timestamp = eosio::current_time_point().sec_since_epoch();
     uint64_t periods = 0;
 
     periods = ((timestamp - itr -> timestamp) * 10000) / itr -> period;
+
+    print("PERIODS: " + std::to_string(periods) + ", timestamp: " + std::to_string(timestamp) + ", timestap: " + std::to_string(itr->timestamp) );
 
     if(periods > 0) return true;
     return false;
@@ -25,35 +35,95 @@ ACTION scheduler::reset() {
     while(itr != operations.end()){
         itr = operations.erase(itr);
     }
+
+    std::vector<name> id_v = { 
+        name("rep.harvest"), 
+        name("trx.harvest"), 
+        name("plad.harvest") 
+    };
+    
+    std::vector<name> operations_v = {
+        name("calcrep"),
+        name("calctrx"),
+        name("calcplanted")
+    };
+
+    std::vector<name> contracts_v = {
+        contracts::harvest,
+        contracts::harvest,
+        contracts::harvest
+    };
+
+    std::vector<uint64_t> delay_v = {
+        600000,
+        600000,
+        600000
+    };
+
+    int i = 0;
+    while(i < 3){
+        operations.emplace(_self, [&](auto & noperation){
+            noperation.id = id_v[i];
+            noperation.operation = operations_v[i];
+            noperation.contract = contracts_v[i];
+            noperation.pause = 0;
+            noperation.period = delay_v[i];
+            noperation.timestamp = current_time_point().sec_since_epoch();
+        });
+        i++;
+    }
 }
 
 
-ACTION scheduler::configop(name action, name contract, uint64_t period) {
+ACTION scheduler::configop(name id, name action, name contract, uint64_t period) {
     require_auth(_self);
 
-    auto itr = operations.find(action.value);
-
+    auto itr = operations.find(id.value);
+    
     if(itr != operations.end()){
         operations.modify(itr, _self, [&](auto & moperation) {
             moperation.operation = action;
             moperation.contract = contract;
             moperation.period = period;
+            moperation.pause = 0;
         });
     }
     else{
         operations.emplace(_self, [&](auto & noperation) {
+            noperation.id = id;
+            noperation.pause = 0;
             noperation.operation = action;
             noperation.contract = contract;
             noperation.period = period;
             noperation.timestamp = current_time_point().sec_since_epoch();
         });
     }
-
 }
 
+ACTION scheduler::removeop(name id) {
+    require_auth(get_self());
+
+    auto itr = operations.find(id.value);
+    check(itr != operations.end(), contracts::scheduler.to_string() + ": the operation " + id.to_string() + " does not exist");
+
+    operations.erase(itr);
+}
+
+ACTION scheduler::pauseop(name id, uint8_t pause) {
+    require_auth(get_self());
+
+    auto itr = operations.find(id.value);
+    check(itr != operations.end(), contracts::scheduler.to_string() + ": the operation " + id.to_string() + " does not exist");
+
+    operations.modify(itr, _self, [&](auto & moperation) {
+        moperation.pause = pause;
+    });
+}
 
 ACTION scheduler::confirm(name operation) {
     require_auth(_self);
+
+    print("Confirm the execution of " + operation.to_string());
 
     auto itr = operations.find(operation.value);
     check(itr != operations.end(), "Operation does not exist");
@@ -66,6 +136,8 @@ ACTION scheduler::confirm(name operation) {
 
 ACTION scheduler::execute() {
    // require_auth(_self);
+
+   print("Executing...");
 
     /*
         Just as quick reminder.
@@ -93,29 +165,50 @@ ACTION scheduler::execute() {
     */
 
     auto itr = operations.begin();
+
+    auto it_s = config.find(seconds_to_execute.value);
+    check(it_s != config.end(), contracts::scheduler.to_string() + ": the parameter " + seconds_to_execute.to_string() + " is not configured in " + contracts::settings.to_string());
+
+    action next_execution(
+        permission_level{get_self(), "active"_n},
+        get_self(),
+        "execute"_n,
+        std::make_tuple()
+    );
+
+    print("Creating the diferred transaction...");
+
+    transaction tx;
+    tx.actions.emplace_back(next_execution);
+    tx.delay_sec = it_s -> value / 10000;
+    tx.send(eosio::current_time_point().sec_since_epoch() + 30, _self);
+    
+    print("transaction sended");
+
     while(itr != operations.end()) {
-        if(isRdyToExec(itr -> operation)){
-            
+        if(isRdyToExec(itr -> id)){
+
+            print("Operation to be executed: " + itr -> id.to_string());
+
             action a = action(
-                //permission_level{contracts::forum, "period"_n},
-                //permission_level(get_self(), "scheduled"_n),
-                permission_level{contracts::forum, "execute"_n},
+                permission_level{itr -> contract, "execute"_n},
                 itr -> contract,
                 itr -> operation,
                 std::make_tuple()
             );
 
-            a.send();
+            transaction txa;
+            txa.actions.emplace_back(a);
+            txa.delay_sec = 0;
+            txa.send(eosio::current_time_point().sec_since_epoch() + 20, _self);
 
-            //transaction tx;
-            //tx.actions.emplace_back(a);
-            //tx.send(eosio::current_time_point().sec_since_epoch() + 10, _self, false);
+            // a.send();
 
             action c = action(
                 permission_level{get_self(), "active"_n},
                 get_self(),
                 "confirm"_n,
-                std::make_tuple(itr -> operation)
+                std::make_tuple(itr -> id)
             );
 
             c.send();
@@ -124,9 +217,8 @@ ACTION scheduler::execute() {
         }
         itr++;
     }
-    
+
 }
 
 
-
-EOSIO_DISPATCH(scheduler,(configop)(execute)(reset)(confirm));
+EOSIO_DISPATCH(scheduler,(configop)(execute)(reset)(confirm)(pauseop)(removeop));

--- a/src/seeds.scheduler.cpp
+++ b/src/seeds.scheduler.cpp
@@ -99,7 +99,7 @@ ACTION scheduler::execute() {
             action a = action(
                 //permission_level{contracts::forum, "period"_n},
                 //permission_level(get_self(), "scheduled"_n),
-                permission_level{get_self(), "active"_n},
+                permission_level{contracts::forum, "execute"_n},
                 itr -> contract,
                 itr -> operation,
                 std::make_tuple()

--- a/src/seeds.scheduler.cpp
+++ b/src/seeds.scheduler.cpp
@@ -129,4 +129,4 @@ ACTION scheduler::execute() {
 
 
 
-EOSIO_DISPATCH(scheduler,(configop)(execute)(noop)(reset)(np)(confirm));
+EOSIO_DISPATCH(scheduler,(configop)(execute)(reset)(confirm));

--- a/src/seeds.scheduler.cpp
+++ b/src/seeds.scheduler.cpp
@@ -19,9 +19,9 @@ bool scheduler::isRdyToExec(name operation){
     uint64_t timestamp = eosio::current_time_point().sec_since_epoch();
     uint64_t periods = 0;
 
-    periods = ((timestamp - itr -> timestamp) * 10000) / itr -> period;
+    periods = (timestamp - itr -> timestamp) / itr -> period;
 
-    print("PERIODS: " + std::to_string(periods) + ", timestamp: " + std::to_string(timestamp) + ", timestap: " + std::to_string(itr->timestamp) );
+    print("\nPERIODS: " + std::to_string(periods) + ", timestamp: " + std::to_string(timestamp) + ", timestap: " + std::to_string(itr->timestamp) );
 
     if(periods > 0) return true;
     return false;
@@ -55,9 +55,9 @@ ACTION scheduler::reset() {
     };
 
     std::vector<uint64_t> delay_v = {
-        600000,
-        600000,
-        600000
+        60,
+        60,
+        60
     };
 
     int i = 0;
@@ -180,8 +180,8 @@ ACTION scheduler::execute() {
 
     transaction tx;
     tx.actions.emplace_back(next_execution);
-    tx.delay_sec = it_s -> value / 10000;
-    tx.send(eosio::current_time_point().sec_since_epoch() + 30, _self);
+    tx.delay_sec = it_s -> value;
+    tx.send(contracts::scheduler.value /*eosio::current_time_point().sec_since_epoch() + 30*/, _self);
     
     print("transaction sended");
 
@@ -220,5 +220,10 @@ ACTION scheduler::execute() {
 
 }
 
+ACTION scheduler::cancelexec() {
+    require_auth(get_self());
+    cancel_deferred(contracts::scheduler.value);
+}
 
-EOSIO_DISPATCH(scheduler,(configop)(execute)(reset)(confirm)(pauseop)(removeop));
+
+EOSIO_DISPATCH(scheduler,(configop)(execute)(reset)(confirm)(pauseop)(removeop)(cancelexec));

--- a/test/forum.test.js
+++ b/test/forum.test.js
@@ -39,8 +39,6 @@ describe('forum', async assert => {
     await contracts.scheduler.reset({ authorization: `${scheduler}@active` })
 
     console.log('configure')
-    await contracts.scheduler.configop('onperiod', 'forum.seeds', 20000, { authorization: `${scheduler}@active` })
-    await contracts.scheduler.configop('newday', 'forum.seeds', 20000, { authorization: `${scheduler}@active` })
     await contracts.settings.configure("maxpoints", 100000, { authorization: `${settings}@active` })
     await contracts.settings.configure("vbp", 70000, { authorization: `${settings}@active` })
     await contracts.settings.configure("cutoff", 280000, { authorization: `${settings}@active` })
@@ -108,9 +106,9 @@ describe('forum', async assert => {
     })
 
     console.log('depreciate')
-    await contracts.forum.onperiod([], { authorization: `${forum}@active` })
+    await contracts.forum.onperiod([], { authorization: `${forum}@execute` })
     await sleep(10000)
-    await contracts.forum.onperiod([], { authorization: `${forum}@active` })
+    await contracts.forum.onperiod([], { authorization: `${forum}@execute` })
 
     console.log('vote comments')
 
@@ -133,7 +131,7 @@ describe('forum', async assert => {
 
     console.log('new day')
     try{
-        await contracts.forum.newday([], { authorization: `${forum}@active` })
+        await contracts.forum.newday([], { authorization: `${forum}@execute` })
     }
     catch(err){
         console.log("new day is not ready to be executed.", err)

--- a/test/scheduler.test.js
+++ b/test/scheduler.test.js
@@ -66,7 +66,7 @@ describe('scheduler', async assert => {
 
     await sleep(30)
     console.log('scheduler execute')
-    await contracts.scheduler.execute([], { authorization: `${scheduler}@active` })
+    await contracts.scheduler.execute([], { authorization: `${firstuser}@active` })
 
     const repBeforeDepreciation = await getTableRows({
         code: forum,
@@ -77,7 +77,7 @@ describe('scheduler', async assert => {
 
     await sleep(10000)
     console.log('scheduler execute')
-    await contracts.scheduler.execute([], { authorization: `${scheduler}@active` })
+    await contracts.scheduler.execute([], { authorization: `${seconduser}@active` })
 
 
     const repAfterDepreciation = await getTableRows({
@@ -109,7 +109,7 @@ describe('scheduler', async assert => {
 
     await sleep(6000)
     console.log('scheduler execute')
-    await contracts.scheduler.execute([], { authorization: `${scheduler}@active` })
+    await contracts.scheduler.execute([], { authorization: `${firstuser}@active` })
 
     console.log('vote post')
     await contracts.forum.downvotepost(firstuser, 2, { authorization: `${firstuser}@active` })
@@ -121,6 +121,15 @@ describe('scheduler', async assert => {
         table: 'votepower',
         json: true
     })
+
+    console.log('try to execute a function of forum without the execute permission')
+    try {
+        await contracts.forum.onperiod([], { authorization: `${firstuser}@active` })
+    }
+    catch(err) {
+        const e = JSON.parse(err)
+        console.log(e.error.details[0].message.replace('assertion failure with message: ', ''))
+    }
 
     assert({
         given: 'the function onperiod not ready to be executed',

--- a/test/scheduler.test.js
+++ b/test/scheduler.test.js
@@ -39,14 +39,18 @@ describe('scheduler', async assert => {
     await contracts.accounts.reset({ authorization: `${accounts}@active` })
 
     console.log('configure')
-    await contracts.scheduler.configop('onperiod', 'forum.seeds', 70000, { authorization: `${scheduler}@active` })
-    await contracts.scheduler.configop('newday', 'forum.seeds', 150000, { authorization: `${scheduler}@active` })
+    await contracts.scheduler.configop('run.forum', 'onperiod', 'forum.seeds', 7, { authorization: `${scheduler}@active` })
+    await contracts.scheduler.configop('new.forum', 'newday', 'forum.seeds', 20, { authorization: `${scheduler}@active` })
+    await contracts.scheduler.configop('rep.harvest', 'calcrep', 'harvst.seeds', 1200, { authorization: `${scheduler}@active` })
+    await contracts.scheduler.configop('trx.harvest', 'calctrx', 'harvst.seeds', 1200, { authorization: `${scheduler}@active` })
+    await contracts.scheduler.configop('plad.harvest', 'calcplanted', 'harvst.seeds', 1200, { authorization: `${scheduler}@active` })
     await contracts.settings.configure("maxpoints", 100000, { authorization: `${settings}@active` })
     await contracts.settings.configure("vbp", 70000, { authorization: `${settings}@active` })
     await contracts.settings.configure("cutoff", 280000, { authorization: `${settings}@active` })
     await contracts.settings.configure("cutoffz", 5000, { authorization: `${settings}@active` })
     await contracts.settings.configure("depreciation", 9500, { authorization: `${settings}@active` })
     await contracts.settings.configure("dps", 2, { authorization: `${settings}@active` })
+    await contracts.settings.configure('secndstoexec', 1, { authorization: `${settings}@active` })
 
     console.log('join users')
     await contracts.accounts.adduser(firstuser, 'first user', 'individual', { authorization: `${accounts}@active` })
@@ -75,9 +79,9 @@ describe('scheduler', async assert => {
         json: true
     })
 
-    await sleep(10000)
-    console.log('scheduler execute')
-    await contracts.scheduler.execute([], { authorization: `${seconduser}@active` })
+    await sleep(7000)
+    // console.log('scheduler execute')
+    // await contracts.scheduler.execute([], { authorization: `${seconduser}@active` })
 
 
     const repAfterDepreciation = await getTableRows({
@@ -108,8 +112,8 @@ describe('scheduler', async assert => {
     })
 
     await sleep(6000)
-    console.log('scheduler execute')
-    await contracts.scheduler.execute([], { authorization: `${firstuser}@active` })
+    // console.log('scheduler execute')
+    // await contracts.scheduler.execute([], { authorization: `${firstuser}@active` })
 
     console.log('vote post')
     await contracts.forum.downvotepost(firstuser, 2, { authorization: `${firstuser}@active` })
@@ -130,6 +134,8 @@ describe('scheduler', async assert => {
         const e = JSON.parse(err)
         console.log(e.error.details[0].message.replace('assertion failure with message: ', ''))
     }
+
+    await contracts.scheduler.cancelexec({ authorization: `${scheduler}@active` })
 
     assert({
         given: 'the function onperiod not ready to be executed',


### PR DESCRIPTION
- Scheduler modified to execute actions from harvest, proposals, referendums and forum contracts. It could execute any action of any contract with the permission @execute and if the action does not need parameters.
- Removed deferred transactions from calcplanted, calctrx, calcrep from harvest to prevent them to auto-schedule.
- Schedulers now takes seconds as timestamp.
- Added the cancelexec action to cancel the execute deferred transaction if necessary.