### PR TITLE
Feature/org reputation tx pt

### DIFF
--- a/include/seeds.harvest.hpp
+++ b/include/seeds.harvest.hpp
@@ -78,13 +78,16 @@ CONTRACT harvest : public contract {
     ACTION testupdatecs(name account, uint64_t contribution_score);
     
     ACTION updtotal(); // MIGRATION ACTION
-    
+
+    ACTION setorgtxpt(name organization, uint64_t tx_points);
+
   private:
     symbol seeds_symbol = symbol("SEEDS", 4);
     uint64_t ONE_WEEK = 604800;
 
     name planted_size = "planted.sz"_n;
     name tx_points_size = "txpt.sz"_n;
+    name org_tx_points_size = "org.tx.sz"_n;
     name cs_size = "cs.sz"_n;
 
     void init_balance(name account);
@@ -254,7 +257,10 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
           (unplant)(claimrefund)(cancelrefund)(sow)
           (ranktx)(calctrxpt)(calctrxpts)(rankplanted)(rankplanteds)(calccss)(calccs)(rankcss)(rankcs)(ranktxs)(updatecs)
           (updatetxpt)(updtotal)(calctotal)
-          (testclaim)(testupdatecs))
+          (setorgtxpt)
+          (testclaim)(testupdatecs)
+
+          )
       }
   }
 }

--- a/include/seeds.history.hpp
+++ b/include/seeds.history.hpp
@@ -2,6 +2,7 @@
 #include <contracts.hpp>
 #include <eosio/system.hpp>
 #include <eosio/asset.hpp>
+#include <tables/config_table.hpp>
 
 #include <contracts.hpp>
 #include <tables/user_table.hpp>
@@ -34,12 +35,15 @@ CONTRACT history : public contract {
 
         ACTION orgtxpoints(name organization);
 
-        ACTION orgtxpt(name organization, uint64_t id, uint64_t chunksize, uint64_t running_total);
+        ACTION orgtxpt(name organization, uint128_t start_val, uint64_t chunksize, uint64_t running_total);
 
 
     private:
       void check_user(name account);
       uint32_t num_transactions(name account, uint32_t limit);
+      uint64_t config_get(name key);
+      void fire_orgtx_calc(name organization, uint128_t start_val, uint64_t chunksize, uint64_t running_total);
+      bool clean_old_tx(name org, uint64_t chunksize);
 
       TABLE citizen_table {
         uint64_t id;
@@ -92,15 +96,13 @@ CONTRACT history : public contract {
        uint64_t primary_key() const { return id; }
        uint64_t by_timestamp() const { return timestamp; }
        uint64_t by_quantity() const { return quantity.amount; }
-       uint64_t by_other() const { return other.value; }
-       uint64_t by_in() const { return in ? 1 : 0; }
+       uint128_t by_other() const { return (uint128_t(other.value) << 64) + id; }
     };
 
     typedef eosio::multi_index<"orgtx"_n, org_tx_table,
       indexed_by<"bytimestamp"_n,const_mem_fun<org_tx_table, uint64_t, &org_tx_table::by_timestamp>>,
       indexed_by<"byquantity"_n,const_mem_fun<org_tx_table, uint64_t, &org_tx_table::by_quantity>>,
-      indexed_by<"byother"_n,const_mem_fun<org_tx_table, uint64_t, &org_tx_table::by_other>>,
-      indexed_by<"byin"_n,const_mem_fun<org_tx_table, uint64_t, &org_tx_table::by_in>>
+      indexed_by<"byother"_n,const_mem_fun<org_tx_table, uint128_t, &org_tx_table::by_other>>
     > org_tx_tables;
 
     typedef eosio::multi_index<"transactions"_n, transaction_table,
@@ -130,4 +132,10 @@ CONTRACT history : public contract {
     citizen_tables citizens;
 };
 
-EOSIO_DISPATCH(history, (reset)(historyentry)(trxentry)(addcitizen)(addresident)(numtrx));
+EOSIO_DISPATCH(history, 
+  (reset)
+  (historyentry)(trxentry)
+  (addcitizen)(addresident)
+  (numtrx)
+  (orgtxpoints)(orgtxpt)
+  );

--- a/include/seeds.history.hpp
+++ b/include/seeds.history.hpp
@@ -79,20 +79,23 @@ CONTRACT history : public contract {
 
     TABLE org_tx_table {
        uint64_t id;
-       name from;
+       name other;
+       bool in;
        asset quantity;
        uint64_t timestamp;
 
        uint64_t primary_key() const { return id; }
        uint64_t by_timestamp() const { return timestamp; }
-       uint64_t by_from() const { return from.value; }
        uint64_t by_quantity() const { return quantity.amount; }
+       uint64_t by_other() const { return from.value; }
+       bool by_in() const { return in; }
     };
 
     typedef eosio::multi_index<"orgtx"_n, org_tx_table,
       indexed_by<"bytimestamp"_n,const_mem_fun<org_tx_table, uint64_t, &org_tx_table::by_timestamp>>,
       indexed_by<"byquantity"_n,const_mem_fun<org_tx_table, uint64_t, &org_tx_table::by_quantity>>,
-      indexed_by<"byfrom"_n,const_mem_fun<org_tx_table, uint64_t, &org_tx_table::by_from>>
+      indexed_by<"byother"_n,const_mem_fun<org_tx_table, uint64_t, &org_tx_table::by_other>>
+      indexed_by<"byin"_n,const_mem_fun<org_tx_table, bool, &org_tx_table::by_in>>
     > org_tx_tables;
 
     typedef eosio::multi_index<"transactions"_n, transaction_table,

--- a/include/seeds.history.hpp
+++ b/include/seeds.history.hpp
@@ -32,6 +32,11 @@ CONTRACT history : public contract {
 
         ACTION numtrx(name account);
 
+        ACTION orgtxpoints(name organization);
+
+        ACTION orgtxpt(name organization, uint64_t id, uint64_t chunksize, uint64_t running_total);
+
+
     private:
       void check_user(name account);
       uint32_t num_transactions(name account, uint32_t limit);
@@ -87,15 +92,15 @@ CONTRACT history : public contract {
        uint64_t primary_key() const { return id; }
        uint64_t by_timestamp() const { return timestamp; }
        uint64_t by_quantity() const { return quantity.amount; }
-       uint64_t by_other() const { return from.value; }
-       bool by_in() const { return in; }
+       uint64_t by_other() const { return other.value; }
+       uint64_t by_in() const { return in ? 1 : 0; }
     };
 
     typedef eosio::multi_index<"orgtx"_n, org_tx_table,
       indexed_by<"bytimestamp"_n,const_mem_fun<org_tx_table, uint64_t, &org_tx_table::by_timestamp>>,
       indexed_by<"byquantity"_n,const_mem_fun<org_tx_table, uint64_t, &org_tx_table::by_quantity>>,
-      indexed_by<"byother"_n,const_mem_fun<org_tx_table, uint64_t, &org_tx_table::by_other>>
-      indexed_by<"byin"_n,const_mem_fun<org_tx_table, bool, &org_tx_table::by_in>>
+      indexed_by<"byother"_n,const_mem_fun<org_tx_table, uint64_t, &org_tx_table::by_other>>,
+      indexed_by<"byin"_n,const_mem_fun<org_tx_table, uint64_t, &org_tx_table::by_in>>
     > org_tx_tables;
 
     typedef eosio::multi_index<"transactions"_n, transaction_table,

--- a/include/seeds.history.hpp
+++ b/include/seeds.history.hpp
@@ -76,6 +76,25 @@ CONTRACT history : public contract {
        uint64_t by_to() const { return to.value; }
        uint64_t by_quantity() const { return quantity.amount; }
     };
+
+    TABLE org_tx_table {
+       uint64_t id;
+       name from;
+       asset quantity;
+       uint64_t timestamp;
+
+       uint64_t primary_key() const { return id; }
+       uint64_t by_timestamp() const { return timestamp; }
+       uint64_t by_from() const { return from.value; }
+       uint64_t by_quantity() const { return quantity.amount; }
+    };
+
+    typedef eosio::multi_index<"orgtx"_n, org_tx_table,
+      indexed_by<"bytimestamp"_n,const_mem_fun<org_tx_table, uint64_t, &org_tx_table::by_timestamp>>,
+      indexed_by<"byquantity"_n,const_mem_fun<org_tx_table, uint64_t, &org_tx_table::by_quantity>>,
+      indexed_by<"byfrom"_n,const_mem_fun<org_tx_table, uint64_t, &org_tx_table::by_from>>
+    > org_tx_tables;
+
     typedef eosio::multi_index<"transactions"_n, transaction_table,
       indexed_by<"bytimestamp"_n,const_mem_fun<transaction_table, uint64_t, &transaction_table::by_timestamp>>,
       indexed_by<"byquantity"_n,const_mem_fun<transaction_table, uint64_t, &transaction_table::by_quantity>>,

--- a/include/seeds.organization.hpp
+++ b/include/seeds.organization.hpp
@@ -58,6 +58,8 @@ CONTRACT organization : public contract {
 
         void deposit(name from, name to, asset quantity, std::string memo);
 
+        ACTION scoreorgs(name next);
+
     private:
         symbol seeds_symbol = symbol("SEEDS", 4);
 
@@ -188,7 +190,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
   } else if (code == receiver) {
       switch (action) {
           EOSIO_DISPATCH_HELPER(organization, (reset)(addmember)(removemember)(changerole)(changeowner)(addregen)
-            (subregen)(create)(destroy)(refund)(appuse)(registerapp)(banapp)(cleandaus)(cleandau))
+            (subregen)(create)(destroy)(refund)(appuse)(registerapp)(banapp)(cleandaus)(cleandau)(scoreorgs))
       }
   }
 }

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -334,6 +334,22 @@ var permissions = [{
   target: `${accounts.accounts.account}@api`,
   action: 'subrep'
 }, {
+  target: `${accounts.harvest.account}@setorgtxpt`,
+  actor: `${accounts.history.account}@eosio.code`,
+  parent: 'active',
+  type: 'createActorPermission'
+}, {
+  target: `${accounts.harvest.account}@setorgtxpt`,
+  action: 'setorgtxpt'
+}, {
+  target: `${accounts.history.account}@orgtxpoints`,
+  actor: `${accounts.organization.account}@eosio.code`,
+  parent: 'active',
+  type: 'createActorPermission'
+}, {
+  target: `${accounts.history.account}@orgtxpoints`,
+  action: 'orgtxpoints'
+}, {
   target: `${accounts.accounts.account}@api`,
   action: 'addref'
 }, {

--- a/src/seeds.accounts.cpp
+++ b/src/seeds.accounts.cpp
@@ -633,45 +633,6 @@ uint32_t accounts::num_transactions(name account, uint32_t limit) {
   return count;
 }
 
-// void accounts::migraterep(uint64_t account, uint64_t cycle, uint64_t chunksize) {
-//   require_auth(_self);
-//   auto uitr = account == 0 ? users.begin() : users.find(account);
-//   uint64_t count = 0;
-//   while (uitr != users.end() && count < chunksize) {
-//     if (uitr->reputation > 0) {
-//       auto ritr = rep.find(uitr->account.value);
-//       if (ritr != rep.end()) {
-//         rep.modify(ritr, _self, [&](auto& item) {
-//           item.rep = uitr->reputation;
-//         });
-//       } else {
-//         add_rep_item(uitr->account, uitr->reputation);
-//       }
-//     }
-//     uitr++;
-//     count++;
-//   }
-//   if (uitr == users.end()) {
-//     // done
-//     size_set("users.sz"_n, chunksize * cycle + count);
-//   } else {
-//     // recursive call
-//     uint64_t nextaccount = uitr->account.value;
-//     action next_execution(
-//         permission_level{get_self(), "active"_n},
-//         get_self(),
-//         "migraterep"_n,
-//         std::make_tuple(nextaccount, cycle+1, chunksize)
-//     );
-
-//     transaction tx;
-//     tx.actions.emplace_back(next_execution);
-//     tx.delay_sec = 1;
-//     tx.send(nextaccount + 1, _self);
-    
-//   }
-// }
-
 void accounts::rankreps() {
   rankrep(0, 0, 200);
 }

--- a/src/seeds.exchange.cpp
+++ b/src/seeds.exchange.cpp
@@ -179,7 +179,7 @@ void exchange::buytlos(name buyer, name contract, asset tlos_quantity, string me
 void exchange::newpayment(name recipientAccount, string paymentSymbol, string paymentId, uint64_t multipliedUsdValue) {
 
     require_auth(get_self());
-
+ 
     asset usd_asset = asset(multipliedUsdValue, usd_symbol);
 
     auto history_by_payment_id = payhistory.get_index<"bypaymentid"_n>();

--- a/src/seeds.harvest.cpp
+++ b/src/seeds.harvest.cpp
@@ -378,7 +378,6 @@ uint32_t harvest::calc_transaction_points(name account) {
       //auto it = transactions_by_to.erase(--tx_to_itr.base());// TODO add test for this
       //tx_to_itr = std::reverse_iterator(it);            
     } else {
-      //print("update to ");
 
       // update "to"
       if (current_to != tx_to_itr->to) {
@@ -389,12 +388,8 @@ uint32_t harvest::calc_transaction_points(name account) {
         current_num++;
       }
 
-      //print("iterating over "+std::to_string(tx_to_itr->id));
-
       if (current_num < max_number_of_transactions) {
         uint64_t volume = tx_to_itr->quantity.amount;
-
-      //print("volume "+std::to_string(volume));
 
         // limit max volume
         if (volume > max_quantity * 10000) {
@@ -402,12 +397,9 @@ uint32_t harvest::calc_transaction_points(name account) {
           volume = max_quantity * 10000;
         }
 
-
         // multiply by receiver reputation
         double points = (double(volume) / 10000.0) * current_rep_multiplier;
         
-        //print("tx points "+std::to_string(points));
-
         result += points;
 
       } 
@@ -417,14 +409,6 @@ uint32_t harvest::calc_transaction_points(name account) {
     count++;
   }
 
-  //print("set result "+std::to_string(result));
-
-  // use ceil function so each schore is counted if it is > 0
-    
-  // DEBUG
-  // if (result == 0) {
-  //   result = 33.0;
-  // }
   // enter into transaction points table
   auto titr = txpoints.find(account.value);
   uint64_t points = ceil(result);

--- a/src/seeds.history.cpp
+++ b/src/seeds.history.cpp
@@ -13,10 +13,15 @@ void history::reset(name account) {
   }
   
   transaction_tables transactions(get_self(), account.value);
-  auto titr = transactions.begin();
-  
+  auto titr = transactions.begin();  
   while (titr != transactions.end()) {
     titr = transactions.erase(titr);
+  }
+  
+  org_tx_tables orgtx(get_self(), account.value);
+  auto oitr = orgtx.begin();
+  while (oitr != orgtx.end()) {
+    oitr = orgtx.erase(oitr);
   }
   
   auto citr = citizens.begin();

--- a/src/seeds.settings.cpp
+++ b/src/seeds.settings.cpp
@@ -33,6 +33,12 @@ void settings::reset() {
 
   confwithdesc(name("txlimit.mul"), 10, "Multiplier to calculate maximum number of transactions per user", high_impact);
 
+  confwithdesc(name("i.trx.max"), uint64_t(1777) * uint64_t(10000), "Individuals: Maximum points for a transaction", high_impact);
+  confwithdesc(name("i.trx.div"), 26, "Individuals: Transaction diversity not more than 26 from 1 user is counted", high_impact);
+  
+  confwithdesc(name("org.trx.max"), uint64_t(1777) * uint64_t(10000), "Organization: Maximum points for a transaction", high_impact);
+  confwithdesc(name("org.trx.div"), 26, "Organization: Transaction diversity not more than 26 from 1 other is counted", high_impact);
+
   confwithdesc(name("txlimit.min"), 7, "Minimum number of transactions per user", high_impact);
 
   // Scheduler cycle

--- a/test/history.test.js
+++ b/test/history.test.js
@@ -145,7 +145,7 @@ describe('org transaction entry', async assert => {
   const firstorg = 'testorg111'
   const secondorg = 'testorg222'
 
-  const contracts = await initContracts({ history, accounts, organization, token })
+  const contracts = await initContracts({ settings, history, accounts, organization, token })
   
   console.log('history reset')
   await contracts.history.reset(firstuser, { authorization: `${history}@active` })
@@ -153,6 +153,9 @@ describe('org transaction entry', async assert => {
   
   console.log('accounts reset')
   await contracts.accounts.reset({ authorization: `${accounts}@active` })
+
+  console.log('settings reset')
+  await contracts.settings.reset({ authorization: `${settings}@active` })
 
   console.log('org reset')
   await contracts.organization.reset({ authorization: `${organization}@active` })

--- a/test/organization.test.js
+++ b/test/organization.test.js
@@ -1,5 +1,5 @@
 const { describe } = require("riteway")
-const { eos, encodeName, getBalance, getBalanceFloat, names, getTableRows, isLocal } = require("../scripts/helper")
+const { eos, encodeName, getBalance, getBalanceFloat, names, getTableRows, isLocal, initContracts } = require("../scripts/helper")
 const { equals } = require("ramda")
 const { asset } = require("eosjs/lib/schema")
 
@@ -27,6 +27,8 @@ describe('organization', async assert => {
     ]).then(([organization, token, accounts, settings, harvest]) => ({
         organization, token, accounts, settings, harvest
     }))
+    console.log('settings reset')
+    await contracts.settings.reset({ authorization: `${settings}@active` })
 
     console.log('reset organization')
     await contracts.organization.reset({ authorization: `${organization}@active` })
@@ -40,9 +42,9 @@ describe('organization', async assert => {
     console.log('harvest reset')
     await contracts.harvest.reset({ authorization: `${harvest}@active` })
 
-    console.log('configure')
-    await contracts.settings.configure('planted', 500000, { authorization: `${settings}@active` })
-
+    // console.log('configure')
+    // await contracts.settings.configure('planted', 500000, { authorization: `${settings}@active` })
+  
     console.log('join users')
     await contracts.accounts.adduser(firstuser, 'first user', 'individual', { authorization: `${accounts}@active` })
     await contracts.accounts.adduser(seconduser, 'second user', 'individual', { authorization: `${accounts}@active` })
@@ -614,6 +616,129 @@ describe('app', async assert => {
 })
 
 
+describe('transaction points', async assert => {
+    const contracts = await initContracts({ settings, history, accounts, organization, token, harvest })
+    let firstorg = 'testorg1'
+    let secondorg = 'testorg2'
 
+    console.log('settings reset')
+    await contracts.settings.reset({ authorization: `${settings}@active` })
 
+    console.log('reset organization')
+    await contracts.organization.reset({ authorization: `${organization}@active` })
 
+    console.log('reset token stats')
+    await contracts.token.resetweekly({ authorization: `${token}@active` })
+
+    console.log('accounts reset')
+    await contracts.accounts.reset({ authorization: `${accounts}@active` })
+    
+    console.log('harvest reset')
+    await contracts.harvest.reset({ authorization: `${harvest}@active` })
+
+    console.log('history reset')
+    await contracts.history.reset(firstuser, { authorization: `${history}@active` })
+    await contracts.history.reset(seconduser, { authorization: `${history}@active` })
+    await contracts.history.reset(firstorg, { authorization: `${history}@active` })
+    await contracts.history.reset(secondorg, { authorization: `${history}@active` })
+  
+    console.log('join users')
+    await contracts.accounts.adduser(firstuser, 'first user', 'individual', { authorization: `${accounts}@active` })
+    await contracts.accounts.adduser(seconduser, 'second user', 'individual', { authorization: `${accounts}@active` })
+
+    console.log('add rep')
+    await contracts.accounts.addrep(firstuser, 10000, { authorization: `${accounts}@active` })
+    await contracts.accounts.addrep(seconduser, 13000, { authorization: `${accounts}@active` })
+
+    console.log('create balance')
+    await contracts.token.transfer(firstuser, organization, "400.0000 SEEDS", "Initial supply", { authorization: `${firstuser}@active` })
+    await contracts.token.transfer(seconduser, organization, "200.0000 SEEDS", "Initial supply", { authorization: `${seconduser}@active` })
+    
+    console.log('create organization')
+
+    await contracts.organization.create(firstuser, firstorg, "Org Number 1", eosDevKey, { authorization: `${firstuser}@active` })
+    await contracts.organization.create(firstuser, secondorg, "Org 2", eosDevKey,  { authorization: `${firstuser}@active` })
+
+    console.log('add rep for these users then make some transactions')
+    await contracts.accounts.testsetrs(firstuser, 99, { authorization: `${accounts}@active` })
+    await contracts.accounts.testsetrs(seconduser, 25, { authorization: `${accounts}@active` })
+    await contracts.accounts.testsetrs(firstorg, 33, { authorization: `${accounts}@active` })
+    await contracts.accounts.testsetrs(secondorg, 66, { authorization: `${accounts}@active` })
+
+    console.log('make transfers')
+    const transfer = async (a, b, amount) => {
+        await contracts.token.transfer(a, b, amount, Math.random().toString(36).substring(7), { authorization: `${a}@active` })
+    }
+    
+    await transfer(firstuser, firstorg, "10.0000 SEEDS")
+    await transfer(firstuser, secondorg, "19.0000 SEEDS")
+    await transfer(secondorg, firstorg, "19.0000 SEEDS")
+    await transfer(firstorg, seconduser, "13.0000 SEEDS")
+    await transfer(seconduser, firstorg, "7.0000 SEEDS")
+    
+    const orgTx1 = await getTableRows({
+        code: history,
+        scope: firstorg,
+        table: 'orgtx',
+        json: true
+    })
+
+    const orgTx2 = await getTableRows({
+        code: history,
+        scope: secondorg,
+        table: 'orgtx',
+        json: true
+    })
+
+    const userTx1 = await getTableRows({
+        code: history,
+        scope: firstuser,
+        table: 'transactions',
+        json: true
+    })
+    const userTx2 = await getTableRows({
+        code: history,
+        scope: seconduser,
+        table: 'transactions',
+        json: true
+    })
+
+    console.log("org1 tx "+JSON.stringify(orgTx1, null, 2))
+    console.log("org2 tx "+JSON.stringify(orgTx2, null, 2))
+    console.log("user1 tx "+JSON.stringify(userTx1, null, 2))
+    console.log("user2 tx "+JSON.stringify(userTx2, null, 2))
+
+    let t1 = await contracts.history.orgtxpt(firstorg, 0, 200, 0, { authorization: `${history}@active` })
+    printConsole(t1)
+
+    let txt = await contracts.organization.scoreorgs(firstorg, { authorization: `${organization}@active` })
+
+    let checkTxPoints = async () => {
+        const txpoints = await getTableRows({
+            code: harvest,
+            scope: 'org',
+            table: 'txpoints',
+            json: true
+        })    
+        
+        console.log("harvest txpoints "+JSON.stringify(txpoints, null, 2))
+    
+    }
+    await checkTxPoints()
+
+    await contracts.organization.scoreorgs(secondorg, { authorization: `${organization}@active` })
+
+    await checkTxPoints()
+
+})
+
+const printConsole = (objResult) => {
+    const str = ""+JSON.stringify(objResult, null, 2)
+    const lines = str.split("\n")
+    for (var i=0; i<lines.length; i++) {
+        const l = lines[i].trim()
+        if (l.startsWith('"console')) {
+            console.log(l)
+        }
+    }
+}


### PR DESCRIPTION
## Additions

Organization contract scoreorgs action
History contract orgtxpoints and orgtxpt actions
Harvest contract setorgtxpt action
Permissions in the init script / updatePermissions
Unit tests for organization transaction point scores

History contract now keeps track of organization transactions
History contract can also calculate and send to harvest transaction points for orgs

Harvest contract can then score them (doesn't do that yet but should be simple as it's just a different scope)

Deployed to testnet

## Organization transaction points and score

- [x] - Track organization transactions in history contract - orgs track both to and from
- [x] - Add unit tests
- [x] - Add org tx points and rank table in harvest contract - tx points table with scope "org"
