### PR TITLE
Harvest - Restructure Transactions Table in history #138

### DIFF
--- a/include/seeds.history.hpp
+++ b/include/seeds.history.hpp
@@ -43,6 +43,12 @@ CONTRACT history : public contract {
 
         ACTION orgtxpt(name organization, uint128_t start_val, uint64_t chunksize, uint64_t running_total);
 
+        ACTION resetmigrate(name account);
+
+        ACTION migratetrxs();
+
+        ACTION migratetrx (uint64_t start, uint64_t chunksize);
+
 
     private:
       void check_user(name account);
@@ -123,6 +129,55 @@ CONTRACT history : public contract {
         uint128_t by_other() const { return (uint128_t(other.value) << 64) + id; }
       };
 
+      // --- migration tables ---
+      TABLE transaction_table_migration {
+        uint64_t id;
+        name to;
+        asset quantity;
+        uint64_t timestamp;
+
+        uint64_t primary_key() const { return id; }
+        uint64_t by_timestamp() const { return timestamp; }
+        uint64_t by_to() const { return to.value; }
+        uint64_t by_quantity() const { return quantity.amount; }
+        uint128_t by_to_quantity() const { return (uint128_t(to.value) << 64) + quantity.amount; }
+      };
+
+      TABLE org_tx_table_migration{
+        uint64_t id;
+        name other;
+        bool in;
+        asset quantity;
+        uint64_t timestamp;
+
+        uint64_t primary_key() const { return id; }
+        uint64_t by_timestamp() const { return timestamp; }
+        uint64_t by_quantity() const { return quantity.amount; }
+        uint128_t by_other() const { return (uint128_t(other.value) << 64) + id; }
+        uint128_t by_to_quantity() const { 
+          if (!in) {
+            return (uint128_t(other.value) << 64) + quantity.amount;
+          } else {
+            return uint128_t(0);
+          }
+        }
+      };
+
+      typedef eosio::multi_index<"orgtxm"_n, org_tx_table_migration,
+        indexed_by<"bytimestamp"_n,const_mem_fun<org_tx_table_migration, uint64_t, &org_tx_table_migration::by_timestamp>>,
+        indexed_by<"byquantity"_n,const_mem_fun<org_tx_table_migration, uint64_t, &org_tx_table_migration::by_quantity>>,
+        indexed_by<"byother"_n,const_mem_fun<org_tx_table_migration, uint128_t, &org_tx_table_migration::by_other>>,
+        indexed_by<"bytoquantity"_n,const_mem_fun<org_tx_table_migration, uint128_t, &org_tx_table_migration::by_to_quantity>>
+      > org_tx_table_migrations;
+
+      typedef eosio::multi_index<"transactionm"_n, transaction_table_migration,
+        indexed_by<"bytimestamp"_n,const_mem_fun<transaction_table_migration, uint64_t, &transaction_table_migration::by_timestamp>>,
+        indexed_by<"byquantity"_n,const_mem_fun<transaction_table_migration, uint64_t, &transaction_table_migration::by_quantity>>,
+        indexed_by<"byto"_n,const_mem_fun<transaction_table_migration, uint64_t, &transaction_table_migration::by_to>>,
+        indexed_by<"bytoquantity"_n,const_mem_fun<transaction_table_migration, uint128_t, &transaction_table_migration::by_to_quantity>>
+      > transaction_table_migrations;
+      // -----------------------
+
       typedef eosio::multi_index<"orgtx"_n, org_tx_table,
         indexed_by<"bytimestamp"_n,const_mem_fun<org_tx_table, uint64_t, &org_tx_table::by_timestamp>>,
         indexed_by<"byquantity"_n,const_mem_fun<org_tx_table, uint64_t, &org_tx_table::by_quantity>>,
@@ -175,4 +230,5 @@ EOSIO_DISPATCH(history,
   (addreputable)(addregen)
   (numtrx)
   (orgtxpoints)(orgtxpt)
+  (migratetrxs)(migratetrx)(resetmigrate)
   );

--- a/src/seeds.history.cpp
+++ b/src/seeds.history.cpp
@@ -326,3 +326,102 @@ uint64_t history::config_get(name key) {
   }
   return citr->value;
 }
+
+void history::resetmigrate (name account) {
+  require_auth(get_self());
+  
+  transaction_table_migrations transactions(get_self(), account.value);
+  auto titr = transactions.begin();  
+  while (titr != transactions.end()) {
+    titr = transactions.erase(titr);
+  }
+  
+  org_tx_table_migrations orgtx(get_self(), account.value);
+  auto oitr = orgtx.begin();
+  while (oitr != orgtx.end()) {
+    oitr = orgtx.erase(oitr);
+  } 
+}
+
+void history::migratetrxs () {
+  require_auth(get_self());
+  migratetrx(0, 400);
+}
+
+void history::migratetrx (uint64_t start, uint64_t chunksize) {
+  require_auth(get_self());
+
+  auto uitr = start == 0 ? users.begin() : users.find(start);
+  uint64_t count = 0;
+
+  while (uitr != users.end() && count < chunksize) {
+    if (uitr -> type != name("organisation")) {
+      transaction_tables transactions(get_self(), uitr -> account.value);
+      transaction_table_migrations transactions_migration(get_self(), uitr -> account.value);
+
+      auto titr = transactions.begin();
+      while (titr != transactions.end()) {
+        auto tmigration = transactions_migration.find(titr -> id);
+        if (tmigration != transactions_migration.end()) {
+          transactions_migration.modify(tmigration, _self, [&](auto & item){
+            item.to = titr -> to;
+            item.quantity = titr -> quantity;
+            item.timestamp = titr -> timestamp;            
+          });
+        } else {
+          transactions_migration.emplace(_self, [&](auto & item){
+            item.id = titr -> id;
+            item.to = titr -> to;
+            item.quantity = titr -> quantity;
+            item.timestamp = titr -> timestamp;
+          });
+        }
+        titr = transactions.erase(titr);
+        count++;
+      }
+      count++;
+    } else {
+      org_tx_tables transactions(get_self(), uitr -> account.value);
+      org_tx_table_migrations transactions_migration(get_self(), uitr -> account.value);
+
+      auto titr = transactions.begin();
+      while (titr != transactions.end()) {
+        auto tmigration = transactions_migration.find(titr -> id);
+        if (tmigration != transactions_migration.end()) {
+          transactions_migration.modify(tmigration, _self, [&](auto & item){
+            item.other = titr -> other;
+            item.in = titr -> in;
+            item.quantity = titr -> quantity;
+            item.timestamp = titr -> timestamp;            
+          });
+        } else {
+          transactions_migration.emplace(_self, [&](auto & item){
+            item.id = titr -> id;
+            item.other = titr -> other;
+            item.in = titr -> in;
+            item.quantity = titr -> quantity;
+            item.timestamp = titr -> timestamp;
+          });
+        }
+        titr = transactions.erase(titr);
+        count++;
+      }
+      count++;
+    }
+    uitr++;
+  }
+
+  if (uitr != users.end()) {
+    action next_execution(
+        permission_level{get_self(), "active"_n},
+        get_self(),
+        "migratetrx"_n,
+        std::make_tuple(uitr -> account, chunksize)
+    );
+    transaction tx;
+    tx.actions.emplace_back(next_execution);
+    tx.delay_sec = 1;
+    tx.send(uitr -> account.value + 1, _self);
+  }
+}
+


### PR DESCRIPTION
- Added migration tables `transaction_table_migration` and `org_tx_table_migration`
- Added migration functions to transfer the information from the original tables to the migration tables

The original tables with the new index and the function to transfer back the information are in the branch feature/harvest-resctructure-transactions-table