### PR TITLE
Feature/simple vote depreciation - #114

### DIFF
--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -52,13 +52,15 @@ CONTRACT proposals : public contract {
 
       ACTION onperiod();
 
-      ACTION decayvoice();
-
       ACTION updatevoices();
 
       ACTION updatevoice(uint64_t start);
 
       ACTION checkstake(uint64_t prop_id);
+
+      ACTION decayvoices();
+
+      ACTION decayvoice(uint64_t start, uint64_t chunksize);
 
   private:
       symbol seeds_symbol = symbol("SEEDS", 4);
@@ -180,7 +182,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
   } else if (code == receiver) {
       switch (action) {
         EOSIO_DISPATCH_HELPER(proposals, (reset)(create)(update)(addvoice)(changetrust)(favour)(against)
-        (neutral)(erasepartpts)(checkstake)(onperiod)(decayvoice)(cancel)(updatevoices)(updatevoice))
+        (neutral)(erasepartpts)(checkstake)(onperiod)(decayvoice)(cancel)(updatevoices)(updatevoice)(decayvoices))
       }
   }
 }

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -11,6 +11,7 @@ namespace utils {
   const uint64_t seconds_per_minute = 60;
   const uint64_t seconds_per_hour = seconds_per_minute * 60;
   const uint64_t moon_cycle = seconds_per_day * 29 + seconds_per_day / 2;
+  const uint64_t proposal_cycle = moon_cycle / 2; // proposals run at half moon cycles at the moment
 
   symbol seeds_symbol = symbol("SEEDS", 4);
 

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -527,6 +527,9 @@ var permissions = [{
 }, { 
   target: `${accounts.organization.account}@execute`,
   actor: `${accounts.scheduler.account}@active`
+}, {
+  target: `${accounts.proposals.account}@execute`,
+  action: 'decayvoices'
 }]
 
 const isTestnet = chainId == networks.telosTestnet

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -211,11 +211,6 @@ void proposals::updatevoice(uint64_t start) {
   }
 }
 
-uint64_t proposals::get_cycle_period_sec() {
-  auto moon_cycle = config.get(name("mooncyclesec").value, "The mooncyclesec parameter has not been initialized yet.");
-  return moon_cycle.value / 2; // Using half moon cycles for now
-}
-
 uint64_t proposals::get_voice_decay_period_sec() {
   auto voice_decay_period = config.get(name("propdecaysec").value, "The propdecaysec parameter has not been initialized yet.");
   return voice_decay_period.value;

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -230,24 +230,15 @@ void proposals::decayvoices() {
   uint64_t decay_time = config.get(name("decaytime").value, "The decaytime parameter has not been initialized yet.").value;
   uint64_t decay_sec = config.get(name("propdecaysec").value, "The propdecaysec parameter has not been initialized yet.").value;
 
-  print("\n---------------------------------\n");
-  print("t_onperiod:", c.t_onperiod, "\n");
-  print("t_voicedecay:", c.t_voicedecay, "\n");
-  print("now:", now, "\n");
-  print("t_onperiod - now = ", now - c.t_onperiod, "\n");
-  print("now - c.t_voicedecay = ", now - c.t_voicedecay, "\n");
-
   if ((c.t_onperiod < now)
       && (now - c.t_onperiod >= decay_time)
       && (now - c.t_voicedecay >= decay_sec)
   ) {
-    print("executing...\n");
     c.t_voicedecay = now;
     cycle.set(c, get_self());
     auto batch_size = config.get(name("batchsize").value, "The batchsize parameter has not been initialized yet.");
     decayvoice(0, batch_size.value);
   }
-  print("\n---------------------------------\n");
 }
 
 void proposals::decayvoice(uint64_t start, uint64_t chunksize) {
@@ -275,8 +266,6 @@ void proposals::decayvoice(uint64_t start, uint64_t chunksize) {
         "decayvoice"_n,
         std::make_tuple(next_value, chunksize)
     );
-
-    print("\n\n\nCALLED NEW BATCH\n\n\n");
 
     transaction tx;
     tx.actions.emplace_back(next_execution);

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -221,10 +221,68 @@ uint64_t proposals::get_voice_decay_period_sec() {
   return voice_decay_period.value;
 }
 
-void proposals::decayvoice() {
-  // Not yet implemented    
+void proposals::decayvoices() {
   require_auth(get_self());
 
+  cycle_table c = cycle.get_or_create(get_self(), cycle_table());
+
+  uint64_t now = current_time_point().sec_since_epoch();
+  uint64_t decay_time = config.get(name("decaytime").value, "The decaytime parameter has not been initialized yet.").value;
+  uint64_t decay_sec = config.get(name("propdecaysec").value, "The propdecaysec parameter has not been initialized yet.").value;
+
+  print("\n---------------------------------\n");
+  print("t_onperiod:", c.t_onperiod, "\n");
+  print("t_voicedecay:", c.t_voicedecay, "\n");
+  print("now:", now, "\n");
+  print("t_onperiod - now = ", now - c.t_onperiod, "\n");
+  print("now - c.t_voicedecay = ", now - c.t_voicedecay, "\n");
+
+  if ((c.t_onperiod < now)
+      && (now - c.t_onperiod >= decay_time)
+      && (now - c.t_voicedecay >= decay_sec)
+  ) {
+    print("executing...\n");
+    c.t_voicedecay = now;
+    cycle.set(c, get_self());
+    auto batch_size = config.get(name("batchsize").value, "The batchsize parameter has not been initialized yet.");
+    decayvoice(0, batch_size.value);
+  }
+  print("\n---------------------------------\n");
+}
+
+void proposals::decayvoice(uint64_t start, uint64_t chunksize) {
+  require_auth(get_self());
+  auto percentage_decay = config.get(name("vdecayprntge").value, "The vdecayprntge parameter has not been initialized yet.");
+  check(percentage_decay.value <= 100, "Voice decay parameter can not be more than 100%.");
+  auto vitr = start == 0 ? voice.begin() : voice.find(start);
+  uint64_t count = 0;
+
+  double multiplier = (100.0 - (double)percentage_decay.value) / 100.0;
+
+  while (vitr != voice.end() && count < chunksize) {
+    voice.modify(vitr, _self, [&](auto & v){
+      v.balance *= multiplier;
+    });
+    vitr++;
+    count++;
+  }
+
+  if (vitr != voice.end()) {
+    uint64_t next_value = vitr->account.value;
+    action next_execution(
+        permission_level{get_self(), "active"_n},
+        get_self(),
+        "decayvoice"_n,
+        std::make_tuple(next_value, chunksize)
+    );
+
+    print("\n\n\nCALLED NEW BATCH\n\n\n");
+
+    transaction tx;
+    tx.actions.emplace_back(next_execution);
+    tx.delay_sec = 1;
+    tx.send(next_value, _self);
+  }
 }
 
 void proposals::update_cycle() {

--- a/src/seeds.scheduler.cpp
+++ b/src/seeds.scheduler.cpp
@@ -68,6 +68,8 @@ ACTION scheduler::reset() {
         name("hrvst.calctx"), // 24h
 
         name("org.clndaus"),
+
+        name("prop.dvoices"),
     };
     
     std::vector<name> operations_v = {
@@ -85,6 +87,8 @@ ACTION scheduler::reset() {
         name("calctrxpts"),
 
         name("cleandaus"),
+
+        name("decayvoices"),
     };
 
     std::vector<name> contracts_v = {
@@ -102,6 +106,8 @@ ACTION scheduler::reset() {
         contracts::harvest,
 
         contracts::organization,
+
+        contracts::proposals,
     };
 
     std::vector<uint64_t> delay_v = {
@@ -119,6 +125,8 @@ ACTION scheduler::reset() {
         utils::seconds_per_day,
 
         utils::seconds_per_day / 2,
+
+        utils::seconds_per_day
     };
 
     uint64_t now = current_time_point().sec_since_epoch();
@@ -137,6 +145,7 @@ ACTION scheduler::reset() {
         now + 600 - utils::seconds_per_hour, // kicks off 10 minutes later
         now,
 
+        now,
         now,
     };
 

--- a/src/seeds.settings.cpp
+++ b/src/seeds.settings.cpp
@@ -27,9 +27,11 @@ void settings::reset() {
   confwithdesc(name("hrvstreward"), 100000, "Harvest reward", high_impact);
   confwithdesc(name("org.minplant"), 200 * 10000, "Minimum amount to create an organization (in Seeds)", high_impact);
   confwithdesc(name("mooncyclesec"), utils::moon_cycle, "Number of seconds a moon cycle has", high_impact);
-  confwithdesc(name("propdecaysec"), utils::seconds_per_day, "Number of seconds per day", high_impact);
   confwithdesc(name("batchsize"), 200, "Number of elements per batch", high_impact);
   confwithdesc(name("bio.fee"), uint64_t(1000) * uint64_t(10000), "Minimum amount to create a bio region (in Seeds)", high_impact);
+  confwithdesc(name("vdecayprntge"), 15, "The percentage of voice decay (in percentage)", high_impact);
+  confwithdesc(name("decaytime"), utils::moon_cycle / 2, "Minimum amount of seconds before start voice decay", high_impact);
+  confwithdesc(name("propdecaysec"), utils::seconds_per_day, "Minimum amount of seconds before execute a new voice decay", high_impact);
 
   confwithdesc(name("txlimit.mul"), 10, "Multiplier to calculate maximum number of transactions per user", high_impact);
 

--- a/src/seeds.settings.cpp
+++ b/src/seeds.settings.cpp
@@ -30,7 +30,7 @@ void settings::reset() {
   confwithdesc(name("batchsize"), 200, "Number of elements per batch", high_impact);
   confwithdesc(name("bio.fee"), uint64_t(1000) * uint64_t(10000), "Minimum amount to create a bio region (in Seeds)", high_impact);
   confwithdesc(name("vdecayprntge"), 15, "The percentage of voice decay (in percentage)", high_impact);
-  confwithdesc(name("decaytime"), utils::moon_cycle / 2, "Minimum amount of seconds before start voice decay", high_impact);
+  confwithdesc(name("decaytime"), utils::proposal_cycle / 2, "Minimum amount of seconds before start voice decay", high_impact);
   confwithdesc(name("propdecaysec"), utils::seconds_per_day, "Minimum amount of seconds before execute a new voice decay", high_impact);
 
   confwithdesc(name("txlimit.mul"), 10, "Multiplier to calculate maximum number of transactions per user", high_impact);


### PR DESCRIPTION
- Added `decayvoices` and `decayvoice` actions
- Added new settings
- Added to scheduler reset

## Deploy Steps

- [ ] Deploy proposals contract
- [ ] Deploy scheduler contract
- [ ] Deploy settings contract
- [ ] run updatePermissions
- [ ] run reset on settings contract

Amazingly, the voice decay timestamp was already in there so no migration of tables - foresight level visionary ;) 

