### PR TITLE
Bugfix/harvest calc cs score

### DIFF
--- a/include/seeds.harvest.hpp
+++ b/include/seeds.harvest.hpp
@@ -20,6 +20,7 @@ CONTRACT harvest : public contract {
         balances(receiver, receiver.value),
         harveststat(receiver, receiver.value),
         txpoints(receiver, receiver.value),
+        cspoints(receiver, receiver.value),
         config(contracts::settings, contracts::settings.value),
         users(contracts::accounts, contracts::accounts.value),
         cbs(contracts::accounts, contracts::accounts.value)
@@ -145,7 +146,26 @@ CONTRACT harvest : public contract {
       uint64_t contrib_timestamp;
 
       uint64_t primary_key()const { return account.value; }
+      
+      uint64_t by_cs_points()const { return ( (planted_score + transactions_score + community_building_score) * reputation_score * 2) / 100; }
+
     };
+
+    TABLE cs_points_table {
+        name account;
+        uint64_t contribution_points;
+        uint64_t cycle;
+
+        uint64_t primary_key() const { return account.value; }
+        uint64_t by_cs_points()const { return contribution_points; }
+        uint64_t by_cycle()const { return cycle; }
+    };
+
+    typedef eosio::multi_index<"cspoints"_n, cs_points_table,
+      indexed_by<"bycspoints"_n,const_mem_fun<cs_points_table, uint64_t, &cs_points_table::by_cs_points>>,
+      indexed_by<"bycycle"_n,const_mem_fun<cs_points_table, uint64_t, &cs_points_table::by_cycle>>
+    > cs_points_tables;
+
 
     // External Tables
 
@@ -225,6 +245,7 @@ CONTRACT harvest : public contract {
     balance_tables balances;
     tx_points_tables txpoints;
     harvest_tables harveststat;
+    cs_points_tables cspoints;
 
     // External Tables
     config_tables config;

--- a/src/seeds.scheduler.cpp
+++ b/src/seeds.scheduler.cpp
@@ -80,17 +80,17 @@ ACTION scheduler::reset() {
     };
 
     int i = 0;
-    while(i < 6){
-        configop(id_v[i], operations_v[i], contracts_v[i], delay_v[i]);
+    uint64_t now = current_time_point().sec_since_epoch()+1;
 
-        // operations.emplace(_self, [&](auto & noperation){
-        //     noperation.id = id_v[i];
-        //     noperation.operation = operations_v[i];
-        //     noperation.contract = contracts_v[i];
-        //     noperation.pause = 0;
-        //     noperation.period = delay_v[i];
-        //     noperation.timestamp = current_time_point().sec_since_epoch();
-        // });
+    while(i < 6){
+        operations.emplace(_self, [&](auto & noperation){
+            noperation.id = id_v[i];
+            noperation.operation = operations_v[i];
+            noperation.contract = contracts_v[i];
+            noperation.pause = 0;
+            noperation.period = delay_v[i];
+            noperation.timestamp = now + i;
+        });
         i++;
     }
 }

--- a/test/accounts.test.js
+++ b/test/accounts.test.js
@@ -25,7 +25,8 @@ describe('genesis testing', async assert => {
   await contract.reset({ authorization: `${accounts}@active` })
 
   console.log('test genesis')
-  await contract.adduser(thirduser, 'First user', "individual", { authorization: `${accounts}@active` })
+  await contract.adduser(thirduser, 'third user', "individual", { authorization: `${accounts}@active` })
+  await contract.adduser(seconduser, 'second user', "individual", { authorization: `${accounts}@active` })
   await contract.testcitizen(thirduser, { authorization: `${accounts}@active` })
 
   const users = await eos.getTableRows({
@@ -35,7 +36,7 @@ describe('genesis testing', async assert => {
     json: true,
   })
 
-  let user = users.rows[0]
+  let user = users.rows[1]
 
   assert({
     given: 'genesis',
@@ -44,8 +45,24 @@ describe('genesis testing', async assert => {
     expected: "citizen"
   })
 
+  await contract.genesisrep({ authorization: `${accounts}@active` })
+
+  let reps = await get_reps()
+
+  console.log("reps: "+JSON.stringify(reps, null, 2))
+
+  assert({
+    given: 'genesis reps',
+    should: 'citizens have 100 rep',
+    actual: reps,
+    expected: [0, 100]
+  })
+
+
+
 })
 
+// helper function
 const get_reps = async () => {
   const users = await eos.getTableRows({
     code: accounts,

--- a/test/harvest.test.js
+++ b/test/harvest.test.js
@@ -553,13 +553,29 @@ describe("harvest transaction score", async assert => {
     json: true,
     limit: 100
   })
-  let secondCS = harvestStats.rows.filter( item => item.account == seconduser )[0].contribution_score
+  const cspoints = await eos.getTableRows({
+    code: harvest,
+    scope: harvest,
+    table: 'cspoints',
+    json: true,
+    limit: 100
+  })
+
+  // let secondCSpoints = cspoints.rows.filter( item => item.account == seconduser )[0].contribution_points
+  // let secondCS = harvestStats.rows.filter( item => item.account == seconduser )[0].contribution_score
+
+  assert({
+    given: 'contribution score points',
+    should: 'have contribution score',
+    actual: cspoints.rows.map(({ contribution_points }) => contribution_points), 
+    expected: [0, 150, 0, 0]
+  })
 
   assert({
     given: 'contribution score',
     should: 'have contribution score',
-    actual: secondCS, 
-    expected: 150
+    actual: harvestStats.rows.map(({ contribution_score }) => contribution_score), 
+    expected: [0, 100, 0, 0]
   })
 
 })


### PR DESCRIPTION
- Added cs points table to harvest
- calccs now enters points into points table and ranks by points
- scheduler update to execute the actions in a beneficial order - more efficient to calculate tx points before tx scores for example