### PR TITLE
Separate voice distributions for Alliance vs Campaign type proposals #137

### DIFF
--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -75,11 +75,18 @@ CONTRACT proposals : public contract {
 
       ACTION testvdecay(uint64_t timestamp);
 
+      ACTION migratevoice(uint64_t start);
+
+      ACTION testsetvoice(name user, uint64_t amount);
+
   private:
       symbol seeds_symbol = symbol("SEEDS", 4);
       name trust = "trust"_n;
       name distrust = "distrust"_n;
       name abstain = "abstain"_n;
+
+      name alliance_type = "alliance"_n;
+      name campaign_type = "campaign"_n;
 
       void update_cycle();
       void update_voicedecay();
@@ -104,6 +111,10 @@ CONTRACT proposals : public contract {
       void recover_voice(name account);
       void demote_citizen(name account);
       uint64_t calculate_decay(uint64_t voice);
+      name get_type (name fund);
+      void voice_change (name user, uint64_t amount, bool reduce, name scope);
+      void set_voice (name user, uint64_t amount, name scope);
+      void erase_voice (name user);
 
       DEFINE_CONFIG_TABLE
         
@@ -216,7 +227,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
       switch (action) {
         EOSIO_DISPATCH_HELPER(proposals, (reset)(create)(update)(addvoice)(changetrust)(favour)(against)
         (neutral)(erasepartpts)(checkstake)(onperiod)(decayvoice)(cancel)(updatevoices)(updatevoice)(decayvoices)
-        (addactive)(removeactive)(updateactivs)(updateactive)(testvdecay))
+        (addactive)(removeactive)(updateactivs)(updateactive)(testvdecay)(migratevoice)(testsetvoice))
       }
   }
 }

--- a/test/proposals.test.js
+++ b/test/proposals.test.js
@@ -676,6 +676,12 @@ describe('Change Trust', async assert => {
       table: 'voice',
       json: true,
     })
+    const voiceAlliance = await eos.getTableRows({
+      code: proposals,
+      scope: 'alliance',
+      table: 'voice',
+      json: true,
+    })
     //console.log('given ' + given + " : "  + JSON.stringify(voice))
     assert({
       given: given,
@@ -683,7 +689,12 @@ describe('Change Trust', async assert => {
       actual: voice.rows.length,
       expected: expected
     })
-
+    assert({
+      given: given,
+      should: should,
+      actual: voiceAlliance.rows.length,
+      expected: expected
+    })
   }
 
   await check("before", "empty", 0) 
@@ -699,8 +710,6 @@ describe('Change Trust', async assert => {
   //await contracts.proposals.changetrust(firstuser, 1, { authorization: `${proposals}@active` })
 
   //await check("after", "has voice", 1) 
-
-  
 
 })
 
@@ -1204,7 +1213,14 @@ describe('Demote inactive citizens', async assert => {
 
   console.log("user 3 comes back to citizen from being demoted")
   await contracts.accounts.testcitizen(thirduser, { authorization: `${accounts}@active` })
+  
   const voiceFirstUser = await eos.getTableRows({
+    code: proposals,
+    scope: proposals,
+    table: 'voice',
+    json: true,
+  })
+  const voiceAllianceFirstUser = await eos.getTableRows({
     code: proposals,
     scope: proposals,
     table: 'voice',
@@ -1219,13 +1235,23 @@ describe('Demote inactive citizens', async assert => {
   })
 
   assert({
-    given: 'voice recovered',
+    given: 'voice for campaigns recovered',
     should: 'have the correct amount of voice',
     expected: [
       { account: 'seedsuseraaa', balance: 50 },
       { account: 'seedsuserccc', balance: 57 }
     ],
     actual: voiceFirstUser.rows.filter(r => r.account == firstuser || r.account == thirduser)
+  })
+
+  assert({
+    given: 'voice for alliances recovered',
+    should: 'have the correct amount of voice',
+    expected: [
+      { account: 'seedsuseraaa', balance: 50 },
+      { account: 'seedsuserccc', balance: 57 }
+    ],
+    actual: voiceAllianceFirstUser.rows.filter(r => r.account == firstuser || r.account == thirduser)
   })
 
 })
@@ -1290,10 +1316,23 @@ describe('Voice decay', async assert => {
       json: true,
     })
 
+    const voiceAlliance = await eos.getTableRows({
+      code: proposals,
+      scope: 'alliance',
+      table: 'voice',
+      json: true,
+    })
+
     assert({
       given: 'ran voice decay for the ' + n + ' time',
       should: 'decay voices if required',
       actual: voice.rows.map(r => r.balance),
+      expected: expectedValues
+    })
+    assert({
+      given: 'ran voice decay for the ' + n + ' time',
+      should: 'decay voices for alliance if required',
+      actual: voiceAlliance.rows.map(r => r.balance),
       expected: expectedValues
     })
   }
@@ -1316,5 +1355,98 @@ describe('Voice decay', async assert => {
   await sleep(4000)
 
   await testVoiceDecay([40, 89, 0], 6)
+
+})
+
+
+describe('Voice scope', async assert => {
+
+  if (!isLocal()) {
+    console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
+    return
+  }
+
+  const contracts = await initContracts({ accounts, proposals, token, harvest, settings, escrow })
+
+  console.log('settings reset')
+  await contracts.settings.reset({ authorization: `${settings}@active` })
+
+  console.log('accounts reset')
+  await contracts.accounts.reset({ authorization: `${accounts}@active` })
+
+  console.log('proposals reset')
+  await contracts.harvest.reset({ authorization: `${harvest}@active` })
+
+  console.log('proposals reset')
+  await contracts.proposals.reset({ authorization: `${proposals}@active` })
+
+  console.log('change batch size')
+  await contracts.settings.configure('batchsize', 2, { authorization: `${settings}@active` })
+
+  console.log('join users')
+  await contracts.accounts.adduser(firstuser, 'firstuser', 'individual', { authorization: `${accounts}@active` })
+  await contracts.accounts.adduser(seconduser, 'seconduser', 'individual', { authorization: `${accounts}@active` })
+
+  console.log('force status')
+  await contracts.accounts.testcitizen(firstuser, { authorization: `${accounts}@active` })
+  await contracts.accounts.testcitizen(seconduser, { authorization: `${accounts}@active` })
+
+  console.log('create alliance proposal')
+  await contracts.proposals.create(firstuser, firstuser, '12.0000 SEEDS', 'alliance', 'test alliance', 'description', 'image', 'url', alliancesbank, { authorization: `${firstuser}@active` })
+  
+  console.log('create campaign proposal')
+  await contracts.proposals.create(firstuser, firstuser, '12.0000 SEEDS', 'campaign', 'test campaign', 'description', 'image', 'url', campaignbank, { authorization: `${firstuser}@active` })
+  await contracts.proposals.create(firstuser, firstuser, '12.0000 SEEDS', 'campaign', 'test campaign 2', 'description', 'image', 'url', campaignbank, { authorization: `${firstuser}@active` })
+
+  console.log('stake')
+  await contracts.token.transfer(firstuser, proposals, '555.0000 SEEDS', '1', { authorization: `${firstuser}@active` })
+  await contracts.token.transfer(firstuser, proposals, '555.0000 SEEDS', '2', { authorization: `${firstuser}@active` })
+  await contracts.token.transfer(firstuser, proposals, '555.0000 SEEDS', '', { authorization: `${firstuser}@active` })
+  
+  console.log('active proposals')
+  await contracts.proposals.onperiod({ authorization: `${proposals}@active` })
+
+  console.log('add voice')
+  await contracts.proposals.testsetvoice(firstuser, 40, { authorization: `${proposals}@active` })
+  await contracts.proposals.testsetvoice(seconduser, 60, { authorization: `${proposals}@active` })
+
+  console.log('spend voice')
+  await contracts.proposals.against(seconduser, 1, 8, { authorization: `${seconduser}@active` })
+  await contracts.proposals.favour(seconduser, 2, 8, { authorization: `${seconduser}@active` })
+  await contracts.proposals.favour(seconduser, 3, 8, { authorization: `${seconduser}@active` })
+
+  const voiceCampaignsAfter = await eos.getTableRows({
+    code: proposals,
+    scope: proposals,
+    table: 'voice',
+    json: true,
+  })  
+
+  const voiceAlliancesAfter = await eos.getTableRows({
+    code: proposals,
+    scope: 'alliance',
+    table: 'voice',
+    json: true,
+  })
+
+  assert({
+    given: 'voice for campaigns used',
+    should: 'spend the correct scope',
+    expected: [
+      { account: 'seedsuseraaa', balance: 40 },
+      { account: 'seedsuserbbb', balance: 44 }
+    ],
+    actual: voiceCampaignsAfter.rows
+  })
+
+  assert({
+    given: 'voice for alliances used',
+    should: 'spend the correct scope',
+    expected: [
+      { account: 'seedsuseraaa', balance: 40 },
+      { account: 'seedsuserbbb', balance: 52 }
+    ],
+    actual: voiceAlliancesAfter.rows
+  })
 
 })


### PR DESCRIPTION
- Added new scope for alliance proposals
- Added new methods to modify voices
- Added tests

The action `migratevoice` is there only to take all the existing voice entries and copy them into the new scope. But the fact that a user does not exist in the voice table scoped by `alliance` does not affect the rest of the methods. Indeed some methods can add the missing voice entry for a user that already has voice scoped by `contract's name`.