### PR TITLE
maximum ask of new accounts is 250,000

### DIFF
--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -69,6 +69,10 @@ CONTRACT proposals : public contract {
       name abstain = "abstain"_n;
       name max_initial_ask_prop = "prop.maxask"_n;
 
+      name type_alliance = "alliance"_n;
+      name type_campaign = "campaign"_n;
+      name type_hypha = "hypha"_n;
+
       void update_cycle();
       void update_voicedecay();
       uint64_t get_cycle_period_sec();

--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -67,6 +67,7 @@ CONTRACT proposals : public contract {
       name trust = "trust"_n;
       name distrust = "distrust"_n;
       name abstain = "abstain"_n;
+      name max_initial_ask_prop = "prop.maxask"_n;
 
       void update_cycle();
       void update_voicedecay();
@@ -86,6 +87,9 @@ CONTRACT proposals : public contract {
       void update_voice_table();
       void vote_aux(name voter, uint64_t id, uint64_t amount, name option);
       void change_rep(name beneficiary, bool passed);
+      bool is_trusted(name account);
+      void acct_history(name account, uint64_t amount, bool passed);
+      uint64_t config_get(name key);
 
       DEFINE_CONFIG_TABLE
         
@@ -154,6 +158,16 @@ CONTRACT proposals : public contract {
       uint64_t t_onperiod; // last time onperiod ran
       uint64_t t_voicedecay; // last time voice was decayed
     };
+
+    TABLE proposer_history_table {
+      name account;
+      uint64_t props_succeeded;
+      uint64_t props_failed;
+      uint64_t total_raised;
+      uint64_t total_asked;
+      uint64_t primary_key()const { return account.value; }
+    };
+
     
     typedef eosio::multi_index<"props"_n, proposal_table> proposal_tables;
     typedef eosio::multi_index<"votes"_n, vote_table> votes_tables;
@@ -164,6 +178,7 @@ CONTRACT proposals : public contract {
     typedef singleton<"cycle"_n, cycle_table> cycle_tables;
     typedef eosio::multi_index<"cycle"_n, cycle_table> dump_for_cycle;
     typedef eosio::multi_index<"minstake"_n, min_stake_table> min_stake_tables;
+    typedef eosio::multi_index<"prophist"_n, proposer_history_table> proposer_history_tables;
 
     config_tables config;
     proposal_tables props;

--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -75,6 +75,8 @@ CONTRACT proposals : public contract {
 
       ACTION testvdecay(uint64_t timestamp);
 
+      ACTION migrathistry(); // migrate trust - remove again when done
+
   private:
       symbol seeds_symbol = symbol("SEEDS", 4);
       name trust = "trust"_n;
@@ -234,7 +236,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
       switch (action) {
         EOSIO_DISPATCH_HELPER(proposals, (reset)(create)(update)(addvoice)(changetrust)(favour)(against)
         (neutral)(erasepartpts)(checkstake)(onperiod)(decayvoice)(cancel)(updatevoices)(updatevoice)(decayvoices)
-        (addactive)(removeactive)(updateactivs)(updateactive)(testvdecay))
+        (addactive)(removeactive)(updateactivs)(updateactive)(testvdecay)(migrathistry))
       }
   }
 }

--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -124,7 +124,6 @@ CONTRACT proposals : public contract {
       void change_rep(name beneficiary, bool passed);
       bool is_trusted(name account);
       void acct_history(name account, uint64_t amount, bool passed);
-      uint64_t config_get(name key);
       void size_change(name id, int64_t delta);
       uint64_t get_size(name id);
       void recover_voice(name account);
@@ -260,7 +259,6 @@ CONTRACT proposals : public contract {
     cycle_tables cycle;
     min_stake_tables minstake;
     active_tables actives;
-    size_tables sizes;
 
 };
 

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -501,6 +501,8 @@ void proposals::stake(name from, name to, asset quantity, string memo) {
 }
 
 void proposals::erasepartpts(uint64_t active_proposals) {
+  require_auth(get_self());
+
   uint64_t batch_size = config_get(name("batchsize"));
   uint64_t reward_points = config_get(name("voterep1.ind"));
 

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -896,6 +896,7 @@ void proposals::testvdecay(uint64_t timestamp) {
 }
 
 void proposals::migrathistry() {
+  require_auth(get_self());
 
   auto pitr = props.begin();
 

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -903,7 +903,7 @@ void proposals::migrathistry() {
   auto pitr = props.begin();
 
   while (pitr != props.end()) {
-    acct_history(pitr->creator, pitr->quantity.amount, pitr->status == name("passed"));
+    acct_history(pitr->creator, pitr->quantity.amount, pitr->status == name("passed") || pitr->status == name("evaluate"));
     pitr++;
   }
 

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -894,3 +894,14 @@ void proposals::testvdecay(uint64_t timestamp) {
   c.t_voicedecay = timestamp;
   cycle.set(c, get_self());
 }
+
+void proposals::migrathistry() {
+
+  auto pitr = props.begin();
+
+  while (pitr != props.end()) {
+    acct_history(pitr->creator, pitr->quantity.amount, pitr->status == name("passed"));
+    pitr++;
+  }
+
+}

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -385,9 +385,9 @@ void proposals::create(name creator, name recipient, asset quantity, string titl
 
   utils::check_asset(quantity);
 
-  if (!is_trusted(creator)) {
+  if (proposal_type == type_campaign && !is_trusted(creator)) {
     uint64_t max_ask = config_get(max_initial_ask_prop);
-    check(quantity.amount <= max_ask, "Earn trust by making and passing proposals up to 250,000 Seeds before asking for more.");
+    check(quantity.amount <= max_ask, "First time campaign proposals are limited to 250,000 Seeds.");
   }
 
   uint64_t lastId = 0;

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -1076,15 +1076,6 @@ void proposals::recover_voice(name account) {
   }
 }
 
-uint64_t proposals::config_get(name key) {
-  auto citr = config.find(key.value);
-  if (citr == config.end()) { 
-    // only create the error message string in error case for efficiency
-    check(false, ("settings: the "+key.to_string()+" parameter has not been initialized").c_str());
-  }
-  return citr->value;
-}
-
 void proposals::removeactive(name account) {
   require_auth(get_self());
 

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -287,8 +287,20 @@ void proposals::create(name creator, name recipient, asset quantity, string titl
 
   check_user(creator);
 
-  check(fund == bankaccts::milestone || fund == bankaccts::alliances || fund == bankaccts::campaigns, 
-  "Invalid fund - fund must be one of "+bankaccts::milestone.to_string() + ", "+ bankaccts::alliances.to_string() + ", " + bankaccts::campaigns.to_string() );
+  name proposal_type;
+
+  if (fund == bankaccts::milestone) {
+    proposal_type = type_hypha;
+  } else if (fund == bankaccts::alliances) {
+    proposal_type = type_alliance;
+  } else if (fund == bankaccts::campaigns) {
+    proposal_type = type_campaign;
+  } else {
+    check(false, "Invalid fund - fund must be one of "+
+      bankaccts::milestone.to_string() + ", "+ 
+      bankaccts::alliances.to_string() + ", " + 
+      bankaccts::campaigns.to_string() );
+  }
 
   if (fund == bankaccts::milestone) { // Milestone Seeds
     check(recipient == bankaccts::hyphabank, "Hypha proposals must go to " + bankaccts::hyphabank.to_string() + " - wrong recepient: " + recipient.to_string());
@@ -296,6 +308,7 @@ void proposals::create(name creator, name recipient, asset quantity, string titl
     check(is_account(recipient), "recipient is not a valid account: " + recipient.to_string());
     check(is_account(fund), "fund is not a valid account: " + fund.to_string());
   }
+
   utils::check_asset(quantity);
 
   if (!is_trusted(creator)) {

--- a/src/seeds.settings.cpp
+++ b/src/seeds.settings.cpp
@@ -7,8 +7,9 @@ void settings::reset() {
   confwithdesc(name("propminstake"), uint64_t(555) * uint64_t(10000), "Minimum proposals stake threshold (in Seeds)", high_impact); 
   confwithdesc(name("propmaxstake"), uint64_t(11111) * uint64_t(10000), "Max proposals stake 11,111 threshold (in Seeds)", high_impact);
   confwithdesc(name("propstakeper"), 5, "Proposal funding fee in % - 5%", high_impact); 
+  confwithdesc(name("prop.maxask"), uint64_t(50000) * uint64_t(10000), "Max first ask 50,000 Seeds", high_impact);
 
-  confwithdesc(name("proppass.rep"), 10, "Reputation points for passed proposal", high_impact); // rep points for passed proposal
+  confwithdesc(name("proppass.rep"), 10, "Reputation points for passed proposal", high_impact); 
   
   confwithdesc(name("unity.high"), 80, "High unity threshold (in percentage)", high_impact);
   confwithdesc(name("unity.medium"), 70, "Medium unity threshold (in percentage)", high_impact);
@@ -23,7 +24,8 @@ void settings::reset() {
   confwithdesc(name("refsquorum"), 80, "Quorum referendums threshold", high_impact);
   confwithdesc(name("propmajority"), 80, "Majority proposals threshold", high_impact);
   confwithdesc(name("propquorum"), 5, "Quorum proposals threshold", high_impact);
-  confwithdesc(name("propvoice"), 77, "Voice base per period", high_impact); // voice base per period
+  confwithdesc(name("propvoice"), 77, "(No longer used)", high_impact); // No longer used - remove
+
   confwithdesc(name("hrvstreward"), 100000, "Harvest reward", high_impact);
   confwithdesc(name("org.minplant"), 200 * 10000, "Minimum amount to create an organization (in Seeds)", high_impact);
   confwithdesc(name("mooncyclesec"), utils::moon_cycle, "Number of seconds a moon cycle has", high_impact);

--- a/src/seeds.settings.cpp
+++ b/src/seeds.settings.cpp
@@ -7,7 +7,7 @@ void settings::reset() {
   confwithdesc(name("propminstake"), uint64_t(555) * uint64_t(10000), "Minimum proposals stake threshold (in Seeds)", high_impact); 
   confwithdesc(name("propmaxstake"), uint64_t(11111) * uint64_t(10000), "Max proposals stake 11,111 threshold (in Seeds)", high_impact);
   confwithdesc(name("propstakeper"), 5, "Proposal funding fee in % - 5%", high_impact); 
-  confwithdesc(name("prop.maxask"), uint64_t(50000) * uint64_t(10000), "Max first ask 50,000 Seeds", high_impact);
+  confwithdesc(name("prop.maxask"), uint64_t(250000) * uint64_t(10000), "Max first ask 250,000 Seeds", high_impact);
 
   confwithdesc(name("proppass.rep"), 10, "Reputation points for passed proposal", high_impact); 
   

--- a/test/proposals.test.js
+++ b/test/proposals.test.js
@@ -1040,6 +1040,9 @@ describe('Proposals Quorum', async assert => {
   await contracts.proposals.createx(firstuser, firstuser, '2.5000 SEEDS', 'title', 'summary', 'description', 'image', 'url', campaignbank, [ 10, 30, 30, 30 ], { authorization: `${firstuser}@active` })
   await contracts.proposals.createx(seconduser, seconduser, '1.4000 SEEDS', 'title', 'summary', 'description', 'image', 'url', campaignbank, [ 10, 30, 30, 30 ], { authorization: `${seconduser}@active` })
 
+  console.log('fill bank')
+  await contracts.token.transfer(firstuser, campaignbank, '200000.0000 SEEDS', '1', { authorization: `${firstuser}@active` })
+
   console.log('deposit stake (memo 1)')
   await contracts.token.transfer(firstuser, proposals, '2.0000 SEEDS', '1', { authorization: `${firstuser}@active` })
   console.log('deposit stake (memo 2)')

--- a/test/proposals.test.js
+++ b/test/proposals.test.js
@@ -33,6 +33,9 @@ describe('Proposals', async assert => {
   console.log('harvest reset')
   await contracts.harvest.reset({ authorization: `${harvest}@active` })
 
+  console.log('token reset')
+  await contracts.token.resetweekly({ authorization: `${token}@active` })
+
   console.log('proposals reset')
   await contracts.proposals.reset({ authorization: `${proposals}@active` })
 
@@ -44,6 +47,9 @@ describe('Proposals', async assert => {
   await contracts.accounts.adduser(seconduser, 'seconduser', 'individual', { authorization: `${accounts}@active` })
   await contracts.accounts.adduser(thirduser, 'thirduser', 'individual', { authorization: `${accounts}@active` })
   await contracts.accounts.adduser(fourthuser, 'fourthuser', 'individual', { authorization: `${accounts}@active` })
+
+  console.log('plant seeds')
+  //await contracts.token.transfer(firstuser, proposals, '50.0000 SEEDS', '', { authorization: `${firstuser}@active` })
 
   console.log('create proposal '+campaignbank)
 

--- a/test/proposals.test.js
+++ b/test/proposals.test.js
@@ -1332,7 +1332,7 @@ describe('Voice decay', async assert => {
 })
 
 
-describe.only('Build trust', async assert => {
+describe('Build trust', async assert => {
 
   if (!isLocal()) {
     console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")

--- a/test/proposals.test.js
+++ b/test/proposals.test.js
@@ -1332,7 +1332,7 @@ describe('Voice decay', async assert => {
 })
 
 
-describe('Build trust', async assert => {
+describe.only('Build trust', async assert => {
 
   if (!isLocal()) {
     console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
@@ -1408,6 +1408,9 @@ describe('Build trust', async assert => {
   })
 
   let rows = props.rows.filter(item => item.stage == "staged")
+
+  console.log('create big alliance proposal 1M')
+  await contracts.proposals.create(firstuser, firstuser, '1000000.0000 SEEDS', '1,000,0000 seeds please', 'summary', 'description', 'image', 'url', alliancesbank, { authorization: `${firstuser}@active` })
 
   assert({
     given: 'untrusted account asking for 1M Seeds',


### PR DESCRIPTION
## Spec

- The first time a user creates a proposal, they cannot ask for more than 50,000
- If their project requires more funding, we will ask them to make a second proposal after their first one has passed and is in review.

## Implementation

- keep track of people's ask and success history
- For people with non-positive track record, max is 50,000


Still missing:

- [x] Unit test
- [x] Change value to 250k? 
- [x] Implementation: A failed proposal "resets" a user's score. We add up successes and failures - maybe not needed. 
- [ ] Add ability to blacklist?
- [x] Migrate old accounts into the trust table- so all previous proposals count. 

## Deployment

- [ ] deploy proposals and settings
- [ ] call reset on settings
- [ ] call migrathistry() after deploying