### PR TITLE
Token Sale Rounds 1 - 50

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ package-lock.json
 !.env.example
 
 .vscode/settings.json
+.vscode/c_cpp_properties.json

--- a/include/seeds.exchange.hpp
+++ b/include/seeds.exchange.hpp
@@ -45,7 +45,8 @@ CONTRACT exchange : public contract {
 
   private:
 
-    void purchase_usd(name buyer, asset usd_quantity, string memo);
+    void purchase_usd(name buyer, asset usd_quantity, string memo); 
+    asset seeds_for_usd(asset usd_quantity);
 
     symbol tlos_symbol = symbol("TLOS", 4);
     symbol seeds_symbol = symbol("SEEDS", 4);

--- a/include/seeds.exchange.hpp
+++ b/include/seeds.exchange.hpp
@@ -33,8 +33,6 @@ CONTRACT exchange : public contract {
     
     ACTION updatelimit(asset citizen_limit, asset resident_limit, asset visitor_limit);
 
-    ACTION updateprice(); // updates price table
-
     ACTION addround(uint64_t volume, asset seeds_per_usd);
 
     ACTION initrounds(uint64_t volume_per_round, asset initial_seeds_per_usd);
@@ -47,6 +45,7 @@ CONTRACT exchange : public contract {
 
     void purchase_usd(name buyer, asset usd_quantity, string memo); 
     asset seeds_for_usd(asset usd_quantity);
+    void updateprice(); // updates price table
 
     symbol tlos_symbol = symbol("TLOS", 4);
     symbol seeds_symbol = symbol("SEEDS", 4);
@@ -138,7 +137,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
       execute_action<exchange>(name(receiver), name(code), &exchange::buytlos);
   } else if (code == receiver) {
       switch (action) {
-          EOSIO_DISPATCH_HELPER(exchange, (reset)(onperiod)(updatetlos)(updatelimit)(newpayment)(addround)(updateprice)(initsale)(initrounds))
+          EOSIO_DISPATCH_HELPER(exchange, (reset)(onperiod)(updatetlos)(updatelimit)(newpayment)(addround)(initsale)(initrounds))
       }
   }
 }

--- a/include/seeds.exchange.hpp
+++ b/include/seeds.exchange.hpp
@@ -27,7 +27,7 @@ CONTRACT exchange : public contract {
     
     ACTION newpayment(name recipientAccount, string paymentSymbol, string paymentId, uint64_t multipliedUsdValue);
 
-    ACTION updateusd(asset seeds_per_usd);
+    //ACTION updateusd(asset seeds_per_usd); // we are now in sales rounds
 
     ACTION updatetlos(asset tlos_per_usd);
     
@@ -138,7 +138,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
       execute_action<exchange>(name(receiver), name(code), &exchange::buytlos);
   } else if (code == receiver) {
       switch (action) {
-          EOSIO_DISPATCH_HELPER(exchange, (reset)(onperiod)(updateusd)(updatetlos)(updatelimit)(newpayment)(addround)(updateprice)(initsale)(initrounds))
+          EOSIO_DISPATCH_HELPER(exchange, (reset)(onperiod)(updatetlos)(updatelimit)(newpayment)(addround)(updateprice)(initsale)(initrounds))
       }
   }
 }

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -507,7 +507,9 @@ const getBalance = async (user) => {
 
 const getBalanceFloat = async (user) => {
   const balance = await eos.getCurrencyBalance(names.token, user, 'SEEDS')
-  return parseFloat(balance[0])
+  var float = parseInt(Math.round(parseFloat(balance[0]) * 10000)) / 10000.0;
+
+  return float;
 }
 
 const initContracts = (accounts) =>

--- a/src/seeds.exchange.cpp
+++ b/src/seeds.exchange.cpp
@@ -41,9 +41,6 @@ asset exchange::seeds_for_usd(asset usd_quantity) {
 
   soldtable s = sold.get_or_create(get_self(), soldtable());
 
-  //price_table p = price.get_or_create(get_self(), price_table());
-  //auto ritr = rounds.find(p.current_round);
-
   double usd_total = double(usd_quantity.amount);
   double usd_remaining = usd_total;
   double seeds_amount = 0.0;
@@ -64,18 +61,9 @@ asset exchange::seeds_for_usd(asset usd_quantity) {
       // price of available seeds
       double usd_available = available_in_round * usd_per_seeds;
 
-
-    //check(false, "debug. "+std::to_string(ritr->seeds_per_usd.amount)+" usd_per_seeds "+std::to_string(usd_per_seeds) + 
-    //" available: "+std::to_string(available_in_round) + " usd_available: " + std::to_string(usd_available));
-
       // if < usd amount remaining -> calculate, add, and exit
       if (usd_available >= usd_remaining) {
-        
         seeds_amount += (usd_remaining * ritr->seeds_per_usd.amount) / 10000;
-
-        //check(ritr->id < 2, "seeds_amount. "+ std::to_string(seeds_amount) +"seeds-perusd: "+std::to_string(ritr->seeds_per_usd.amount)+" usd_per_seeds "+std::to_string(usd_per_seeds) + 
-        //" available: "+std::to_string(available_in_round) + " usd_available: " + std::to_string(usd_available));
-
         usd_remaining = 0;
         break;
       } else {
@@ -91,12 +79,6 @@ asset exchange::seeds_for_usd(asset usd_quantity) {
     " available USD value: "+std::to_string( (usd_total - usd_remaining) / 10000.0) + " max vol: " + std::to_string(round_end_volume));
 
   }
-
-    // check(false, "DEBUG. requested "+std::to_string(usd_total) + 
-    // " available: "+std::to_string(usd_total - usd_remaining) + " max vol: " + std::to_string(round_start_volume)+
-    // " amount "+std::to_string(seeds_amount));
-
-  updateprice();
 
   return asset(seeds_amount, seeds_symbol);
 }
@@ -154,6 +136,8 @@ void exchange::purchase_usd(name buyer, asset usd_quantity, string memo) {
   soldtable stb = sold.get_or_create(get_self(), soldtable());
   stb.total_sold = stb.total_sold + seeds_amount;
   sold.set(stb, get_self());
+
+  updateprice();
 
   action(
     permission_level{get_self(), "active"_n},

--- a/src/seeds.exchange.cpp
+++ b/src/seeds.exchange.cpp
@@ -6,9 +6,19 @@ void exchange::reset() {
 
   config.remove();
 
-/**/
+  asset citizen_limit =  asset(uint64_t(2500000000), seeds_symbol);
+  asset resident_limit =  asset(uint64_t(2500000000), seeds_symbol);
+  asset visitor_limit =  asset(25000 * 10000, seeds_symbol);
+
+  asset tlos_per_usd =  asset(0.03 * 10000, seeds_symbol);
+
+  updatelimit(citizen_limit, resident_limit, visitor_limit);
+  updatetlos(tlos_per_usd);
+
+/**
  
-  // NEVER CHECK THESE IN - we never want to erase rounds or sold table on mainnet
+  // NEVER CHECK THESE IN
+  // we never want to erase rounds or sold table or history except for unit testing
   
   sold.remove();
 
@@ -16,24 +26,14 @@ void exchange::reset() {
   while(pitr != payhistory.end()) {
     pitr = payhistory.erase(pitr);
   }
-
-/**/
-
-  asset citizen_limit =  asset(uint64_t(2500000000), seeds_symbol);
-  asset resident_limit =  asset(uint64_t(2500000000), seeds_symbol);
-  asset visitor_limit =  asset(25000 * 10000, seeds_symbol);
-
-  asset seeds_per_usd =  asset( uint64_t(1000000), seeds_symbol);
-  asset tlos_per_usd =  asset(0.03 * 10000, seeds_symbol);
-
-  updatelimit(citizen_limit, resident_limit, visitor_limit);
-  updateusd(seeds_per_usd);
-  updatetlos(tlos_per_usd);
-
+  
   auto ritr = rounds.begin();
   while(ritr != rounds.end()){
     ritr = rounds.erase(ritr);
   }
+
+/**/
+
 }
 
 asset exchange::seeds_for_usd(asset usd_quantity) {
@@ -215,16 +215,16 @@ void exchange::updatelimit(asset citizen_limit, asset resident_limit, asset visi
   config.set(c, get_self());
 }
 
-void exchange::updateusd(asset seeds_per_usd) {
-  require_auth(get_self());
+// void exchange::updateusd(asset seeds_per_usd) {
+//   require_auth(get_self());
 
-  configtable c = config.get_or_create(get_self(), configtable());
+//   configtable c = config.get_or_create(get_self(), configtable());
   
-  c.seeds_per_usd = seeds_per_usd;
-  c.timestamp = current_time_point().sec_since_epoch();
+//   c.seeds_per_usd = seeds_per_usd;
+//   c.timestamp = current_time_point().sec_since_epoch();
   
-  config.set(c, get_self());
-}
+//   config.set(c, get_self());
+// }
 
 void exchange::updatetlos(asset tlos_per_usd) {
   require_auth(get_self());

--- a/src/seeds.exchange.cpp
+++ b/src/seeds.exchange.cpp
@@ -237,8 +237,7 @@ void exchange::updatetlos(asset tlos_per_usd) {
   config.set(c, get_self());
 }
 
-ACTION exchange::updateprice() {
-  require_auth(get_self());
+void exchange::updateprice() {
 
   soldtable stb = sold.get_or_create(get_self(), soldtable());
   uint64_t total_sold = stb.total_sold;

--- a/test/exchange.test.js
+++ b/test/exchange.test.js
@@ -66,7 +66,7 @@ describe('Exchange', async assert => {
     json: true,
   })
 
-  console.log("balance before "+balanceAfter)
+  console.log("balance after "+balanceAfter)
 
   usd = 99
 
@@ -124,7 +124,7 @@ describe('Exchange', async assert => {
   // })
 })
 
-describe.only('Token Sale', async assert => {
+describe('Token Sale Rounds', async assert => {
 
   const contracts = await initContracts({ accounts, token, exchange })
   
@@ -145,18 +145,7 @@ describe.only('Token Sale', async assert => {
   
   console.log(`update TLOS rate - tlos per usd`)
   await contracts.exchange.updatetlos("3.0000 SEEDS", { authorization: `${exchange}@active` })
-  
-  //console.log(`transfer ${tlosQuantity} from ${firstuser} to ${exchange}`)
-  //await contracts.tlostoken.transfer(firstuser, exchange, tlosQuantity, '', { authorization: `${firstuser}@active` })
-
-  let usd = 0.0099
-  let seeds_per_usd = 100
-  let expectedSeeds = seeds_per_usd * usd
-
-  //await contracts.exchange.newpayment(firstuser, "BTC", "0x3affgfaaaabbb", parseInt(usd * 10000), { authorization: `${exchange}@active` })
-
-  usd = 99
-    
+      
   console.log(`init token sale rounds`)
 
   const getRounds = async () => {
@@ -168,7 +157,7 @@ describe.only('Token Sale', async assert => {
       limit: 100,
     })
 
-    console.log("rounds "+JSON.stringify(rounds, null, 2))
+    //console.log("rounds "+JSON.stringify(rounds, null, 2))
 
     return rounds
   }
@@ -188,14 +177,13 @@ describe.only('Token Sale', async assert => {
 
   let usd_rates = rounds.map( ({usd_rate})  => usd_rate )
 
-  console.log("rounds "+JSON.stringify(rounds, null, 2))
+  //console.log("rounds "+JSON.stringify(rounds, null, 2))
 
+  let vol = (444) * 10000
   console.log("test add round")
+  await contracts.exchange.addround( vol, "1.1000 SEEDS", { authorization: `${exchange}@active` })  
 
-  console.log("test update price")
-
-  console.log("test purchasing")
-
+  let roundsAfterAdd = await getRounds()
 
   assert({
     given: `rounds price with 3.3% cumulative increase `,
@@ -203,5 +191,298 @@ describe.only('Token Sale', async assert => {
     actual: [usd_rates[0], usd_rates[1], usd_rates[29], usd_rates[49]],
     expected: [ "0.01100",  "0.01136", "0.02820", "0.05399"]
   })
+
+  assert({
+    given: `add round `,
+    should: `be appended to rounds`,
+    actual: roundsAfterAdd.rows[50],
+    expected: {
+      "id": 50,
+      "max_sold": 50000000 + vol,
+      "seeds_per_usd": "1.1000 SEEDS"
+    }
+  })
+
+
+})
+
+const getRounds = async () => {
+  let rounds = await eos.getTableRows({
+    code: exchange,
+    scope: exchange,
+    table: 'rounds',
+    json: true,
+    limit: 100,
+  })
+  return rounds
+}
+
+describe('Token Sale Price', async assert => {
+
+  const contracts = await initContracts({ accounts, token, exchange })
+  
+  console.log(`reset exchange`)
+  await contracts.exchange.reset({ authorization: `${exchange}@active` })  
+
+  console.log(`reset accounts`)
+  await contracts.accounts.reset({ authorization: `${accounts}@active` })
+
+  console.log(`add user`)
+  await contracts.accounts.adduser(firstuser, 'First user', "individual", { authorization: `${accounts}@active` })
+
+  console.log(`transfer seeds to ${exchange}`)
+  //await contracts.token.transfer(firstuser, exchange, "2000000.0000 SEEDS", 'unit test', { authorization: `${firstuser}@active` })
+
+  console.log(`update daily limits`)
+  await contracts.exchange.updatelimit("100.0000 SEEDS", "10.0000 SEEDS", "3000000.0000 SEEDS", { authorization: `${exchange}@active` })
+  
+  console.log(`update TLOS rate - tlos per usd`)
+  await contracts.exchange.updatetlos("3.0000 SEEDS", { authorization: `${exchange}@active` })
+  await contracts.exchange.updateusd("1.0000 SEEDS", { authorization: `${exchange}@active` })
+
+  console.log(`init token sale rounds`)
+
+  console.log("test init rounds - 10.0000 seeds per round")
+
+  for (let i=0; i<12; i++) {
+    await contracts.exchange.addround( 10 * 10000, i+1+".0000 SEEDS", { authorization: `${exchange}@active` })  
+  }
+
+  console.log("rounds "+JSON.stringify(await getRounds(), null, 2))
+
+  let b1 = await getBalanceFloat(firstuser)
+
+  const updateprice = async (expected_round, expected_price, expected_remaining) => {
+    await contracts.exchange.updateprice( { authorization: `${exchange}@active` })
+    let price = await eos.getTableRows({
+      code: exchange,
+      scope: exchange,
+      table: 'price',
+      json: true,
+    })
+    //console.log("price: "+JSON.stringify(price, null, 2))
+
+    assert({
+      given: `new price`,
+      should: `expected round: `+expected_round + " price: "+expected_price + " remaining "+expected_remaining,
+      actual: price.rows[0],
+      expected: {
+        "id": 0,
+        "current_round_id": expected_round,
+        "current_seeds_per_usd": parseInt(expected_price)+".0000 SEEDS",
+        "remaining": expected_remaining
+      }
+    })
+
+  }
+
+  const check = async (initial, expectedDelta, usd) => {
+    let balance = await getBalanceFloat(firstuser)
+    let delta = balance - initial
+    //console.log(" expected "+expectedDelta + " actual " + delta + " initial "+ initial + " balance: "+ balance)
+
+    assert({
+      given: `purchase `+usd+" usd worth",
+      should: `receive expected number of Seeds: `+expectedDelta,
+      actual: delta.toFixed(4),
+      expected: expectedDelta.toFixed(4)
+    })
+  
+  }
+
+  console.log("buy seeds 10 USD")
+
+  // edge case, buy entire round, check price after
+  await contracts.exchange.newpayment(firstuser, "BTC", "0", parseInt(10 * 10000), { authorization: `${exchange}@active` })
+
+  let seedsBalance = 10
+
+  await check(b1, seedsBalance, 10)
+
+  b1 += seedsBalance
+
+  await updateprice(1, 2, 10 * 10000)
+
+
+  console.log("buy seeds 0.5 USD")
+
+  await contracts.exchange.newpayment(firstuser, "BTC", "01", parseInt(5000), { authorization: `${exchange}@active` })
+
+  await check(b1, 1, 0.5)
+
+  b1 += 1
+
+  await updateprice(1, 2, 9 * 10000)
+
+  console.log("buy seeds 6 USD") 
+
+  // 9 seeds left at 2 seeds / usd = 4.5 USD
+  // 1.5 * 3 seeds = 4.5
+
+  //9 + 4.5 = 13.5
+
+  //11 + 13.5 = 24.5
+
+  // cross over into a new round - 
+  await contracts.exchange.newpayment(firstuser, "BTC", "02", parseInt(6 * 10000), { authorization: `${exchange}@active` })
+
+  await check(b1, 13.5, "")
+
+  b1 += 13.5
+
+
+  await updateprice(2, 3,  55000)
+
+  // 8.22 usd
+
+  // 5.5 S remain at 3 s/usd
+  // 5.5 .... 1.833333333 USD ==> 5.5 Seeds
+
+  // remain: 6.3866666667
+
+  // 10 S at 4/usd 2.5 usd 10 Seeds
+  // 10 at 5 => 2 usd      10 Seeds
+  // 10 at 6 => 1.666666   10 Seeds
+  // 10 at 7 => 0.22 USD buys 1.54 Seeds
+
+  // total: 37.04
+
+  console.log("buy seeds 8.22 USD")
+
+  await contracts.exchange.newpayment(firstuser, "BTC", "04", parseInt(8.22 * 10000), { authorization: `${exchange}@active` })
+
+  //61.54
+  await check(b1, 37.04, "")
+
+  await updateprice(6, 7, 84600)
+
+
+
+})
+
+
+describe.only('Token Sale 50 Rounds', async assert => {
+
+  const contracts = await initContracts({ accounts, token, exchange })
+  
+  console.log(`reset exchange`)
+  await contracts.exchange.reset({ authorization: `${exchange}@active` })  
+
+  console.log(`reset accounts`)
+  await contracts.accounts.reset({ authorization: `${accounts}@active` })
+
+  console.log(`add user`)
+  await contracts.accounts.adduser(firstuser, 'First user', "individual", { authorization: `${accounts}@active` })
+
+  console.log(`transfer seeds to ${exchange}`)
+  //await contracts.token.transfer(firstuser, exchange, "2000000.0000 SEEDS", 'unit test', { authorization: `${firstuser}@active` })
+
+  console.log(`update daily limits`)
+  await contracts.exchange.updatelimit("100.0000 SEEDS", "10.0000 SEEDS", "3000000.0000 SEEDS", { authorization: `${exchange}@active` })
+  
+  console.log(`update TLOS rate - tlos per usd`)
+  await contracts.exchange.updatetlos("3.0000 SEEDS", { authorization: `${exchange}@active` })
+  await contracts.exchange.updateusd("1.0000 SEEDS", { authorization: `${exchange}@active` })
+
+  console.log(`init token sale rounds`)
+
+  console.log("test init rounds - 10.0000 seeds per round")
+
+  
+  let usd_per_seeds = 0.011
+
+  for (let i=0; i<50; i++) {
+
+    let seeds_per_usd = 1 / usd_per_seeds
+
+    console.log("round "+i+" = "+seeds_per_usd.toFixed(4)+" SEEDS")
+
+    await contracts.exchange.addround( 10 * 10000, seeds_per_usd.toFixed(4)+" SEEDS", { authorization: `${exchange}@active` })  
+
+    usd_per_seeds = usd_per_seeds * 1.033
+
+  }
+
+  console.log("rounds "+JSON.stringify(await getRounds(), null, 2))
+
+  let b1 = await getBalanceFloat(firstuser)
+
+  const updateprice = async (expected_round, expected_price, expected_remaining) => {
+    await contracts.exchange.updateprice( { authorization: `${exchange}@active` })
+    let price = await eos.getTableRows({
+      code: exchange,
+      scope: exchange,
+      table: 'price',
+      json: true,
+    })
+    //console.log("price: "+JSON.stringify(price, null, 2))
+
+    assert({
+      given: `new price`,
+      should: `expected round: `+expected_round + " price: "+expected_price + " remaining "+expected_remaining,
+      actual: price.rows[0],
+      expected: {
+        "id": 0,
+        "current_round_id": expected_round,
+        "current_seeds_per_usd": expected_price.toFixed(4)+" SEEDS",
+        "remaining": expected_remaining
+      }
+    })
+
+  }
+
+  const check = async (initial, expectedDelta, usd) => {
+    let balance = await getBalanceFloat(firstuser)
+    let delta = balance - initial
+    //console.log(" expected "+expectedDelta + " actual " + delta + " initial "+ initial + " balance: "+ balance)
+
+    assert({
+      given: `purchase `+usd+" usd worth",
+      should: `receive expected number of Seeds: `+expectedDelta,
+      actual: delta.toFixed(4),
+      expected: expectedDelta.toFixed(4)
+    })
+  
+  }
+
+  console.log("buy seeds 0.011 USD")
+
+  // edge case, buy entire round, check price after
+  await contracts.exchange.newpayment(firstuser, "BTC", "0", parseInt(0.011 * 10000), { authorization: `${exchange}@active` })
+
+  let seedsBalance = 1
+
+  await check(b1, seedsBalance, 0.011)
+
+  b1 += seedsBalance
+
+  await updateprice(0, 90.9091, 9 * 10000)
+
+  let buy = 0.099
+
+  console.log("buy seeds USD"+buy)
+  await contracts.exchange.newpayment(firstuser, "BTC", "01", parseInt(buy * 10000), { authorization: `${exchange}@active` })
+  seedsBalance = 9
+  await check(b1, seedsBalance, buy)
+  b1 += seedsBalance
+  await updateprice(1, 88.0049, 10 * 10000)
+
+
+  // 13.3 seeds = 10 seeds at round 2 price of 88.0049 ==> 0.1136300365
+  // 3.3 seeds are round 3 price of 85.1935 ==> 0.03873534953
+
+  // == 0.152365386
+
+  buy = 0.1524 // 65386
+  console.log("buy seeds "+buy) 
+
+
+  await contracts.exchange.newpayment(firstuser, "BTC", "02", parseInt(buy * 10000), { authorization: `${exchange}@active` })
+
+  await check(b1, 13.3029, buy)
+
+  b1 += 13.3029
+
+  await updateprice(2, 85.1935,  (10 - 3.3029) * 10000)
 
 })

--- a/test/exchange.test.js
+++ b/test/exchange.test.js
@@ -48,9 +48,23 @@ describe('Exchange', async assert => {
 
   console.log("balance before "+balanceBefore)
 
+  let soldBefore = await eos.getTableRows({
+    code: exchange,
+    scope: exchange,
+    table: 'sold',
+    json: true,
+  })
+
   await contracts.exchange.newpayment(firstuser, "BTC", "0x3affgf", parseInt(usd * 10000), { authorization: `${exchange}@active` })
 
   let balanceAfter = await getBalanceFloat(firstuser)
+
+  let soldAfter = await eos.getTableRows({
+    code: exchange,
+    scope: exchange,
+    table: 'sold',
+    json: true,
+  })
 
   console.log("balance before "+balanceAfter)
 
@@ -70,13 +84,9 @@ describe('Exchange', async assert => {
   } catch (err) {
   }
 
-
-
   console.log(`reset daily stats`)
   await contracts.exchange.onperiod({ authorization: `${exchange}@active` })  
-  
-  const seedsBalance = await getBalanceFloat(firstuser)
-  
+
   assert({
     given: `sent ${usd} USD to exchange`,
     should: `receive ${expectedSeeds} to account going from `+balanceBefore + ' to ' + balanceAfter,
@@ -85,12 +95,18 @@ describe('Exchange', async assert => {
   })
 
   assert({
+    given: 'sent seeds',
+    should: 'update sold',
+    actual: soldAfter.rows[0].total_sold,
+    expected: soldBefore.rows[0].total_sold + expectedSeeds * 10000
+  })
+
+  assert({
     given: `user buys more than they are allowed`,
     should: `fail`,
     actual: canExceedBalance,
     expected: false
   })
-
 
   assert({
     given: `newpurchase called multiple times with same transaction`,
@@ -106,4 +122,86 @@ describe('Exchange', async assert => {
   //   actual: seedsBalance,
   //   expected: Number.parseInt(seedsQuantity)
   // })
+})
+
+describe.only('Token Sale', async assert => {
+
+  const contracts = await initContracts({ accounts, token, exchange })
+  
+  console.log(`reset exchange`)
+  await contracts.exchange.reset({ authorization: `${exchange}@active` })  
+
+  console.log(`reset accounts`)
+  await contracts.accounts.reset({ authorization: `${accounts}@active` })
+
+  console.log(`add user`)
+  await contracts.accounts.adduser(firstuser, 'First user', "individual", { authorization: `${accounts}@active` })
+
+  console.log(`transfer seeds to ${exchange}`)
+  //await contracts.token.transfer(firstuser, exchange, "2000000.0000 SEEDS", 'unit test', { authorization: `${firstuser}@active` })
+
+  console.log(`update daily limits`)
+  await contracts.exchange.updatelimit("2500000.0000 SEEDS", "10000.0000 SEEDS", "3.0000 SEEDS", { authorization: `${exchange}@active` })
+  
+  console.log(`update TLOS rate - tlos per usd`)
+  await contracts.exchange.updatetlos("3.0000 SEEDS", { authorization: `${exchange}@active` })
+  
+  //console.log(`transfer ${tlosQuantity} from ${firstuser} to ${exchange}`)
+  //await contracts.tlostoken.transfer(firstuser, exchange, tlosQuantity, '', { authorization: `${firstuser}@active` })
+
+  let usd = 0.0099
+  let seeds_per_usd = 100
+  let expectedSeeds = seeds_per_usd * usd
+
+  //await contracts.exchange.newpayment(firstuser, "BTC", "0x3affgfaaaabbb", parseInt(usd * 10000), { authorization: `${exchange}@active` })
+
+  usd = 99
+    
+  console.log(`init token sale rounds`)
+
+  const getRounds = async () => {
+    let rounds = await eos.getTableRows({
+      code: exchange,
+      scope: exchange,
+      table: 'rounds',
+      json: true,
+      limit: 100,
+    })
+
+    console.log("rounds "+JSON.stringify(rounds, null, 2))
+
+    return rounds
+  }
+
+  await getRounds()
+
+  console.log("test init rounds - 100 seeds per round")
+  await contracts.exchange.initrounds( (100) * 10000, "90.9091 SEEDS", { authorization: `${exchange}@active` })  
+
+  let rounds = await getRounds()
+
+  rounds = rounds.rows.map( ( item ) => { return { 
+    round: item.id,
+    seeds_per_usd: parseFloat(item.seeds_per_usd), 
+    usd_rate: (1.0 / parseFloat(item.seeds_per_usd)).toFixed(5) } 
+  })
+
+  let usd_rates = rounds.map( ({usd_rate})  => usd_rate )
+
+  console.log("rounds "+JSON.stringify(rounds, null, 2))
+
+  console.log("test add round")
+
+  console.log("test update price")
+
+  console.log("test purchasing")
+
+
+  assert({
+    given: `rounds price with 3.3% cumulative increase `,
+    should: `match values from spreadsheet`,
+    actual: [usd_rates[0], usd_rates[1], usd_rates[29], usd_rates[49]],
+    expected: [ "0.01100",  "0.01136", "0.02820", "0.05399"]
+  })
+
 })

--- a/test/exchange.test.js
+++ b/test/exchange.test.js
@@ -235,6 +235,11 @@ describe('Basic Init Check', async assert => {
   let results = []
   for (let i=0; i<50; i++) {
     let seeds_per_usd = 1 / usd_per_seeds
+
+    if (i==43) {
+      console.log("Round 44: usd_per_seeds: "+usd_per_seeds + " seeds_per_usd: "+seeds_per_usd)
+      // note: 225057.49999 is rounded by c++ to 225058 - doesn't matter given our precision requirements of 4 digits.
+    }
     results.push({
       volume: (volume * 10000)+"",
       price: (Math.round(seeds_per_usd*10000.0)/10000.0).toFixed(4)
@@ -246,7 +251,7 @@ describe('Basic Init Check', async assert => {
   for(let i=0; i<results.length; i++) {
     assert({
       given: 'round '+i,
-      should: 'have seeds per usd: ' + results[i].price + " SEEDS",
+      should: 'have seeds per usd: ' + results[i].price + " SEEDS   Volume: "+results[i].volume,
       actual: { 
         price: rounds.rows[i].seeds_per_usd,
         volume: rounds.rows[i].max_sold
@@ -584,8 +589,7 @@ describe('Token Sale 50 Rounds', async assert => {
     await contracts.exchange.newpayment(firstuser, "BTC", "05aaaa", parseInt(1 * 10000), { authorization: `${exchange}@active` })
     out_of_funds_purchase = true
   } catch (err) {
-    console.log("expected error "+err) 
-
+    //console.log("expected error "+err) 
   }
   assert({
     given: 'purchase more than available in rounds',

--- a/test/exchange.test.js
+++ b/test/exchange.test.js
@@ -313,7 +313,7 @@ describe('Token Sale Price', async assert => {
   let b1 = await getBalanceFloat(firstuser)
 
   const updateprice = async (expected_round, expected_price, expected_remaining) => {
-    await contracts.exchange.updateprice( { authorization: `${exchange}@active` })
+
     let price = await eos.getTableRows({
       code: exchange,
       scope: exchange,
@@ -473,8 +473,6 @@ describe('Token Sale 50 Rounds', async assert => {
   let b1 = await getBalanceFloat(firstuser)
 
   const updateprice = async (expected_round, expected_price, expected_remaining) => {
-
-    await contracts.exchange.updateprice( { authorization: `${exchange}@active` })
 
     let price = await eos.getTableRows({
       code: exchange,

--- a/test/exchange.test.js
+++ b/test/exchange.test.js
@@ -28,9 +28,9 @@ describe('Exchange', async assert => {
   console.log(`update daily limits`)
   await contracts.exchange.updatelimit("2500.0000 SEEDS", "100.0000 SEEDS", "3.0000 SEEDS", { authorization: `${exchange}@active` })
   
-  console.log(`update USD exchange rate - seeds per USD`)
+  //console.log(`update USD exchange rate - seeds per USD`)
   let seeds_per_usd = 100
-  await contracts.exchange.updateusd(""+seeds_per_usd + ".0000 SEEDS", { authorization: `${exchange}@active` })
+  //await contracts.exchange.updateusd(""+seeds_per_usd + ".0000 SEEDS", { authorization: `${exchange}@active` })
 
   console.log(`update TLOS rate - tlos per usd`)
   await contracts.exchange.updatetlos("3.0000 SEEDS", { authorization: `${exchange}@active` })
@@ -298,7 +298,7 @@ describe('Token Sale Price', async assert => {
   
   console.log(`update TLOS rate - tlos per usd`)
   await contracts.exchange.updatetlos("3.0000 SEEDS", { authorization: `${exchange}@active` })
-  await contracts.exchange.updateusd("1.0000 SEEDS", { authorization: `${exchange}@active` })
+  //await contracts.exchange.updateusd("1.0000 SEEDS", { authorization: `${exchange}@active` })
 
   console.log(`init token sale rounds`)
 
@@ -442,7 +442,7 @@ describe('Token Sale 50 Rounds', async assert => {
   
   console.log(`update TLOS rate - tlos per usd`)
   await contracts.exchange.updatetlos("3.0000 SEEDS", { authorization: `${exchange}@active` })
-  await contracts.exchange.updateusd("1.0000 SEEDS", { authorization: `${exchange}@active` })
+  //await contracts.exchange.updateusd("1.0000 SEEDS", { authorization: `${exchange}@active` })
 
   console.log(`init token sale rounds`)
 


### PR DESCRIPTION
## Overview
Starts at 0.011 USD / Seeds
50 rounds of 1,100,000.00 SEEDS
Increase 3.3% per round

Specification in [Master - Seeds Distribution](https://docs.google.com/spreadsheets/d/1uf_8E0cSqB0qw9kWzFMgqlyDwqoJRmPig5bbhR2puJo/edit#gid=1993216757)

## Code changes
- Rounds added
- Init rounds action
- addround action
- initsale action
- Updating the price before and after sale
- Updating price in config
- Removed ability to manually set USD price
- Unit test tests for all cases
- Unit tests fro purchases crossing over rounds, e.g. buying 1.5 rounds, or buying 0.1 of one round and 0.3 of the next round
- Edge cases (running out of rounds)
