### PR TITLE
Scores refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ package-lock.json
 .vscode/settings.json
 .vscode/c_cpp_properties.json
 secrets_generated/
+scripts/attest.js

--- a/include/seeds.accounts.hpp
+++ b/include/seeds.accounts.hpp
@@ -64,6 +64,7 @@ CONTRACT accounts : public contract {
       ACTION testvisitor(name user);
       ACTION testremove(name user);
       ACTION testsetrep(name user, uint64_t amount);
+      ACTION testsetrs(name user, uint64_t amount);
       ACTION testsetcbs(name user, uint64_t amount);
       ACTION testreward();
 
@@ -218,7 +219,7 @@ CONTRACT accounts : public contract {
 };
 
 EOSIO_DISPATCH(accounts, (reset)(adduser)(makeresident)(makecitizen)(update)(addref)(invitevouch)(addrep)
-(subrep)(testsetrep)(testcitizen)(genesis)(testresident)(testvisitor)(testremove)(testsetcbs)
+(subrep)(testsetrep)(testsetrs)(testcitizen)(genesis)(testresident)(testvisitor)(testremove)(testsetcbs)
 (testreward)(punish)(requestvouch)(vouch)
 (rankreps)(rankrep)(rankcbss)(rankcbs)
 );

--- a/include/seeds.accounts.hpp
+++ b/include/seeds.accounts.hpp
@@ -115,6 +115,7 @@ CONTRACT accounts : public contract {
       void add_rep_item(name account, uint64_t reputation);
       void size_change(name id, int delta);
       void size_set(name id, uint64_t newsize);
+      uint64_t get_size(name id);
 
       DEFINE_USER_TABLE
 

--- a/include/seeds.harvest.hpp
+++ b/include/seeds.harvest.hpp
@@ -8,6 +8,7 @@
 #include <harvest_table.hpp>
 #include <cycle_table.hpp>
 #include <utils.hpp>
+#include <tables/size_table.hpp>
 #include <cmath> 
 
 using namespace eosio;
@@ -24,6 +25,7 @@ CONTRACT harvest : public contract {
         txpoints(receiver, receiver.value),
         cspoints(receiver, receiver.value),
         cycle(receiver, receiver.value),
+        sizes(receiver, receiver.value),
         config(contracts::settings, contracts::settings.value),
         users(contracts::accounts, contracts::accounts.value),
         cbs(contracts::accounts, contracts::accounts.value)
@@ -81,6 +83,9 @@ CONTRACT harvest : public contract {
     void deposit(asset quantity);
     void withdraw(name account, asset quantity);
     void calc_tx_points(name account, uint64_t cycle);
+    
+    void size_change(name id, int delta);
+    void size_set(name id, uint64_t newsize);
 
     // Contract Tables
 
@@ -135,6 +140,13 @@ CONTRACT harvest : public contract {
       indexed_by<"bycycle"_n,const_mem_fun<cs_points_table, uint64_t, &cs_points_table::by_cycle>>
     > cs_points_tables;
 
+    DEFINE_REP_TABLE
+
+    DEFINE_REP_TABLE_MULTI_INDEX
+
+    DEFINE_SIZE_TABLE
+
+    DEFINE_SIZE_TABLE_MULTI_INDEX
 
     // External Tables
 

--- a/include/seeds.harvest.hpp
+++ b/include/seeds.harvest.hpp
@@ -91,7 +91,8 @@ CONTRACT harvest : public contract {
     double get_rep_multiplier(name account);
     void add_planted(name account, asset quantity);
     void sub_planted(name account, asset quantity);
-
+    void calc_contribution_score(name account);
+    
     void size_change(name id, int delta);
     void size_set(name id, uint64_t newsize);
     uint64_t get_size(name id);

--- a/include/seeds.harvest.hpp
+++ b/include/seeds.harvest.hpp
@@ -69,6 +69,7 @@ CONTRACT harvest : public contract {
     ACTION rankcs(uint64_t start_val, uint64_t chunk, uint64_t chunksize);
 
     ACTION updatetxpt(name account);
+    ACTION calctotal(uint64_t startval);
 
     ACTION payforcpu(name account);
 
@@ -76,7 +77,9 @@ CONTRACT harvest : public contract {
     ACTION testupdatecs(name account, uint64_t contribution_score);
     ACTION clearscores();  // DEBUG REMOVE - migrate method
     ACTION migrateplant(uint64_t startval);
-
+    
+    ACTION updtotal(); // MIGRATION ACTION
+    
   private:
     symbol seeds_symbol = symbol("SEEDS", 4);
     uint64_t ONE_WEEK = 604800;
@@ -262,7 +265,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
           (payforcpu)(reset)(runharvest)
           (unplant)(claimrefund)(cancelrefund)(sow)
           (ranktx)(calctrxpt)(calctrxpts)(rankplanted)(rankplanteds)(calccss)(calccs)(rankcss)(rankcs)(ranktxs)(updatecs)
-          (updatetxpt)(clearscores)(migrateplant)
+          (updatetxpt)(clearscores)(migrateplant)(updtotal)(calctotal)
           (testclaim)(testupdatecs))
       }
   }

--- a/include/seeds.harvest.hpp
+++ b/include/seeds.harvest.hpp
@@ -92,8 +92,8 @@ CONTRACT harvest : public contract {
     void init_harvest_stat(name account);
     void check_user(name account);
     void check_asset(asset quantity);
-    void deposit(asset quantity);
-    void withdraw(name account, asset quantity);
+    void _deposit(asset quantity);
+    void _withdraw(name account, asset quantity);
     uint32_t calc_transaction_points(name account);
     double get_rep_multiplier(name account);
     void add_planted(name account, asset quantity);

--- a/include/seeds.harvest.hpp
+++ b/include/seeds.harvest.hpp
@@ -88,7 +88,7 @@ CONTRACT harvest : public contract {
     void check_asset(asset quantity);
     void deposit(asset quantity);
     void withdraw(name account, asset quantity);
-    uint32_t calc_tx_points(name account);
+    uint32_t calc_transaction_points(name account);
     double get_rep_multiplier(name account);
 
     void size_change(name id, int delta);

--- a/include/seeds.harvest.hpp
+++ b/include/seeds.harvest.hpp
@@ -46,13 +46,15 @@ CONTRACT harvest : public contract {
 
     ACTION cancelrefund(name from, uint64_t request_id);
 
-    ACTION claimreward(name from);
+    //ACTION claimreward(name from);
 
     ACTION sow(name from, name to, asset quantity);
 
     ACTION runharvest();
 
-    ACTION calcplanted(); // caluclate planted score
+    ACTION rankplanteds();
+
+    ACTION rankplanted(uint128_t start_val, uint64_t chunk, uint64_t chunksize);
 
     ACTION calctrxpt(); // calculate transaction points
     ACTION calctrxpts(uint64_t start_val, uint64_t chunk, uint64_t chunksize);
@@ -64,13 +66,10 @@ CONTRACT harvest : public contract {
 
     ACTION updatetxpt(name account);
 
-
     ACTION payforcpu(name account);
 
-    ACTION testreward(name from);
     ACTION testclaim(name from, uint64_t request_id, uint64_t sec_rewind);
     ACTION testupdatecs(name account, uint64_t contribution_score);
-
     ACTION clearscores();  // DEBUG REMOVE - migrate method
     ACTION migrateplant(uint64_t startval);
 
@@ -90,6 +89,8 @@ CONTRACT harvest : public contract {
     void withdraw(name account, asset quantity);
     uint32_t calc_transaction_points(name account);
     double get_rep_multiplier(name account);
+    void add_planted(name account, asset quantity);
+    void sub_planted(name account, asset quantity);
 
     void size_change(name id, int delta);
     void size_set(name id, uint64_t newsize);
@@ -239,10 +240,10 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
       switch (action) {
           EOSIO_DISPATCH_HELPER(harvest, 
           (payforcpu)(reset)(runharvest)
-          (unplant)(claimreward)(claimrefund)(cancelrefund)(sow)
-          (ranktx)(calctrxpt)(calctrxpts)(calcplanted)(calccs)
+          (unplant)(claimrefund)(cancelrefund)(sow)
+          (ranktx)(calctrxpt)(calctrxpts)(rankplanted)(rankplanteds)(calccs)
           (updatetxpt)(clearscores)(migrateplant)
-          (testreward)(testclaim)(testupdatecs))
+          (testclaim)(testupdatecs))
       }
   }
 }

--- a/include/seeds.harvest.hpp
+++ b/include/seeds.harvest.hpp
@@ -88,7 +88,7 @@ CONTRACT harvest : public contract {
     void check_asset(asset quantity);
     void deposit(asset quantity);
     void withdraw(name account, asset quantity);
-    void calc_tx_points(name account);
+    uint32_t calc_tx_points(name account);
     double get_rep_multiplier(name account);
 
     void size_change(name id, int delta);

--- a/include/seeds.harvest.hpp
+++ b/include/seeds.harvest.hpp
@@ -76,8 +76,6 @@ CONTRACT harvest : public contract {
 
     ACTION testclaim(name from, uint64_t request_id, uint64_t sec_rewind);
     ACTION testupdatecs(name account, uint64_t contribution_score);
-    ACTION clearscores();  // DEBUG REMOVE - migrate method
-    ACTION migrateplant(uint64_t startval);
     
     ACTION updtotal(); // MIGRATION ACTION
     
@@ -255,7 +253,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
           (payforcpu)(reset)(runharvest)
           (unplant)(claimrefund)(cancelrefund)(sow)
           (ranktx)(calctrxpt)(calctrxpts)(rankplanted)(rankplanteds)(calccss)(calccs)(rankcss)(rankcs)(ranktxs)(updatecs)
-          (updatetxpt)(clearscores)(migrateplant)(updtotal)(calctotal)
+          (updatetxpt)(updtotal)(calctotal)
           (testclaim)(testupdatecs))
       }
   }

--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -72,6 +72,7 @@ CONTRACT proposals : public contract {
       void burn(asset quantity);
       void update_voice_table();
       void vote_aux(name voter, uint64_t id, uint64_t amount, name option);
+      void change_rep(name beneficiary, bool passed);
 
       TABLE config_table {
           name param;

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -1,6 +1,7 @@
 #include <eosio/eosio.hpp>
 #include <eosio/asset.hpp>
-#include <harvest_table.hpp>
+#include <tables/rep_table.hpp>
+#include <tables/size_table.hpp>
 
 using namespace eosio;
 
@@ -34,16 +35,29 @@ namespace utils {
 
   double get_rep_multiplier(name account) {
 
-    DEFINE_HARVEST_TABLE
-    eosio::multi_index<"harvest"_n, harvest_table> harvest(contracts::harvest, contracts::harvest.value);
+    DEFINE_REP_TABLE
+    DEFINE_REP_TABLE_MULTI_INDEX
+    
+    rep_tables rep(contracts::accounts, contracts::accounts.value);
 
-    auto hitr = harvest.find(account.value);
+    auto ritr = rep.find(account.value);
 
-    if (hitr == harvest.end()) {
+    if (ritr == rep.end()) {
       return 0;
     }
 
-    return rep_multiplier_for_score(hitr->reputation_score);
+    return rep_multiplier_for_score(ritr->rank);
+
+  }
+
+  uint64_t get_users_size() {
+
+    DEFINE_SIZE_TABLE
+    DEFINE_SIZE_TABLE_MULTI_INDEX
+    
+    size_tables size(contracts::accounts, contracts::accounts.value);
+
+    return size.get("users.sz"_n.value, "users size unknown").size;
 
   }
 

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -9,6 +9,7 @@ namespace utils {
 
   const uint64_t seconds_per_day = 86400;
   const uint64_t seconds_per_minute = 60;
+  const uint64_t seconds_per_hour = seconds_per_minute * 60;
   const uint64_t moon_cycle = seconds_per_day * 29 + seconds_per_day / 2;
 
   symbol seeds_symbol = symbol("SEEDS", 4);

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -8,6 +8,7 @@ using namespace eosio;
 namespace utils {
 
   const uint64_t seconds_per_day = 86400;
+  const uint64_t seconds_per_minute = 60;
   const uint64_t moon_cycle = seconds_per_day * 29 + seconds_per_day / 2;
 
   symbol seeds_symbol = symbol("SEEDS", 4);

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -463,13 +463,16 @@ var permissions = [{
   actor: `${accounts.scheduler.account}@active`
 }, {
   target: `${accounts.harvest.account}@execute`, 
-  action: 'calcplanted'
+  action: 'ranktxs'
 }, {
   target: `${accounts.harvest.account}@execute`, 
+  action: 'rankplanteds'
+}, {
+  target: `${accounts.harvest.account}@execute`,
   action: 'calccss'
 }, {
   target: `${accounts.harvest.account}@execute`,
-  action: 'calctrx'
+  action: 'rankcss'
 }, {
   target: `${accounts.harvest.account}@execute`,
   action: 'calctrxpts'

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -290,6 +290,9 @@ var permissions = [{
   target: `${accounts.proposals.account}@active`,
   actor: `${accounts.accounts.account}@active`
 }, {
+  target: `${accounts.accounts.account}@active`,
+  actor: `${accounts.proposals.account}@eosio.code`
+}, {
   target: `${accounts.bank.account}@active`,
   actor: `${accounts.proposals.account}@active`
 }, {

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -314,6 +314,9 @@ var permissions = [{
   target: `${accounts.history.account}@active`,
   actor: `${accounts.harvest.account}@active`
 }, {
+  target: `${accounts.harvest.account}@active`,
+  actor: `${accounts.history.account}@eosio.code`
+}, {
   target: `${accounts.token.account}@active`,
   actor: `${accounts.token.account}@eosio.code`
 }, {
@@ -442,9 +445,6 @@ var permissions = [{
   action: 'calcplanted'
 }, {
   target: `${accounts.harvest.account}@execute`, 
-  action: 'calccbs'
-}, {
-  target: `${accounts.harvest.account}@execute`, 
   action: 'calccs'
 }, {
   target: `${accounts.harvest.account}@execute`,
@@ -452,9 +452,6 @@ var permissions = [{
 }, {
   target: `${accounts.harvest.account}@execute`,
   action: 'calctrxpt'
-}, {
-  target: `${accounts.harvest.account}@execute`,
-  action: 'calcrep'
 }, {
   target: `${accounts.exchange.account}@execute`,
   action: 'onperiod'

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -415,6 +415,19 @@ var permissions = [{
   target: `${accounts.proposals.account}@execute`,
   action: 'onperiod'
 }, {
+  target: `${accounts.accounts.account}@execute`,
+  key: activePublicKey,
+  parent: 'active'
+}, {
+  target: `${accounts.accounts.account}@execute`,
+  action: 'rankreps'
+}, {
+  target: `${accounts.accounts.account}@execute`,
+  action: 'rankcbss'
+}, {
+  target: `${accounts.accounts.account}@execute`,
+  actor: `${accounts.scheduler.account}@active`
+}, {
   target: `${accounts.forum.account}@execute`,
   action: 'newday'
 }, {
@@ -445,13 +458,13 @@ var permissions = [{
   action: 'calcplanted'
 }, {
   target: `${accounts.harvest.account}@execute`, 
-  action: 'calccs'
+  action: 'calccss'
 }, {
   target: `${accounts.harvest.account}@execute`,
   action: 'calctrx'
 }, {
   target: `${accounts.harvest.account}@execute`,
-  action: 'calctrxpt'
+  action: 'calctrxpts'
 }, {
   target: `${accounts.exchange.account}@execute`,
   action: 'onperiod'

--- a/scripts/seeds.js
+++ b/scripts/seeds.js
@@ -120,20 +120,6 @@ const updatePermissionAction = async () => {
   await updatePermissions()
 }
 
-const startHarvestCalculations = async () => {
-  console.log("Starting harvest calculations...")
-  const contracts = await initContractsHelper({ harvest })
-
-  console.log("start calcplanted")
-  await contracts.harvest.calcplanted({ authorization: `${harvest}@active` })
-  console.log("start calcrep")
-  await contracts.harvest.calcrep({ authorization: `${harvest}@active` })
-  console.log("start calctrx")
-  await contracts.harvest.calctrx({ authorization: `${harvest}@active` })
-  console.log("done.")
-
-}
-
 program
   .command('compile <contract> [moreContracts...]')
   .description('Compile custom contract')

--- a/scripts/seeds.js
+++ b/scripts/seeds.js
@@ -86,7 +86,7 @@ const resetAction = async (contract) => {
 const runAction = async (contract) => {
   await compileAction(contract)
   await deployAction(contract)
-  await test(contract)
+  //await test(contract)
 }
 
 const batchCallFunc = async (contract, moreContracts, func) => {

--- a/src/seeds.accounts.cpp
+++ b/src/seeds.accounts.cpp
@@ -650,6 +650,8 @@ void accounts::rankrep(uint64_t start_val, uint64_t chunk, uint64_t chunksize) {
   //}
 
   uint64_t total = get_size("rep.sz"_n);
+  if (total == 0) return;
+
   uint64_t current = chunk * chunksize;
   auto rep_by_rep = rep.get_index<"byrep"_n>();
   auto ritr = start_val == 0 ? rep_by_rep.begin() : rep_by_rep.lower_bound(start_val);
@@ -697,6 +699,8 @@ void accounts::rankcbs(uint64_t start_val, uint64_t chunk, uint64_t chunksize) {
   require_auth(_self);
 
   uint64_t total = get_size("cbs.sz"_n);
+  if (total == 0) return;
+
   uint64_t current = chunk * chunksize;
   auto cbs_by_cbs = cbs.get_index<"bycbs"_n>();
   auto citr = start_val == 0 ? cbs_by_cbs.begin() : cbs_by_cbs.lower_bound(start_val);

--- a/src/seeds.accounts.cpp
+++ b/src/seeds.accounts.cpp
@@ -639,7 +639,7 @@ void accounts::rankrep(uint64_t start_val, uint64_t chunk, uint64_t chunksize) {
   //  return;
   //}
 
-  uint64_t total = sizes.get("rep.sz"_n.value, "user rep size not set").size;
+  uint64_t total = get_size("rep.sz"_n);
   uint64_t current = chunk * chunksize;
   auto rep_by_rep = rep.get_index<"byrep"_n>();
   auto ritr = start_val == 0 ? rep_by_rep.begin() : rep_by_rep.lower_bound(start_val);
@@ -686,7 +686,7 @@ void accounts::rankcbss() {
 void accounts::rankcbs(uint64_t start_val, uint64_t chunk, uint64_t chunksize) {
   require_auth(_self);
 
-  uint64_t total = sizes.get("cbs.sz"_n.value, "cbs table size not set").size;
+  uint64_t total = get_size("cbs.sz"_n);
   uint64_t current = chunk * chunksize;
   auto cbs_by_cbs = cbs.get_index<"bycbs"_n>();
   auto citr = start_val == 0 ? cbs_by_cbs.begin() : cbs_by_cbs.lower_bound(start_val);
@@ -766,6 +766,15 @@ void accounts::size_set(name id, uint64_t newsize) {
     sizes.modify(sitr, _self, [&](auto& item) {
       item.size = newsize;
     });
+  }
+}
+
+uint64_t accounts::get_size(name id) {
+  auto sitr = sizes.find(id.value);
+  if (sitr == sizes.end()) {
+    return 0;
+  } else {
+    return sitr->size;
   }
 }
 

--- a/src/seeds.harvest.cpp
+++ b/src/seeds.harvest.cpp
@@ -550,21 +550,21 @@ void harvest::calc_contribution_score(name account) {
   uint64_t community_building_score = 0;
   uint64_t reputation_score = 0;
 
-  auto pitr = planted.find(account);
+  auto pitr = planted.find(account.value);
   if (pitr != planted.end()) planted_score = pitr->rank;
 
-  auto titr = txpoints.find(account);
+  auto titr = txpoints.find(account.value);
   if (titr != txpoints.end()) transactions_score = titr->rank;
 
-  auto citr = cbs.find(account);
+  auto citr = cbs.find(account.value);
   if (citr != cbs.end()) community_building_score = citr->rank;
 
-  auto ritr = rep.find(account);
+  auto ritr = rep.find(account.value);
   if (ritr != rep.end()) reputation_score = ritr->rank;
 
   uint64_t contribution_points = ( (planted_score + transactions_score + community_building_score) * reputation_score * 2) / 100; 
 
-  auto csitr = cspoints.find(account);
+  auto csitr = cspoints.find(account.value);
   if (csitr == cspoints.end()) {
     if (contribution_points > 0) {
       cspoints.emplace(_self, [&](auto& item) {

--- a/src/seeds.harvest.cpp
+++ b/src/seeds.harvest.cpp
@@ -351,8 +351,6 @@ void harvest::calctrxpt() {
     uitr++;
   }
 
-  print("HARVEST: calctrx executed");
-
 }
 
 void harvest::calctrx() {

--- a/src/seeds.harvest.cpp
+++ b/src/seeds.harvest.cpp
@@ -445,9 +445,8 @@ void harvest::calctrxpt(uint64_t start_val, uint64_t chunk, uint64_t chunksize) 
   uint64_t count = 0;
 
   while (uitr != users.end() && count < chunksize) {
-    uint32_t iter = calc_transaction_points(uitr->account);
-
-    count += iter;
+    uint32_t num = calc_transaction_points(uitr->account);
+    count += 1 + num;
     uitr++;
   }
 

--- a/src/seeds.harvest.cpp
+++ b/src/seeds.harvest.cpp
@@ -62,7 +62,7 @@ void harvest::plant(name from, name to, asset quantity, string memo) {
 
     add_planted(target, quantity);
 
-    deposit(quantity);
+    _deposit(quantity);
   }
 }
 
@@ -149,7 +149,7 @@ void harvest::claimrefund(name from, uint64_t request_id) {
     }
   }
   if (total.amount > 0) {
-    withdraw(beneficiary, total);
+    _withdraw(beneficiary, total);
   }
   action(
       permission_level(contracts::history, "active"_n),
@@ -240,7 +240,7 @@ void harvest::unplant(name from, asset quantity) {
 }
 
 void harvest::runharvest() {
-    require_auth(_self);
+  require_auth(get_self());
 }
 
 ACTION harvest::updatetxpt(name account) {
@@ -257,6 +257,8 @@ ACTION harvest::updatecs(name account) {
 // DEBUG action to clear scores tables
 // Deploy before
 ACTION harvest::clearscores() {
+  require_auth(get_self());
+
   uint64_t limit = 200;
 
   auto titr = txpoints.begin();
@@ -278,6 +280,8 @@ ACTION harvest::clearscores() {
 // copy everything to planted table
 
 ACTION harvest::updtotal() { // remove when balances are retired
+  require_auth(get_self());
+
   auto bitr = balances.find(_self.value);
   total_table tt = total.get_or_create(get_self(), total_table());
   tt.total_planted = bitr->planted;
@@ -285,6 +289,7 @@ ACTION harvest::updtotal() { // remove when balances are retired
 }
 
 ACTION harvest::migrateplant(uint64_t startval) {
+  require_auth(get_self());
 
   uint64_t limit = 100;
 
@@ -329,6 +334,7 @@ ACTION harvest::migrateplant(uint64_t startval) {
 }
 
 ACTION harvest::calctotal(uint64_t startval) {
+  require_auth(get_self());
 
   uint64_t limit = 300;
   total_table tt = total.get_or_create(get_self(), total_table());
@@ -819,7 +825,7 @@ void harvest::check_asset(asset quantity)
   check(quantity.symbol == seeds_symbol, "invalid asset");
 }
 
-void harvest::deposit(asset quantity)
+void harvest::_deposit(asset quantity)
 {
   check_asset(quantity);
 
@@ -827,7 +833,7 @@ void harvest::deposit(asset quantity)
   action.send(_self, contracts::bank, quantity, "");
 }
 
-void harvest::withdraw(name beneficiary, asset quantity)
+void harvest::_withdraw(name beneficiary, asset quantity)
 {
   check_asset(quantity);
 

--- a/src/seeds.harvest.cpp
+++ b/src/seeds.harvest.cpp
@@ -545,7 +545,44 @@ void harvest::calccs() {
 }
 
 void harvest::calc_contribution_score(name account) {
-  
+  uint64_t planted_score = 0;
+  uint64_t transactions_score = 0;
+  uint64_t community_building_score = 0;
+  uint64_t reputation_score = 0;
+
+  auto pitr = planted.find(account);
+  if (pitr != planted.end()) planted_score = pitr->rank;
+
+  auto titr = txpoints.find(account);
+  if (titr != txpoints.end()) transactions_score = titr->rank;
+
+  auto citr = cbs.find(account);
+  if (citr != cbs.end()) community_building_score = citr->rank;
+
+  auto ritr = rep.find(account);
+  if (ritr != rep.end()) reputation_score = ritr->rank;
+
+  uint64_t contribution_points = ( (planted_score + transactions_score + community_building_score) * reputation_score * 2) / 100; 
+
+  auto csitr = cspoints.find(account);
+  if (csitr == cspoints.end()) {
+    if (contribution_points > 0) {
+      cspoints.emplace(_self, [&](auto& item) {
+        item.account = account;
+        item.contribution_points = contribution_points;
+      });
+      size_change(cs_size, 1);
+    }
+  } else {
+    if (contribution_points > 0) {
+      cspoints.modify(csitr, _self, [&](auto& item) {
+        item.contribution_points = contribution_points;
+      });
+    } else {
+      cspoints.erase(csitr);
+      size_change(cs_size, -1);
+    }
+  }
 }
 
 void harvest::payforcpu(name account) {

--- a/src/seeds.history.cpp
+++ b/src/seeds.history.cpp
@@ -90,25 +90,17 @@ void history::trxentry(name from, name to, asset quantity) {
   });
 
   // delayed update
-  // action a(
-  //     permission_level{contracts::harvest, "active"_n},
-  //     contracts::harvest,
-  //     "updatetxpt"_n,
-  //     std::make_tuple(from)
-  //   );
-
-  //   transaction tx;
-  //   tx.actions.emplace_back(a);
-  //   tx.delay_sec = 1; // DEBUG no delay
-  //   tx.send(key, _self);
-
-  // debug instant update
-  action(
+  action a(
       permission_level{contracts::harvest, "active"_n},
       contracts::harvest,
       "updatetxpt"_n,
       std::make_tuple(from)
-    ).send();
+    );
+
+    transaction tx;
+    tx.actions.emplace_back(a);
+    tx.delay_sec = 1; // DEBUG no delay
+    tx.send(key, _self);
 
 }
 

--- a/src/seeds.history.cpp
+++ b/src/seeds.history.cpp
@@ -1,4 +1,6 @@
 #include <seeds.history.hpp>
+#include <eosio/system.hpp>
+#include <eosio/transaction.hpp>
 
 void history::reset(name account) {
   require_auth(get_self());
@@ -78,13 +80,36 @@ void history::trxentry(name from, name to, asset quantity) {
   }
     
   transaction_tables transactions(get_self(), from.value);
-  
+  uint64_t key = 0;
   transactions.emplace(_self, [&](auto& item) {
     item.id = transactions.available_primary_key();
     item.to = to;
     item.quantity = quantity;
     item.timestamp = eosio::current_time_point().sec_since_epoch();
+    key = item.id;
   });
+
+  // delayed update
+  // action a(
+  //     permission_level{contracts::harvest, "active"_n},
+  //     contracts::harvest,
+  //     "updatetxpt"_n,
+  //     std::make_tuple(from)
+  //   );
+
+  //   transaction tx;
+  //   tx.actions.emplace_back(a);
+  //   tx.delay_sec = 1; // DEBUG no delay
+  //   tx.send(key, _self);
+
+  // debug instant update
+  action(
+      permission_level{contracts::harvest, "active"_n},
+      contracts::harvest,
+      "updatetxpt"_n,
+      std::make_tuple(from)
+    ).send();
+
 }
 
 void history::check_user(name account)

--- a/src/seeds.scheduler.cpp
+++ b/src/seeds.scheduler.cpp
@@ -45,18 +45,26 @@ ACTION scheduler::reset() {
 
     std::vector<name> id_v = { 
         name("exch.period"),
+        name("acct.rankrep"),
+        name("acct.rankcbs"),
     };
     
     std::vector<name> operations_v = {
         name("onperiod"),
+        name("rankreps"),
+        name("rankcbss"),
     };
 
     std::vector<name> contracts_v = {
         contracts::exchange,
+        contracts::accounts,
+        contracts::accounts,
     };
 
     std::vector<uint64_t> delay_v = {
         utils::seconds_per_day * 7,
+        utils::seconds_per_minute * 30,
+        utils::seconds_per_minute * 30,
     };
 
     int i = 0;

--- a/src/seeds.scheduler.cpp
+++ b/src/seeds.scheduler.cpp
@@ -47,6 +47,11 @@ ACTION scheduler::reset() {
         name("exch.period"),
         name("acct.rankrep"),
         name("acct.rankcbs"),
+        name("hrvst.txpt"),
+        name("hrvst.txsc"),
+        name("hrvst.plant"),
+        name("hrvst.cspt"),
+        name("hrvst.cs"),
     };
     
     std::vector<name> operations_v = {
@@ -153,7 +158,7 @@ ACTION scheduler::confirm(name operation) {
 ACTION scheduler::execute() {
    // require_auth(_self);
 
-   print("Executing...");
+   // print("Executing...");
 
     /*
         Just as quick reminder.

--- a/src/seeds.scheduler.cpp
+++ b/src/seeds.scheduler.cpp
@@ -43,36 +43,6 @@ ACTION scheduler::reset() {
         titr = test.erase(titr);
     }
 
-    std::vector<name> id_v = { 
-        name("cs.rep"), 
-        name("cs.planted"),
-        name("cs.trxpt"), 
-        name("cs.trx"),
-        name("cs.cbs"),
-        name("cs.cs"),
-        name("exch.period"),
-    };
-    
-    std::vector<name> operations_v = {
-        name("calcrep"),
-        name("calcplanted"),
-        name("calctrxpt"),
-        name("calctrx"),
-        name("calccbs"),
-        name("calccs"),
-        name("onperiod"),
-    };
-
-    std::vector<name> contracts_v = {
-        contracts::harvest,
-        contracts::harvest,
-        contracts::harvest,
-        contracts::harvest,
-        contracts::harvest,
-        contracts::harvest,
-        contracts::exchange,
-    };
-
     std::vector<uint64_t> delay_v = {
         60,
         60,

--- a/src/seeds.scheduler.cpp
+++ b/src/seeds.scheduler.cpp
@@ -66,6 +66,7 @@ ACTION scheduler::reset() {
         name("hrvst.rankpl"),
 
         name("hrvst.calccs"), // after the above 4
+        name("hrvst.rankcs"), 
         name("hrvst.calctx"), // 24h
     };
     
@@ -77,9 +78,10 @@ ACTION scheduler::reset() {
         name("rankcbss"),
         
         name("ranktxs"),
-        name("rankcbss"),
+        name("rankplanteds"),
 
         name("calccss"),
+        name("rankcss"),
         name("calctrxpts"),
     };
 
@@ -95,6 +97,7 @@ ACTION scheduler::reset() {
 
         contracts::harvest,
         contracts::harvest,
+        contracts::harvest,
     };
 
     std::vector<uint64_t> delay_v = {
@@ -107,6 +110,7 @@ ACTION scheduler::reset() {
         utils::seconds_per_hour,
         utils::seconds_per_hour,
 
+        utils::seconds_per_hour,
         utils::seconds_per_hour,
         utils::seconds_per_day,
     };
@@ -124,6 +128,7 @@ ACTION scheduler::reset() {
         now,
 
         now + 120, // kicks off 2 minutes later
+        now + 240, // kicks off 4 minutes later
         now,
     };
 
@@ -271,7 +276,7 @@ ACTION scheduler::execute() {
     // schedule next execution
     // =======================
 
-    auto it_s = has_executed ? 1 : config.get(seconds_to_execute.value, contracts::scheduler.to_string() + ": the parameter " + seconds_to_execute.to_string() + " is not configured in " + contracts::settings.to_string()).value;
+    auto it_s = has_executed ? 1 : config.get(seconds_to_execute.value, (contracts::scheduler.to_string() + ": the parameter " + seconds_to_execute.to_string() + " is not configured in " + contracts::settings.to_string()).c_str()).value;
 
     action next_execution(
         permission_level{get_self(), "active"_n},
@@ -284,7 +289,7 @@ ACTION scheduler::execute() {
 
     transaction tx;
     tx.actions.emplace_back(next_execution);
-    tx.delay_sec = it_s -> value;
+    tx.delay_sec = it_s;
     tx.send(contracts::scheduler.value /*eosio::current_time_point().sec_since_epoch() + 30*/, _self);
     
 

--- a/src/seeds.settings.cpp
+++ b/src/seeds.settings.cpp
@@ -15,6 +15,7 @@ void settings::reset() {
   configure(name("org.minplant"), 200 * 10000);
   configure(name("mooncyclesec"), utils::moon_cycle);
   configure(name("propdecaysec"), utils::seconds_per_day);
+  configure(name("batchsize"), 200);
   configure(name("bio.fee"), uint64_t(1000) * uint64_t(10000));
   
   // Scheduler cycle
@@ -33,6 +34,11 @@ void settings::reset() {
   configure(name("refrep1.ind"), 1);
   // reputation points for referrer when user becomes citizen
   configure(name("refrep2.ind"), 1);
+
+  // reputation points for voting all active proposals
+  configure(name("voterep1.ind"), 5);
+  // reputation points for entering in the participants table
+  configure(name("voterep2.ind"), 1);
 
   // reward for individual referrer when user becomes resident  
   configure(name("refrwd1.ind"), 1000 * 10000); // 1000 SEEDS

--- a/src/seeds.settings.cpp
+++ b/src/seeds.settings.cpp
@@ -5,6 +5,8 @@ void settings::reset() {
 
   // config
   configure(name("propminstake"), 500 * 10000); // 500 Seeds
+  configure(name("proppass.rep"), 10); // rep points for passed proposal
+  
   configure(name("refsnewprice"), 25 * 10000);
   configure(name("refsmajority"), 80);
   configure(name("refsquorum"), 80);

--- a/test/accounts.test.js
+++ b/test/accounts.test.js
@@ -57,11 +57,17 @@ const get_reps = async () => {
   const users = await eos.getTableRows({
     code: accounts,
     scope: accounts,
-    table: 'users',
+    table: 'rep',
     json: true,
   })
 
-  return users.rows.map( ({ reputation }) => reputation )
+  console.log("XX reps "+JSON.stringify(users, null, 2))
+
+  const result = users.rows.map( ({ rep }) => rep )
+
+  console.log("get_reps "+JSON.stringify(result, null, 2))
+
+  return result
 }
 
 const can_vote = async (user) => {
@@ -175,24 +181,21 @@ describe('accounts', async assert => {
   
   console.log('test resident')
 
-  await contract.testresident(firstuser, { authorization: `${accounts}@active` })
+  await contract.testresident(seconduser, { authorization: `${accounts}@active` })
 
   assert({
     given: 'resident',
     should: 'cant vote',
-    actual: await can_vote(firstuser),
+    actual: await can_vote(seconduser),
     expected: false
   })
 
   console.log('test citizen again')
 
-  await contract.testcitizen(firstuser, { authorization: `${accounts}@active` })
-
   let balanceBeforeResident = await getBalance(firstuser)
   //console.log('balanceBeforeResident '+balanceBeforeResident)
 
   console.log('test resident')
-  await contract.testresident(seconduser, { authorization: `${accounts}@active` })
 
   const cbScore1 = await eos.getTableRows({
     code: accounts,
@@ -390,9 +393,9 @@ describe('vouching', async assert => {
   await contract.adduser(seconduser, 'Second user', "individual", { authorization: `${accounts}@active` })
   await contract.adduser(thirduser, 'Third user', "individual", { authorization: `${accounts}@active` })
 
-  await harvestContract.testsetrs(firstuser, 50, { authorization: `${harvest}@active` })
-  await harvestContract.testsetrs(seconduser, 50, { authorization: `${harvest}@active` })
-  await harvestContract.testsetrs(thirduser, 50, { authorization: `${harvest}@active` })
+  await contract.testsetrs(firstuser, 50, { authorization: `${accounts}@active` })
+  await contract.testsetrs(seconduser, 50, { authorization: `${accounts}@active` })
+  await contract.testsetrs(thirduser, 50, { authorization: `${accounts}@active` })
   // not yet active
   //console.log('unrequested vouch for user')
   //await contract.vouch(seconduser, thirduser, { authorization: `${seconduser}@active` })
@@ -404,7 +407,7 @@ describe('vouching', async assert => {
   await contract.requestvouch(thirduser, firstuser,{ authorization: `${thirduser}@active` })
   await contract.requestvouch(seconduser, firstuser,{ authorization: `${seconduser}@active` })
 
-  checkReps([0, 0, 0], "init", "be empty")
+  checkReps([0, 0, 0], "init", "be empty XX")
 
   console.log('vouch for user')
   await contract.vouch(firstuser, seconduser, { authorization: `${firstuser}@active` })
@@ -484,7 +487,7 @@ describe('vouching with reputation', async assert => {
   }
 
   const checkReps = async (expectedReps, given, should) => {
-  
+    
     assert({
       given: given,
       should: should,
@@ -516,16 +519,16 @@ describe('vouching with reputation', async assert => {
   console.log('test citizen')
   await contract.testcitizen(firstuser, { authorization: `${accounts}@active` })
 
-  checkReps([0, 0, 0, 0], "init", "be empty")
+  checkReps([], "init", "be empty")
 
   console.log('vouch for user')
-  await harvestContract.testsetrs(firstuser, 25, { authorization: `${harvest}@active` })
+  await contract.testsetrs(firstuser, 25, { authorization: `${accounts}@active` })
   await contract.vouch(firstuser, seconduser, { authorization: `${firstuser}@active` })
 
-  await harvestContract.testsetrs(firstuser, 75, { authorization: `${harvest}@active` })
+  await contract.testsetrs(firstuser, 75, { authorization: `${accounts}@active` })
   await contract.vouch(firstuser, thirduser, { authorization: `${firstuser}@active` })
 
-  await harvestContract.testsetrs(firstuser, 99, { authorization: `${harvest}@active` })
+  await contract.testsetrs(firstuser, 99, { authorization: `${accounts}@active` })
   await contract.vouch(firstuser, fourthuser, { authorization: `${firstuser}@active` })
 
   checkReps([0, 10, 30, 40], "after vouching", "get rep bonus for being vouched")
@@ -704,9 +707,10 @@ describe('make resident', async assert => {
   console.log('add referral')
   await contracts.accounts.addref(firstuser, seconduser, { authorization: `${accounts}@api` })
   console.log('update reputation')
-  await contracts.accounts.addrep(firstuser, 100, { authorization: `${accounts}@api` })
+  await contracts.accounts.addrep(firstuser, 50, { authorization: `${accounts}@api` })
 
   // 3 CHECK STATUS - succeed
+  console.log('make resident')
   await contracts.accounts.makeresident(firstuser, { authorization: `${firstuser}@active` })
 
   assert({
@@ -782,10 +786,11 @@ describe('make citizen', async assert => {
   await contracts.accounts.addref(firstuser, seconduser, { authorization: `${accounts}@api` })
   await contracts.accounts.addref(firstuser, thirduser, { authorization: `${accounts}@api` })
   await contracts.accounts.addref(firstuser, fourthuser, { authorization: `${accounts}@api` })
-  console.log('update reputation')
-  await contracts.harvest.testsetrs(firstuser, 51, { authorization: `${harvest}@active` })
+  console.log('update reputation SCORE')
+  await contracts.accounts.testsetrs(firstuser, 51, { authorization: `${accounts}@active` })
 
   // 3 CHECK STATUS - succeed
+  console.log('make citizen')
   await contracts.accounts.makecitizen(firstuser, { authorization: `${firstuser}@active` })
 
   assert({

--- a/test/harvest.test.js
+++ b/test/harvest.test.js
@@ -241,7 +241,7 @@ describe("Harvest General", async assert => {
 
   console.log('calculate transactions score')
   await contracts.harvest.calctrxpt({ authorization: `${harvest}@active` })
-  await contracts.harvest.calctrx({ authorization: `${harvest}@active` })
+  await contracts.harvest.ranktxs({ authorization: `${harvest}@active` })
 
 
   var balanceBefore = await getBalance(seconduser);
@@ -406,7 +406,7 @@ describe("harvest planted score", async assert => {
   await contracts.harvest.calcplanted({ authorization: `${harvest}@active` })
   await contracts.accounts.rankreps({ authorization: `${accounts}@active` })
   await contracts.harvest.calctrxpt({ authorization: `${harvest}@active` })
-  await contracts.harvest.calctrx({ authorization: `${harvest}@active` })
+  await contracts.harvest.ranktxs({ authorization: `${harvest}@active` })
 
   const balances = await eos.getTableRows({
     code: harvest,
@@ -462,7 +462,7 @@ describe("harvest transaction score", async assert => {
 
     console.log("checking points "+points + " scores: "+scores)
     await contracts.harvest.calctrxpt({ authorization: `${harvest}@active` })
-    await contracts.harvest.calctrx({ authorization: `${harvest}@active` })
+    await contracts.harvest.ranktxs({ authorization: `${harvest}@active` })
     
     const txpoints = await eos.getTableRows({
       code: harvest,

--- a/test/harvest.test.js
+++ b/test/harvest.test.js
@@ -47,18 +47,46 @@ describe("Harvest General", async assert => {
   console.log(" tx points 1 "+JSON.stringify(txpoints1, null, 2))
 
   
-  console.log('plant seeds')
+  console.log('plant seeds x')
   await contracts.token.transfer(firstuser, harvest, '500.0000 SEEDS', '', { authorization: `${firstuser}@active` })
   await contracts.token.transfer(seconduser, harvest, '200.0000 SEEDS', '', { authorization: `${seconduser}@active` })
 
-  console.log('plant seeds')
+  console.log('transfer seeds')
   await contracts.token.transfer(firstuser, seconduser, '1.0000 SEEDS', '', { authorization: `${firstuser}@active` })
   await contracts.token.transfer(seconduser, firstuser, '0.1000 SEEDS', '', { authorization: `${seconduser}@active` })
 
   const balanceBeforeUnplanted = await getBalanceFloat(seconduser)
 
+  const checkTotal = async (check) => {
+    const total = await eos.getTableRows({
+      code: harvest,
+      scope: harvest,
+      table: 'total',
+      json: true,
+    })
+    // const planted = await eos.getTableRows({
+    //   code: harvest,
+    //   scope: harvest,
+    //   table: 'planted',
+    //   json: true,
+    // })
+    // console.log("planted "+JSON.stringify(planted, null, 2))
+    // console.log("total "+JSON.stringify(total, null, 2))
+
+    assert({
+      given: 'checking total '+check,
+      should: 'be able the same',
+      actual: total.rows[0].total_planted,
+      expected: check + ".0000 SEEDS"
+    })
+  }
+
+  await checkTotal(700);
+
   let num_seeds_unplanted = 100
   await contracts.harvest.unplant(seconduser, num_seeds_unplanted + '.0000 SEEDS', { authorization: `${seconduser}@active` })
+
+  await checkTotal(600);
 
   var unplantedOverdrawCheck = true
   try {

--- a/test/harvest.test.js
+++ b/test/harvest.test.js
@@ -236,8 +236,8 @@ describe("Harvest General", async assert => {
   await contracts.accounts.addrep(seconduser, 2, { authorization: `${accounts}@active` })
   await contracts.accounts.rankreps({ authorization: `${accounts}@active` })
 
-  console.log('claim reward')
-  await contracts.harvest.testreward(seconduser, { authorization: `${harvest}@active` })
+  //console.log('claim reward')
+  //await contracts.harvest.testreward(seconduser, { authorization: `${harvest}@active` })
 
   console.log('calculate transactions score')
   await contracts.harvest.calctrxpt({ authorization: `${harvest}@active` })
@@ -245,7 +245,7 @@ describe("Harvest General", async assert => {
 
 
   var balanceBefore = await getBalance(seconduser);
-  const transactionReward = await contracts.harvest.claimreward(seconduser, { authorization: `${seconduser}@active` })
+  //const transactionReward = await contracts.harvest.claimreward(seconduser, { authorization: `${seconduser}@active` })
   var balanceAfter = await getBalance(seconduser);
 
   assert({

--- a/test/harvest.test.js
+++ b/test/harvest.test.js
@@ -22,8 +22,6 @@ describe("Harvest General", async assert => {
   console.log('reset token stats')
   await contracts.token.resetweekly({ authorization: `${token}@active` })
 
-  await contracts.harvest.migrateplant(0, { authorization: `${harvest}@active` })
-
   console.log('configure')
   await contracts.settings.configure("hrvstreward", 10000 * 100, { authorization: `${settings}@active` })
 

--- a/test/onboarding.test.js
+++ b/test/onboarding.test.js
@@ -368,7 +368,7 @@ describe('Use application permission to accept', async assert => {
     await contracts.accounts.adduser(firstuser, '', 'individual', { authorization: `${accounts}@active` })     
     
     await contracts.accounts.testresident(firstuser, { authorization: `${accounts}@active` })
-    await contracts.harvest.testsetrs(firstuser, 22, { authorization: `${harvest}@active` })
+    await contracts.accounts.testsetrs(firstuser, 22, { authorization: `${accounts}@active` })
 
     console.log(`${token}.transfer from ${firstuser} to ${onboarding} (${totalQuantity})`)
     await contracts.token.transfer(firstuser, onboarding, totalQuantity, '', { authorization: `${firstuser}@active` })    

--- a/test/proposals.test.js
+++ b/test/proposals.test.js
@@ -197,6 +197,15 @@ describe('Proposals', async assert => {
     json: true,
   })
 
+  const repsBefore = await eos.getTableRows({
+    code: accounts,
+    scope: accounts,
+    table: 'rep',
+    lower: firstuser,
+    upper: firstuser,
+    json: true,
+  })
+
   console.log('execute proposals')
   await contracts.proposals.onperiod({ authorization: `${proposals}@active` })
 
@@ -289,8 +298,8 @@ describe('Proposals', async assert => {
 
   assert({
     given: 'passed proposal',
-    should: 'send reward and stake',
-    actual: repsAfter.rows[0].rep,
+    should: 'gain rep',
+    actual: repsAfter.rows[0].rep - repsBefore.rows[0].rep,
     expected: 10
   })
 
@@ -482,11 +491,6 @@ describe('Participants', async assert => {
   console.log('deposit stake (memo 2)')
   await contracts.token.transfer(firstuser, proposals, '500.0000 SEEDS', '2', { authorization: `${firstuser}@active` })
 
-  console.log('add voice')
-  await contracts.proposals.addvoice(firstuser, 44, { authorization: `${proposals}@active` })
-  await contracts.proposals.addvoice(seconduser, 44, { authorization: `${proposals}@active` })
-  await contracts.proposals.addvoice(thirduser, 44, { authorization: `${proposals}@active` })
-
   console.log('force status')
   await contracts.accounts.testcitizen(firstuser, { authorization: `${accounts}@active` })
   await contracts.accounts.testcitizen(seconduser, { authorization: `${accounts}@active` })
@@ -494,7 +498,7 @@ describe('Participants', async assert => {
 
   console.log('move proposals to active')
   await contracts.proposals.onperiod({ authorization: `${proposals}@active` })
-  await sleep(10000)
+  await sleep(3000)
 
   const participantsBefore = await eos.getTableRows({
     code: proposals,
@@ -562,9 +566,9 @@ describe('Participants', async assert => {
     should: 'have the correct voice amount',
     actual: voiceAfter.rows,
     expected: [
-      { account: firstuser, balance: 36 },
-      { account: seconduser, balance: 36 },
-      { account: thirduser, balance: 44 }
+      { account: firstuser, balance: 12 },
+      { account: seconduser, balance: 32 },
+      { account: thirduser, balance: 60 }
     ]
   })
 
@@ -665,9 +669,9 @@ describe('Change Trust', async assert => {
 
   await check("off", "no voice", 0) 
 
-  await contracts.proposals.changetrust(firstuser, 1, { authorization: `${proposals}@active` })
+  //await contracts.proposals.changetrust(firstuser, 1, { authorization: `${proposals}@active` })
 
-  await check("after", "has voice", 1) 
+  //await check("after", "has voice", 1) 
 
   
 

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -27,9 +27,7 @@ describe('token.transfer.history', async assert => {
   const contract = await eos.contract(token)
   const historyContract = await eos.contract(history)
   const accountsContract = await eos.contract(accounts)
-  
-  const transfer = () => contract.transfer(firstuser, seconduser, '10.0000 SEEDS', ``, { authorization: `${firstuser}@active` })
-  
+    
   console.log('reset token')
   await contract.resetweekly({ authorization: `${token}@active` })
 
@@ -46,8 +44,8 @@ describe('token.transfer.history', async assert => {
   await accountsContract.testcitizen(seconduser, { authorization: `${accounts}@active` })
   
   console.log('transfer token')
-  await transfer()
-  
+  await contract.transfer(firstuser, seconduser, '10.0000 SEEDS', `0`, { authorization: `${firstuser}@active` })
+
   const { rows } = await getTableRows({
     code: history,
     scope: firstuser,
@@ -67,7 +65,7 @@ describe('token.transfer.history', async assert => {
     }]
   })
 
-  await transfer()
+  await contract.transfer(firstuser, seconduser, '10.0000 SEEDS', `1`, { authorization: `${firstuser}@active` })
 
   const stats = await getTableRows({
     code: token,
@@ -81,7 +79,7 @@ describe('token.transfer.history', async assert => {
   assert({
     given: 'transactions',
     should: 'have transaction stat entries',
-    actual: stats.rows,
+    actual: stats.rows.filter( (item) => item.account == firstuser || item.account == seconduser),
     expected: [
       {
         "account": "seedsuseraaa",
@@ -113,7 +111,6 @@ describe('token.transfer', async assert => {
   const contract = await eos.contract(token)
 
   let limit = 10;
-  const transfer = (n) => contract.transfer(firstuser, seconduser, '10.0000 SEEDS', `x${n}`, { authorization: `${firstuser}@active` })
 
   const balances = [await getBalance(firstuser)]
   
@@ -122,16 +119,8 @@ describe('token.transfer', async assert => {
 
   console.log(`call transfer x${limit} times`)
   while (--limit >= 0) {
-    await transfer(limit)
+    await contract.transfer(firstuser, seconduser, '10.0000 SEEDS', limit + "x", { authorization: `${firstuser}@active` })
   }
-
-  // Test limit - should be by planted - put this back in when implemented
-  // try {
-  //   await transfer()
-  //   console.log('transferred over limit (NOT expected)')
-  // } catch (err) {
-  //   console.log('transfer over limit failed (as expected)')
-  // }
 
   balances.push(await getBalance(firstuser))
 
@@ -187,13 +176,12 @@ describe('token calculate circulating supply', async assert => {
 
   const contract = await eos.contract(token)
   
-  const transfer = () => contract.transfer(firstuser, seconduser, '10.0000 SEEDS', ``, { authorization: `${firstuser}@active` })
   
   console.log('update circulating')
   await contract.updatecirc({ authorization: `${token}@active` })
   
   console.log('transfer token')
-  await transfer()
+  await contract.transfer(firstuser, seconduser, '10.0000 SEEDS', `cc1`, { authorization: `${firstuser}@active` })
   
   const { rows } = await getTableRows({
     code: token,


### PR DESCRIPTION
# Scores
All scores are calculated in a new way and found here now

Score | Contract | Table | Table Fields
------------ | ------------- | ------------- | -------------
Reputation points and score | accts.seeds | rep | rep, rank
Community Building Score | accts.seeds | cbs | community_building_score, rank
Planted Score | harvst.seeds | planted | planted, rank
Transaction Score | harvst.seeds | txpoints | points, rank
Contribution Score | harvst.seeds | cspoints | contribution_points, rank

# Testing

- [x] Fix all harvest unit tests
- [x] Fix all accounts unit tests

# Migration Contract
Deploy migration contract to clear 
 - [x] harvest: cspoints table
 - [x] harvest: txpoints table
- [x] accounts: rep table
- [x] accounts: cbs table

# Testing Testnet

- [x] Run all calc methods with 1 and 3 chunk sizes
- [x] calctx
- [x] ranktx
- [x] rankplanted
- [x] rankcbs (set cbs)
- [x] calccs
- [x] rankcs


# Deployment

- [x] Deploy accounts
- [x] Deploy Harvest migration contract
- [x] call migrate on harvest migration contract
- [x] Deploy Harvest contract
- [x] Migrate planted by calling migrateplant
- [x] run updatePermissions
