### PR TITLE
limit rank to 99

### DIFF
--- a/include/seeds.forum.hpp
+++ b/include/seeds.forum.hpp
@@ -5,6 +5,7 @@
 #include <tables/user_table.hpp>
 #include <tables/config_table.hpp>
 #include <tables/size_table.hpp>
+#include <utils.hpp>
 
 using namespace eosio;
 using std::string;

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -6,7 +6,6 @@
 using namespace eosio;
 
 namespace utils {
-
   const uint64_t seconds_per_day = 86400;
   const uint64_t seconds_per_minute = 60;
   const uint64_t seconds_per_hour = seconds_per_minute * 60;
@@ -15,21 +14,48 @@ namespace utils {
 
   symbol seeds_symbol = symbol("SEEDS", 4);
 
-  bool is_valid_majority(uint64_t favour, uint64_t against, uint64_t majority) {
+  inline uint64_t rank(uint64_t current, uint64_t total) { 
+    /**
+     * TODO - Table Locks
+     * 
+     * rank can exceed 99 when we count accounts double. This can happen when an account receives reputation while we iterate
+     * and is moved to a new bucket.
+     * We then count it again in this new bucket - this means we end up counting more users than are in the reps table
+     * which skews the count.
+     * The reason this is not atomic is that we go over the table in chunks, so inbetween chunks anything can happen.
+     * 
+     * The correct way to solve this would be to wait until the ranking is finished, and to apply changes in reputation only once that has
+     * happened. Like a manually implemented table lock. (rep or any other number we are ranking)
+     * 
+     * For now that's too complex - a lock would have to be between changing reputation and ranking. Ranking could simply wait until there's no 
+     * lock but applying reputation we would have to store changes in a secondary table rep_delta, apply all changes there while rep ranking is happening
+     * and apply the delta back to the full table once rep ranking is finished.
+     * 
+     * The count rebalances the next time we go over it, it's a dynamic system. 
+     * 
+     * The cheap way to fix it is to limit rank to 99
+    */
+
+    uint64_t r = (current * 100) / total; 
+    if (r > 99) return 99;
+    return r;
+  }
+
+  inline bool is_valid_majority(uint64_t favour, uint64_t against, uint64_t majority) {
     return favour >= (favour + against) * majority / 100;
   }
 
-  bool is_valid_quorum(uint64_t voters_number, uint64_t quorum, uint64_t total_number) {
+  inline bool is_valid_quorum(uint64_t voters_number, uint64_t quorum, uint64_t total_number) {
     uint64_t voted_percentage = voters_number * 100 / total_number;
     return voted_percentage >= quorum;
   }
 
-  void check_asset(asset quantity) {
+  inline void check_asset(asset quantity) {
     check(quantity.is_valid(), "invalid asset");
     check(quantity.symbol == seeds_symbol, "invalid asset");
   }
 
-  double rep_multiplier_for_score(uint64_t rep_score) {
+  inline double rep_multiplier_for_score(uint64_t rep_score) {
     // rep is 0 - 99
     check(rep_score < 101, "illegal rep score ");
     // return 0 - 2

--- a/src/seeds.accounts.cpp
+++ b/src/seeds.accounts.cpp
@@ -671,7 +671,7 @@ void accounts::rankrep(uint64_t start_val, uint64_t chunk, uint64_t chunksize) {
 
   while (ritr != rep_by_rep.end() && count < chunksize) {
 
-    uint64_t rank = (current * 100) / total;
+    uint64_t rank = utils::rank(current, total);
 
     rep_by_rep.modify(ritr, _self, [&](auto& item) {
       item.rank = rank;
@@ -720,7 +720,7 @@ void accounts::rankcbs(uint64_t start_val, uint64_t chunk, uint64_t chunksize) {
 
   while (citr != cbs_by_cbs.end() && count < chunksize) {
 
-    uint64_t rank = (current * 100) / total;
+    uint64_t rank = utils::rank(current, total);
 
     cbs_by_cbs.modify(citr, _self, [&](auto& item) {
       item.rank = rank;

--- a/src/seeds.forum.cpp
+++ b/src/seeds.forum.cpp
@@ -409,7 +409,7 @@ ACTION forum::rankforum(uint64_t start, uint64_t chunksize, uint64_t chunk) {
 
     while (fitr != forum_rep_by_points.end() && count < chunksize) {
 
-        uint64_t rank = (current * 100) / total;
+        uint64_t rank = utils::rank(current, total);
 
         forum_rep_by_points.modify(fitr, _self, [&](auto& item) {
             item.rank = rank;

--- a/src/seeds.harvest.cpp
+++ b/src/seeds.harvest.cpp
@@ -507,7 +507,7 @@ void harvest::ranktx(uint64_t start_val, uint64_t chunk, uint64_t chunksize, nam
 
   while (titr != txpt_by_points.end() && count < chunksize) {
 
-    uint64_t rank = (current * 100) / total;
+    uint64_t rank = utils::rank(current, total);
 
     txpt_by_points.modify(titr, _self, [&](auto& item) {
       item.rank = rank;
@@ -556,7 +556,7 @@ void harvest::rankplanted(uint128_t start_val, uint64_t chunk, uint64_t chunksiz
 
   while (pitr != planted_by_planted.end() && count < chunksize) {
 
-    uint64_t rank = (current * 100) / total;
+    uint64_t rank = utils::rank(current, total);
 
     planted_by_planted.modify(pitr, _self, [&](auto& item) {
       item.rank = rank;
@@ -684,7 +684,7 @@ void harvest::rankcs(uint64_t start_val, uint64_t chunk, uint64_t chunksize) {
 
   while (citr != cs_by_points.end() && count < chunksize) {
 
-    uint64_t rank = (current * 100) / total;
+    uint64_t rank = utils::rank(current, total);
 
     cs_by_points.modify(citr, _self, [&](auto& item) {
       item.rank = rank;

--- a/src/seeds.organization.cpp
+++ b/src/seeds.organization.cpp
@@ -458,7 +458,7 @@ ACTION organization::rankregen(uint64_t start, uint64_t chunk, uint64_t chunksiz
 
     while (rsitr != regen_score_by_avg_regen.end() && count < chunksize) {
 
-        uint64_t rank = (current * 100) / total;
+        uint64_t rank = utils::rank(current, total);
 
         regen_score_by_avg_regen.modify(rsitr, _self, [&](auto & item) {
             item.rank = rank;
@@ -535,7 +535,7 @@ ACTION organization::rankcbsorg(uint64_t start, uint64_t chunk, uint64_t chunksi
 
     while (cbsitr != cbs_by_points.end() && count < chunksize) {
 
-        uint64_t rank = (current * 100) / total;
+        uint64_t rank = utils::rank(current, total);
 
         cbs_by_points.modify(cbsitr, _self, [&](auto & item) {
             item.rank = rank;


### PR DESCRIPTION
## Problem: Rank would sometimes be 100 for the top ranked member

## Solution: Limit Rank to 99 until we can implement the good solution (see below)

## Analysis

This happens when rankings / points change while the rank is in progress. 

For example, user A has 5 points, rank runs and sets user A's rank to 0, the ranking ends at position 200

User A receives another 20 points from somewhere

Ranking continues at position 200, but now user A is located at position 450 (for example) and will eventually be ranked again - maybe at rank 15 for example. 

That rank is correct - that's fine - but we are counting up on how many users we have ranked to determine rank, and so the count is now 1 too many, and when we get to the end of the table, count == size, and rank is set to 100.

The rank will even out again on the next run of the ranking.

The same thing will happen in many other ways, but they're less visible - e.g. the rank for someone will be too high or too low, but it evens out the next run when they're once again ranked correctly.

##      The Good Solution - Table Locks
      
The reason this is not atomic is that we go over the table in chunks, so inbetween chunks the actual ranking can change.
      
The correct way to solve this would be to wait until the ranking is finished, and to apply changes in reputation only once that has happened. Like a manually implemented table lock. (rep or any other number we are ranking)
      
For now that's too complex - a lock would have to be between changing reputation and ranking. 
Ranking could simply wait until there's no lock but applying reputation we would have to store changes in a secondary table rep_delta, apply all changes there while rep ranking is happening and apply the delta back to the full table once rep ranking is finished.
 
And this has to be done for all 8 or so rankings we are doing. The rep delta table has to be cleared while iterating and could exceed 200 items, so it also has to be run in chunks. 