### PR TITLE
Feature/export abi docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,25 @@ command = compile | deploy | test | run
 example: 
 ./scripts/seeds.js run harvest => compiles seeds.harvest.cpp, deploys it, runs unit tests
 ```
+
+### generate contract documentation
+
+This command will generate html automatically based on the contract ABI files.
+
+The <comment> tags inside the documents will be left untouched, even when they are regenerated.
+
+
+This will generate docs only for the `accounts` contract.
+```
+./scripts/seeds.js docsgen accounts:
+```
+
+This will generate all contracts:
+```
+./scripts/seeds.js docsgen all
+```
+
+This will regenerate the index.html file:
+```
+./scripts/seeds.js docsgen index
+```

--- a/docs/accounts.html
+++ b/docs/accounts.html
@@ -1,6 +1,14 @@
 <html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+<!-- Latest compiled and minified CSS -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
+
+<!-- Optional theme -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap-theme.min.css" integrity="sha384-6pzBo3FDv/PJ8r2KRkGHifhEocL+1X2rVCTTkUfGk7/0pbek5mMa1upzvWbrUbOZ" crossorigin="anonymous">
+
+<!-- Latest compiled and minified JavaScript -->
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
 </head><body onload="loadUser()">
   <div id="target"><h1>Smartcontract documentation for accounts</h1>

--- a/docs/accounts.html
+++ b/docs/accounts.html
@@ -10,39 +10,56 @@
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
-</head><body onload="loadUser()">
+<script>
+$(function() {
+  var reader = new commonmark.Parser();
+  var writer = new commonmark.HtmlRenderer();
+
+  $('#target comment').each(function(i, elem) {
+    var parsed = reader.parse($(this).text()); 
+    var result = writer.render(parsed);
+    $(this).html(result);
+  });
+ });
+</script>
+
+</head><body>
   <div id="target"><h1>Smartcontract documentation for accounts</h1>
-<p><comment type="main">Welcome!</comment></p>
+<p><comment type="main">
+  ### Welcome!
+
+  This is **markdown**! 
+</comment></p>
 <h2>Actions</h2>
 <ul>
-<li>addref / <a href="#addref">addref</a> - <comment type="action" name="addref">The addref action.</comment></li>
-<li>addrep / <a href="#addrep">addrep</a> - <comment type="action" name="addrep"></comment></li>
-<li>adduser / <a href="#adduser">adduser</a> - <comment type="action" name="adduser"></comment></li>
-<li>cancitizen / <a href="#cancitizen">cancitizen</a> - <comment type="action" name="cancitizen"></comment></li>
-<li>canresident / <a href="#canresident">canresident</a> - <comment type="action" name="canresident"></comment></li>
-<li>changesize / <a href="#changesize">changesize</a> - <comment type="action" name="changesize"></comment></li>
-<li>demotecitizn / <a href="#demotecitizn">demotecitizn</a> - <comment type="action" name="demotecitizn"></comment></li>
-<li>invitevouch / <a href="#invitevouch">invitevouch</a> - <comment type="action" name="invitevouch"></comment></li>
-<li>makecitizen / <a href="#makecitizen">makecitizen</a> - <comment type="action" name="makecitizen"></comment></li>
-<li>makeresident / <a href="#makeresident">makeresident</a> - <comment type="action" name="makeresident"></comment></li>
-<li>punish / <a href="#punish">punish</a> - <comment type="action" name="punish"></comment></li>
-<li>rankcbs / <a href="#rankcbs">rankcbs</a> - <comment type="action" name="rankcbs"></comment></li>
-<li>rankcbss / <a href="#rankcbss">rankcbss</a> - <comment type="action" name="rankcbss"></comment></li>
-<li>rankrep / <a href="#rankrep">rankrep</a> - <comment type="action" name="rankrep"></comment></li>
-<li>rankreps / <a href="#rankreps">rankreps</a> - <comment type="action" name="rankreps"></comment></li>
-<li>requestvouch / <a href="#requestvouch">requestvouch</a> - <comment type="action" name="requestvouch"></comment></li>
-<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
-<li>subrep / <a href="#subrep">subrep</a> - <comment type="action" name="subrep"></comment></li>
-<li>testcitizen / <a href="#testcitizen">testcitizen</a> - <comment type="action" name="testcitizen"></comment></li>
-<li>testremove / <a href="#testremove">testremove</a> - <comment type="action" name="testremove"></comment></li>
-<li>testresident / <a href="#testresident">testresident</a> - <comment type="action" name="testresident"></comment></li>
-<li>testreward / <a href="#testreward">testreward</a> - <comment type="action" name="testreward"></comment></li>
-<li>testsetcbs / <a href="#testsetcbs">testsetcbs</a> - <comment type="action" name="testsetcbs"></comment></li>
-<li>testsetrep / <a href="#testsetrep">testsetrep</a> - <comment type="action" name="testsetrep"></comment></li>
-<li>testsetrs / <a href="#testsetrs">testsetrs</a> - <comment type="action" name="testsetrs"></comment></li>
-<li>testvisitor / <a href="#testvisitor">testvisitor</a> - <comment type="action" name="testvisitor"></comment></li>
-<li>update / <a href="#update">update</a> - <comment type="action" name="update"></comment></li>
-<li>vouch / <a href="#vouch">vouch</a> - <comment type="action" name="vouch"></comment></li>
+<li><strong>addref</strong> / <a href="#addref">addref</a> - <comment type="action" name="addref">Testing `markup`</comment></li>
+<li><strong>addrep</strong> / <a href="#addrep">addrep</a> - <comment type="action" name="addrep"></comment></li>
+<li><strong>adduser</strong> / <a href="#adduser">adduser</a> - <comment type="action" name="adduser"></comment></li>
+<li><strong>cancitizen</strong> / <a href="#cancitizen">cancitizen</a> - <comment type="action" name="cancitizen"></comment></li>
+<li><strong>canresident</strong> / <a href="#canresident">canresident</a> - <comment type="action" name="canresident"></comment></li>
+<li><strong>changesize</strong> / <a href="#changesize">changesize</a> - <comment type="action" name="changesize"></comment></li>
+<li><strong>demotecitizn</strong> / <a href="#demotecitizn">demotecitizn</a> - <comment type="action" name="demotecitizn"></comment></li>
+<li><strong>invitevouch</strong> / <a href="#invitevouch">invitevouch</a> - <comment type="action" name="invitevouch"></comment></li>
+<li><strong>makecitizen</strong> / <a href="#makecitizen">makecitizen</a> - <comment type="action" name="makecitizen"></comment></li>
+<li><strong>makeresident</strong> / <a href="#makeresident">makeresident</a> - <comment type="action" name="makeresident"></comment></li>
+<li><strong>punish</strong> / <a href="#punish">punish</a> - <comment type="action" name="punish"></comment></li>
+<li><strong>rankcbs</strong> / <a href="#rankcbs">rankcbs</a> - <comment type="action" name="rankcbs"></comment></li>
+<li><strong>rankcbss</strong> / <a href="#rankcbss">rankcbss</a> - <comment type="action" name="rankcbss"></comment></li>
+<li><strong>rankrep</strong> / <a href="#rankrep">rankrep</a> - <comment type="action" name="rankrep"></comment></li>
+<li><strong>rankreps</strong> / <a href="#rankreps">rankreps</a> - <comment type="action" name="rankreps"></comment></li>
+<li><strong>requestvouch</strong> / <a href="#requestvouch">requestvouch</a> - <comment type="action" name="requestvouch"></comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li><strong>subrep</strong> / <a href="#subrep">subrep</a> - <comment type="action" name="subrep"></comment></li>
+<li><strong>testcitizen</strong> / <a href="#testcitizen">testcitizen</a> - <comment type="action" name="testcitizen"></comment></li>
+<li><strong>testremove</strong> / <a href="#testremove">testremove</a> - <comment type="action" name="testremove"></comment></li>
+<li><strong>testresident</strong> / <a href="#testresident">testresident</a> - <comment type="action" name="testresident"></comment></li>
+<li><strong>testreward</strong> / <a href="#testreward">testreward</a> - <comment type="action" name="testreward"></comment></li>
+<li><strong>testsetcbs</strong> / <a href="#testsetcbs">testsetcbs</a> - <comment type="action" name="testsetcbs"></comment></li>
+<li><strong>testsetrep</strong> / <a href="#testsetrep">testsetrep</a> - <comment type="action" name="testsetrep"></comment></li>
+<li><strong>testsetrs</strong> / <a href="#testsetrs">testsetrs</a> - <comment type="action" name="testsetrs"></comment></li>
+<li><strong>testvisitor</strong> / <a href="#testvisitor">testvisitor</a> - <comment type="action" name="testvisitor"></comment></li>
+<li><strong>update</strong> / <a href="#update">update</a> - <comment type="action" name="update"></comment></li>
+<li><strong>vouch</strong> / <a href="#vouch">vouch</a> - <comment type="action" name="vouch"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
@@ -267,7 +284,7 @@
   <script id="template" type="x-tmpl-handlebars">
 # Smartcontract documentation for {{ file }}
 
-<comment type="main">{{comment}}</comment>
+<comment type="main"></comment>
 
 {{#if types}}
 ## Types
@@ -279,19 +296,19 @@
 ## Actions
 
 {{#each actions}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/accounts.html
+++ b/docs/accounts.html
@@ -1,0 +1,307 @@
+<html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+
+</head><body onload="loadUser()">
+  <div id="target"><h1>Smartcontract documentation for accounts</h1>
+<p><comment type="main">Welcome!</comment></p>
+<h2>Actions</h2>
+<ul>
+<li>addref / <a href="#addref">addref</a> - <comment type="action" name="addref">The addref action.</comment></li>
+<li>addrep / <a href="#addrep">addrep</a> - <comment type="action" name="addrep"></comment></li>
+<li>adduser / <a href="#adduser">adduser</a> - <comment type="action" name="adduser"></comment></li>
+<li>cancitizen / <a href="#cancitizen">cancitizen</a> - <comment type="action" name="cancitizen"></comment></li>
+<li>canresident / <a href="#canresident">canresident</a> - <comment type="action" name="canresident"></comment></li>
+<li>changesize / <a href="#changesize">changesize</a> - <comment type="action" name="changesize"></comment></li>
+<li>demotecitizn / <a href="#demotecitizn">demotecitizn</a> - <comment type="action" name="demotecitizn"></comment></li>
+<li>invitevouch / <a href="#invitevouch">invitevouch</a> - <comment type="action" name="invitevouch"></comment></li>
+<li>makecitizen / <a href="#makecitizen">makecitizen</a> - <comment type="action" name="makecitizen"></comment></li>
+<li>makeresident / <a href="#makeresident">makeresident</a> - <comment type="action" name="makeresident"></comment></li>
+<li>punish / <a href="#punish">punish</a> - <comment type="action" name="punish"></comment></li>
+<li>rankcbs / <a href="#rankcbs">rankcbs</a> - <comment type="action" name="rankcbs"></comment></li>
+<li>rankcbss / <a href="#rankcbss">rankcbss</a> - <comment type="action" name="rankcbss"></comment></li>
+<li>rankrep / <a href="#rankrep">rankrep</a> - <comment type="action" name="rankrep"></comment></li>
+<li>rankreps / <a href="#rankreps">rankreps</a> - <comment type="action" name="rankreps"></comment></li>
+<li>requestvouch / <a href="#requestvouch">requestvouch</a> - <comment type="action" name="requestvouch"></comment></li>
+<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li>subrep / <a href="#subrep">subrep</a> - <comment type="action" name="subrep"></comment></li>
+<li>testcitizen / <a href="#testcitizen">testcitizen</a> - <comment type="action" name="testcitizen"></comment></li>
+<li>testremove / <a href="#testremove">testremove</a> - <comment type="action" name="testremove"></comment></li>
+<li>testresident / <a href="#testresident">testresident</a> - <comment type="action" name="testresident"></comment></li>
+<li>testreward / <a href="#testreward">testreward</a> - <comment type="action" name="testreward"></comment></li>
+<li>testsetcbs / <a href="#testsetcbs">testsetcbs</a> - <comment type="action" name="testsetcbs"></comment></li>
+<li>testsetrep / <a href="#testsetrep">testsetrep</a> - <comment type="action" name="testsetrep"></comment></li>
+<li>testsetrs / <a href="#testsetrs">testsetrs</a> - <comment type="action" name="testsetrs"></comment></li>
+<li>testvisitor / <a href="#testvisitor">testvisitor</a> - <comment type="action" name="testvisitor"></comment></li>
+<li>update / <a href="#update">update</a> - <comment type="action" name="update"></comment></li>
+<li>vouch / <a href="#vouch">vouch</a> - <comment type="action" name="vouch"></comment></li>
+</ul>
+<h2>Events</h2>
+<h2>Tables</h2>
+<ul>
+<li><strong>accounts</strong> / <a href="#account">account</a> (i64) - <comment type="table" name="accounts"></comment></li>
+<li><strong>actives</strong> / <a href="#active_table">active_table</a> (i64) - <comment type="table" name="actives"></comment></li>
+<li><strong>cbs</strong> / <a href="#cbs_table">cbs_table</a> (i64) - <comment type="table" name="cbs"></comment></li>
+<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) - <comment type="table" name="config"></comment></li>
+<li><strong>pricehistory</strong> / <a href="#price_history_table">price_history_table</a> (i64) - <comment type="table" name="pricehistory"></comment></li>
+<li><strong>refs</strong> / <a href="#ref_table">ref_table</a> (i64) - <comment type="table" name="refs"></comment></li>
+<li><strong>rep</strong> / <a href="#rep_table">rep_table</a> (i64) - <comment type="table" name="rep"></comment></li>
+<li><strong>reqvouch</strong> / <a href="#req_vouch_table">req_vouch_table</a> (i64) - <comment type="table" name="reqvouch"></comment></li>
+<li><strong>sizes</strong> / <a href="#size_table">size_table</a> (i64) - <comment type="table" name="sizes"></comment></li>
+<li><strong>transactions</strong> / <a href="#transaction_table">transaction_table</a> (i64) - <comment type="table" name="transactions"></comment></li>
+<li><strong>users</strong> / <a href="#user_table">user_table</a> (i64) - <comment type="table" name="users"></comment></li>
+<li><strong>vouch</strong> / <a href="#vouch_table">vouch_table</a> (i64) - <comment type="table" name="vouch"></comment></li>
+</ul>
+<h2>ABI Extensions</h2>
+<h2>Structs</h2>
+<h3 id="account"> account </h3>
+<ul>
+<li>balance / asset</li>
+</ul>
+<h3 id="active_table"> active_table </h3>
+<ul>
+<li>account / name</li>
+<li>timestamp / uint64</li>
+<li>active / bool</li>
+</ul>
+<h3 id="addref"> addref </h3>
+<ul>
+<li>referrer / name</li>
+<li>invited / name</li>
+</ul>
+<h3 id="addrep"> addrep </h3>
+<ul>
+<li>user / name</li>
+<li>amount / uint64</li>
+</ul>
+<h3 id="adduser"> adduser </h3>
+<ul>
+<li>account / name</li>
+<li>nickname / string</li>
+<li>type / name</li>
+</ul>
+<h3 id="cancitizen"> cancitizen </h3>
+<ul>
+<li>user / name</li>
+</ul>
+<h3 id="canresident"> canresident </h3>
+<ul>
+<li>user / name</li>
+</ul>
+<h3 id="cbs_table"> cbs_table </h3>
+<ul>
+<li>account / name</li>
+<li>community_building_score / uint32</li>
+<li>rank / uint64</li>
+</ul>
+<h3 id="changesize"> changesize </h3>
+<ul>
+<li>id / name</li>
+<li>delta / int64</li>
+</ul>
+<h3 id="config_table"> config_table </h3>
+<ul>
+<li>param / name</li>
+<li>value / uint64</li>
+<li>description / string</li>
+<li>impact / name</li>
+</ul>
+<h3 id="demotecitizn"> demotecitizn </h3>
+<ul>
+<li>user / name</li>
+</ul>
+<h3 id="invitevouch"> invitevouch </h3>
+<ul>
+<li>referrer / name</li>
+<li>invited / name</li>
+</ul>
+<h3 id="makecitizen"> makecitizen </h3>
+<ul>
+<li>user / name</li>
+</ul>
+<h3 id="makeresident"> makeresident </h3>
+<ul>
+<li>user / name</li>
+</ul>
+<h3 id="price_history_table"> price_history_table </h3>
+<ul>
+<li>id / uint64</li>
+<li>seeds_usd / asset</li>
+<li>date / time_point</li>
+</ul>
+<h3 id="punish"> punish </h3>
+<ul>
+<li>account / name</li>
+</ul>
+<h3 id="rankcbs"> rankcbs </h3>
+<ul>
+<li>start_val / uint64</li>
+<li>chunk / uint64</li>
+<li>chunksize / uint64</li>
+</ul>
+<h3 id="rankcbss"> rankcbss </h3>
+<h3 id="rankrep"> rankrep </h3>
+<ul>
+<li>start_val / uint64</li>
+<li>chunk / uint64</li>
+<li>chunksize / uint64</li>
+</ul>
+<h3 id="rankreps"> rankreps </h3>
+<h3 id="ref_table"> ref_table </h3>
+<ul>
+<li>referrer / name</li>
+<li>invited / name</li>
+</ul>
+<h3 id="rep_table"> rep_table </h3>
+<ul>
+<li>account / name</li>
+<li>rep / uint32</li>
+<li>rank / uint64</li>
+</ul>
+<h3 id="req_vouch_table"> req_vouch_table </h3>
+<ul>
+<li>id / uint64</li>
+<li>account / name</li>
+<li>sponsor / name</li>
+</ul>
+<h3 id="requestvouch"> requestvouch </h3>
+<ul>
+<li>account / name</li>
+<li>sponsor / name</li>
+</ul>
+<h3 id="reset"> reset </h3>
+<h3 id="size_table"> size_table </h3>
+<ul>
+<li>id / name</li>
+<li>size / uint64</li>
+</ul>
+<h3 id="subrep"> subrep </h3>
+<ul>
+<li>user / name</li>
+<li>amount / uint64</li>
+</ul>
+<h3 id="testcitizen"> testcitizen </h3>
+<ul>
+<li>user / name</li>
+</ul>
+<h3 id="testremove"> testremove </h3>
+<ul>
+<li>user / name</li>
+</ul>
+<h3 id="testresident"> testresident </h3>
+<ul>
+<li>user / name</li>
+</ul>
+<h3 id="testreward"> testreward </h3>
+<h3 id="testsetcbs"> testsetcbs </h3>
+<ul>
+<li>user / name</li>
+<li>amount / uint64</li>
+</ul>
+<h3 id="testsetrep"> testsetrep </h3>
+<ul>
+<li>user / name</li>
+<li>amount / uint64</li>
+</ul>
+<h3 id="testsetrs"> testsetrs </h3>
+<ul>
+<li>user / name</li>
+<li>amount / uint64</li>
+</ul>
+<h3 id="testvisitor"> testvisitor </h3>
+<ul>
+<li>user / name</li>
+</ul>
+<h3 id="transaction_table"> transaction_table </h3>
+<ul>
+<li>id / uint64</li>
+<li>to / name</li>
+<li>quantity / asset</li>
+<li>timestamp / uint64</li>
+</ul>
+<h3 id="update"> update </h3>
+<ul>
+<li>user / name</li>
+<li>type / name</li>
+<li>nickname / string</li>
+<li>image / string</li>
+<li>story / string</li>
+<li>roles / string</li>
+<li>skills / string</li>
+<li>interests / string</li>
+</ul>
+<h3 id="user_table"> user_table </h3>
+<ul>
+<li>account / name</li>
+<li>status / name</li>
+<li>type / name</li>
+<li>nickname / string</li>
+<li>image / string</li>
+<li>story / string</li>
+<li>roles / string</li>
+<li>skills / string</li>
+<li>interests / string</li>
+<li>reputation / uint64</li>
+<li>timestamp / uint64</li>
+</ul>
+<h3 id="vouch"> vouch </h3>
+<ul>
+<li>sponsor / name</li>
+<li>account / name</li>
+</ul>
+<h3 id="vouch_table"> vouch_table </h3>
+<ul>
+<li>account / name</li>
+<li>sponsor / name</li>
+<li>reps / uint64</li>
+</ul>
+</div>
+  <script id="template" type="x-tmpl-handlebars">
+# Smartcontract documentation for {{ file }}
+
+<comment type="main">{{comment}}</comment>
+
+{{#if types}}
+## Types
+{{/if}}
+{{#each types}}
+  {{ name }}
+{{/each}}
+
+## Actions
+
+{{#each actions}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Events
+
+{{#each events}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Tables
+
+{{#each tables}}
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## ABI Extensions
+
+{{#each abi_extensions}}
+  - {{ name }}
+{{/each}}
+
+## Structs
+
+{{#each structs}}
+<h3 id={{ name }}> {{ name }} {{#if base}}( {{base}} ){{/if}}</h3>
+  
+  {{#each fields}}
+  - {{ name }} / {{ type }}
+  {{/each}}
+{{/each}}
+
+  </script>
+
+</body></html>

--- a/docs/accounts.html
+++ b/docs/accounts.html
@@ -26,56 +26,54 @@ $(function() {
 </head><body>
   <div id="target"><h1>Smartcontract documentation for accounts</h1>
 <p><comment type="main">
-  ### Welcome!
-
-  This is **markdown**! 
+For most account interactions, including moving from visitor to citizen, vouching, rewards and user ranking.
 </comment></p>
 <h2>Actions</h2>
 <ul>
-<li><strong>addref</strong> / <a href="#addref">addref</a> - <comment type="action" name="addref">Testing `markup`</comment></li>
-<li><strong>addrep</strong> / <a href="#addrep">addrep</a> - <comment type="action" name="addrep"></comment></li>
-<li><strong>adduser</strong> / <a href="#adduser">adduser</a> - <comment type="action" name="adduser"></comment></li>
-<li><strong>cancitizen</strong> / <a href="#cancitizen">cancitizen</a> - <comment type="action" name="cancitizen"></comment></li>
-<li><strong>canresident</strong> / <a href="#canresident">canresident</a> - <comment type="action" name="canresident"></comment></li>
-<li><strong>changesize</strong> / <a href="#changesize">changesize</a> - <comment type="action" name="changesize"></comment></li>
-<li><strong>demotecitizn</strong> / <a href="#demotecitizn">demotecitizn</a> - <comment type="action" name="demotecitizn"></comment></li>
-<li><strong>invitevouch</strong> / <a href="#invitevouch">invitevouch</a> - <comment type="action" name="invitevouch"></comment></li>
-<li><strong>makecitizen</strong> / <a href="#makecitizen">makecitizen</a> - <comment type="action" name="makecitizen"></comment></li>
-<li><strong>makeresident</strong> / <a href="#makeresident">makeresident</a> - <comment type="action" name="makeresident"></comment></li>
-<li><strong>punish</strong> / <a href="#punish">punish</a> - <comment type="action" name="punish"></comment></li>
-<li><strong>rankcbs</strong> / <a href="#rankcbs">rankcbs</a> - <comment type="action" name="rankcbs"></comment></li>
-<li><strong>rankcbss</strong> / <a href="#rankcbss">rankcbss</a> - <comment type="action" name="rankcbss"></comment></li>
-<li><strong>rankrep</strong> / <a href="#rankrep">rankrep</a> - <comment type="action" name="rankrep"></comment></li>
-<li><strong>rankreps</strong> / <a href="#rankreps">rankreps</a> - <comment type="action" name="rankreps"></comment></li>
-<li><strong>requestvouch</strong> / <a href="#requestvouch">requestvouch</a> - <comment type="action" name="requestvouch"></comment></li>
-<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
-<li><strong>subrep</strong> / <a href="#subrep">subrep</a> - <comment type="action" name="subrep"></comment></li>
-<li><strong>testcitizen</strong> / <a href="#testcitizen">testcitizen</a> - <comment type="action" name="testcitizen"></comment></li>
-<li><strong>testremove</strong> / <a href="#testremove">testremove</a> - <comment type="action" name="testremove"></comment></li>
-<li><strong>testresident</strong> / <a href="#testresident">testresident</a> - <comment type="action" name="testresident"></comment></li>
-<li><strong>testreward</strong> / <a href="#testreward">testreward</a> - <comment type="action" name="testreward"></comment></li>
-<li><strong>testsetcbs</strong> / <a href="#testsetcbs">testsetcbs</a> - <comment type="action" name="testsetcbs"></comment></li>
-<li><strong>testsetrep</strong> / <a href="#testsetrep">testsetrep</a> - <comment type="action" name="testsetrep"></comment></li>
-<li><strong>testsetrs</strong> / <a href="#testsetrs">testsetrs</a> - <comment type="action" name="testsetrs"></comment></li>
-<li><strong>testvisitor</strong> / <a href="#testvisitor">testvisitor</a> - <comment type="action" name="testvisitor"></comment></li>
-<li><strong>update</strong> / <a href="#update">update</a> - <comment type="action" name="update"></comment></li>
-<li><strong>vouch</strong> / <a href="#vouch">vouch</a> - <comment type="action" name="vouch"></comment></li>
+<li><strong>addref</strong> / <a href="#addref">addref</a> <comment type="action" name="addref"></comment></li>
+<li><strong>addrep</strong> / <a href="#addrep">addrep</a> <comment type="action" name="addrep"></comment></li>
+<li><strong>adduser</strong> / <a href="#adduser">adduser</a> <comment type="action" name="adduser"></comment></li>
+<li><strong>cancitizen</strong> / <a href="#cancitizen">cancitizen</a> <comment type="action" name="cancitizen"></comment></li>
+<li><strong>canresident</strong> / <a href="#canresident">canresident</a> <comment type="action" name="canresident"></comment></li>
+<li><strong>changesize</strong> / <a href="#changesize">changesize</a> <comment type="action" name="changesize"></comment></li>
+<li><strong>demotecitizn</strong> / <a href="#demotecitizn">demotecitizn</a> <comment type="action" name="demotecitizn"></comment></li>
+<li><strong>invitevouch</strong> / <a href="#invitevouch">invitevouch</a> <comment type="action" name="invitevouch"></comment></li>
+<li><strong>makecitizen</strong> / <a href="#makecitizen">makecitizen</a> <comment type="action" name="makecitizen"></comment></li>
+<li><strong>makeresident</strong> / <a href="#makeresident">makeresident</a> <comment type="action" name="makeresident"></comment></li>
+<li><strong>punish</strong> / <a href="#punish">punish</a> <comment type="action" name="punish"></comment></li>
+<li><strong>rankcbs</strong> / <a href="#rankcbs">rankcbs</a> <comment type="action" name="rankcbs"></comment></li>
+<li><strong>rankcbss</strong> / <a href="#rankcbss">rankcbss</a> <comment type="action" name="rankcbss"></comment></li>
+<li><strong>rankrep</strong> / <a href="#rankrep">rankrep</a> <comment type="action" name="rankrep"></comment></li>
+<li><strong>rankreps</strong> / <a href="#rankreps">rankreps</a> <comment type="action" name="rankreps"></comment></li>
+<li><strong>requestvouch</strong> / <a href="#requestvouch">requestvouch</a> <comment type="action" name="requestvouch"></comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> <comment type="action" name="reset"></comment></li>
+<li><strong>subrep</strong> / <a href="#subrep">subrep</a> <comment type="action" name="subrep"></comment></li>
+<li><strong>testcitizen</strong> / <a href="#testcitizen">testcitizen</a> <comment type="action" name="testcitizen"></comment></li>
+<li><strong>testremove</strong> / <a href="#testremove">testremove</a> <comment type="action" name="testremove"></comment></li>
+<li><strong>testresident</strong> / <a href="#testresident">testresident</a> <comment type="action" name="testresident"></comment></li>
+<li><strong>testreward</strong> / <a href="#testreward">testreward</a> <comment type="action" name="testreward"></comment></li>
+<li><strong>testsetcbs</strong> / <a href="#testsetcbs">testsetcbs</a> <comment type="action" name="testsetcbs"></comment></li>
+<li><strong>testsetrep</strong> / <a href="#testsetrep">testsetrep</a> <comment type="action" name="testsetrep"></comment></li>
+<li><strong>testsetrs</strong> / <a href="#testsetrs">testsetrs</a> <comment type="action" name="testsetrs"></comment></li>
+<li><strong>testvisitor</strong> / <a href="#testvisitor">testvisitor</a> <comment type="action" name="testvisitor"></comment></li>
+<li><strong>update</strong> / <a href="#update">update</a> <comment type="action" name="update"></comment></li>
+<li><strong>vouch</strong> / <a href="#vouch">vouch</a> <comment type="action" name="vouch"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
 <ul>
-<li><strong>accounts</strong> / <a href="#account">account</a> (i64) - <comment type="table" name="accounts"></comment></li>
-<li><strong>actives</strong> / <a href="#active_table">active_table</a> (i64) - <comment type="table" name="actives"></comment></li>
-<li><strong>cbs</strong> / <a href="#cbs_table">cbs_table</a> (i64) - <comment type="table" name="cbs"></comment></li>
-<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) - <comment type="table" name="config"></comment></li>
-<li><strong>pricehistory</strong> / <a href="#price_history_table">price_history_table</a> (i64) - <comment type="table" name="pricehistory"></comment></li>
-<li><strong>refs</strong> / <a href="#ref_table">ref_table</a> (i64) - <comment type="table" name="refs"></comment></li>
-<li><strong>rep</strong> / <a href="#rep_table">rep_table</a> (i64) - <comment type="table" name="rep"></comment></li>
-<li><strong>reqvouch</strong> / <a href="#req_vouch_table">req_vouch_table</a> (i64) - <comment type="table" name="reqvouch"></comment></li>
-<li><strong>sizes</strong> / <a href="#size_table">size_table</a> (i64) - <comment type="table" name="sizes"></comment></li>
-<li><strong>transactions</strong> / <a href="#transaction_table">transaction_table</a> (i64) - <comment type="table" name="transactions"></comment></li>
-<li><strong>users</strong> / <a href="#user_table">user_table</a> (i64) - <comment type="table" name="users"></comment></li>
-<li><strong>vouch</strong> / <a href="#vouch_table">vouch_table</a> (i64) - <comment type="table" name="vouch"></comment></li>
+<li><strong>accounts</strong> / <a href="#account">account</a> (i64) <comment type="table" name="accounts">The main accounts table.</comment></li>
+<li><strong>actives</strong> / <a href="#active_table">active_table</a> (i64) <comment type="table" name="actives"></comment></li>
+<li><strong>cbs</strong> / <a href="#cbs_table">cbs_table</a> (i64) <comment type="table" name="cbs"></comment></li>
+<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) <comment type="table" name="config"></comment></li>
+<li><strong>pricehistory</strong> / <a href="#price_history_table">price_history_table</a> (i64) <comment type="table" name="pricehistory"></comment></li>
+<li><strong>refs</strong> / <a href="#ref_table">ref_table</a> (i64) <comment type="table" name="refs"></comment></li>
+<li><strong>rep</strong> / <a href="#rep_table">rep_table</a> (i64) <comment type="table" name="rep"></comment></li>
+<li><strong>reqvouch</strong> / <a href="#req_vouch_table">req_vouch_table</a> (i64) <comment type="table" name="reqvouch"></comment></li>
+<li><strong>sizes</strong> / <a href="#size_table">size_table</a> (i64) <comment type="table" name="sizes"></comment></li>
+<li><strong>transactions</strong> / <a href="#transaction_table">transaction_table</a> (i64) <comment type="table" name="transactions"></comment></li>
+<li><strong>users</strong> / <a href="#user_table">user_table</a> (i64) <comment type="table" name="users"></comment></li>
+<li><strong>vouch</strong> / <a href="#vouch_table">vouch_table</a> (i64) <comment type="table" name="vouch"></comment></li>
 </ul>
 <h2>ABI Extensions</h2>
 <h2>Structs</h2>
@@ -296,19 +294,19 @@ $(function() {
 ## Actions
 
 {{#each actions}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/acctcreator.html
+++ b/docs/acctcreator.html
@@ -28,16 +28,16 @@ $(function() {
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li><strong>activate</strong> / <a href="#activate">activate</a> - <comment type="action" name="activate"></comment></li>
-<li><strong>create</strong> / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
-<li><strong>pause</strong> / <a href="#pause">pause</a> - <comment type="action" name="pause"></comment></li>
-<li><strong>setconfig</strong> / <a href="#setconfig">setconfig</a> - <comment type="action" name="setconfig"></comment></li>
-<li><strong>setsetting</strong> / <a href="#setsetting">setsetting</a> - <comment type="action" name="setsetting"></comment></li>
+<li><strong>activate</strong> / <a href="#activate">activate</a> <comment type="action" name="activate"></comment></li>
+<li><strong>create</strong> / <a href="#create">create</a> <comment type="action" name="create"></comment></li>
+<li><strong>pause</strong> / <a href="#pause">pause</a> <comment type="action" name="pause"></comment></li>
+<li><strong>setconfig</strong> / <a href="#setconfig">setconfig</a> <comment type="action" name="setconfig"></comment></li>
+<li><strong>setsetting</strong> / <a href="#setsetting">setsetting</a> <comment type="action" name="setsetting"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
 <ul>
-<li><strong>config</strong> / <a href="#config">config</a> (i64) - <comment type="table" name="config"></comment></li>
+<li><strong>config</strong> / <a href="#config">config</a> (i64) <comment type="table" name="config"></comment></li>
 </ul>
 <h2>ABI Extensions</h2>
 <h2>Structs</h2>
@@ -86,19 +86,19 @@ $(function() {
 ## Actions
 
 {{#each actions}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/acctcreator.html
+++ b/docs/acctcreator.html
@@ -1,0 +1,101 @@
+<html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+
+</head><body onload="loadUser()">
+  <div id="target"><h1>Smartcontract documentation for acctcreator</h1>
+<p><comment type="main"></comment></p>
+<h2>Actions</h2>
+<ul>
+<li>activate / <a href="#activate">activate</a> - <comment type="action" name="activate"></comment></li>
+<li>create / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
+<li>pause / <a href="#pause">pause</a> - <comment type="action" name="pause"></comment></li>
+<li>setconfig / <a href="#setconfig">setconfig</a> - <comment type="action" name="setconfig"></comment></li>
+<li>setsetting / <a href="#setsetting">setsetting</a> - <comment type="action" name="setsetting"></comment></li>
+</ul>
+<h2>Events</h2>
+<h2>Tables</h2>
+<ul>
+<li><strong>config</strong> / <a href="#config">config</a> (i64) - <comment type="table" name="config"></comment></li>
+</ul>
+<h2>ABI Extensions</h2>
+<h2>Structs</h2>
+<h3 id="activate"> activate </h3>
+<h3 id="config"> config </h3>
+<ul>
+<li>account_creator_contract / name</li>
+<li>account_creator_oracle / name</li>
+<li>settings / pair_name_uint8[]</li>
+</ul>
+<h3 id="create"> create </h3>
+<ul>
+<li>account_to_create / name</li>
+<li>owner_key / string</li>
+<li>active_key / string</li>
+</ul>
+<h3 id="pair_name_uint8"> pair_name_uint8 </h3>
+<ul>
+<li>key / name</li>
+<li>value / uint8</li>
+</ul>
+<h3 id="pause"> pause </h3>
+<h3 id="setconfig"> setconfig </h3>
+<ul>
+<li>account_creator_contract / name</li>
+<li>account_creator_oracle / name</li>
+</ul>
+<h3 id="setsetting"> setsetting </h3>
+<ul>
+<li>setting_name / name</li>
+<li>setting_value / uint8</li>
+</ul>
+</div>
+  <script id="template" type="x-tmpl-handlebars">
+# Smartcontract documentation for {{ file }}
+
+<comment type="main">{{comment}}</comment>
+
+{{#if types}}
+## Types
+{{/if}}
+{{#each types}}
+  {{ name }}
+{{/each}}
+
+## Actions
+
+{{#each actions}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Events
+
+{{#each events}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Tables
+
+{{#each tables}}
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## ABI Extensions
+
+{{#each abi_extensions}}
+  - {{ name }}
+{{/each}}
+
+## Structs
+
+{{#each structs}}
+<h3 id={{ name }}> {{ name }} {{#if base}}( {{base}} ){{/if}}</h3>
+  
+  {{#each fields}}
+  - {{ name }} / {{ type }}
+  {{/each}}
+{{/each}}
+
+  </script>
+
+</body></html>

--- a/docs/acctcreator.html
+++ b/docs/acctcreator.html
@@ -10,16 +10,29 @@
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
-</head><body onload="loadUser()">
+<script>
+$(function() {
+  var reader = new commonmark.Parser();
+  var writer = new commonmark.HtmlRenderer();
+
+  $('#target comment').each(function(i, elem) {
+    var parsed = reader.parse($(this).text()); 
+    var result = writer.render(parsed);
+    $(this).html(result);
+  });
+ });
+</script>
+
+</head><body>
   <div id="target"><h1>Smartcontract documentation for acctcreator</h1>
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li>activate / <a href="#activate">activate</a> - <comment type="action" name="activate"></comment></li>
-<li>create / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
-<li>pause / <a href="#pause">pause</a> - <comment type="action" name="pause"></comment></li>
-<li>setconfig / <a href="#setconfig">setconfig</a> - <comment type="action" name="setconfig"></comment></li>
-<li>setsetting / <a href="#setsetting">setsetting</a> - <comment type="action" name="setsetting"></comment></li>
+<li><strong>activate</strong> / <a href="#activate">activate</a> - <comment type="action" name="activate"></comment></li>
+<li><strong>create</strong> / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
+<li><strong>pause</strong> / <a href="#pause">pause</a> - <comment type="action" name="pause"></comment></li>
+<li><strong>setconfig</strong> / <a href="#setconfig">setconfig</a> - <comment type="action" name="setconfig"></comment></li>
+<li><strong>setsetting</strong> / <a href="#setsetting">setsetting</a> - <comment type="action" name="setsetting"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
@@ -61,7 +74,7 @@
   <script id="template" type="x-tmpl-handlebars">
 # Smartcontract documentation for {{ file }}
 
-<comment type="main">{{comment}}</comment>
+<comment type="main"></comment>
 
 {{#if types}}
 ## Types
@@ -73,19 +86,19 @@
 ## Actions
 
 {{#each actions}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/acctcreator.html
+++ b/docs/acctcreator.html
@@ -1,6 +1,14 @@
 <html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+<!-- Latest compiled and minified CSS -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
+
+<!-- Optional theme -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap-theme.min.css" integrity="sha384-6pzBo3FDv/PJ8r2KRkGHifhEocL+1X2rVCTTkUfGk7/0pbek5mMa1upzvWbrUbOZ" crossorigin="anonymous">
+
+<!-- Latest compiled and minified JavaScript -->
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
 </head><body onload="loadUser()">
   <div id="target"><h1>Smartcontract documentation for acctcreator</h1>

--- a/docs/bioregion.html
+++ b/docs/bioregion.html
@@ -25,29 +25,40 @@ $(function() {
 
 </head><body>
   <div id="target"><h1>Smartcontract documentation for bioregion</h1>
-<p><comment type="main"></comment></p>
+<p><comment type="main">
+Bioregions are geographically centeres locations where SEEDS Citizens may decide to base off their operations.
+
+They are covered in the SEEDS Constitution on Part 2, Section 1 **Bioregional Accounts**.
+
+Bioregions are created using the `create` action, however it only becomes active as long as enough people `join` the Bioregion.
+
+Members can also choose to `leave` the Bioregion. 
+
+The founder account may call `addrole` on member accounts for specifying their roles on the Bioregions.
+
+</comment></p>
 <h2>Actions</h2>
 <ul>
-<li><strong>addrole</strong> / <a href="#addrole">addrole</a> <comment type="action" name="addrole"></comment></li>
-<li><strong>create</strong> / <a href="#create">create</a> <comment type="action" name="create"></comment></li>
-<li><strong>join</strong> / <a href="#join">join</a> <comment type="action" name="join"></comment></li>
-<li><strong>leave</strong> / <a href="#leave">leave</a> <comment type="action" name="leave"></comment></li>
-<li><strong>leaverole</strong> / <a href="#leaverole">leaverole</a> <comment type="action" name="leaverole"></comment></li>
-<li><strong>removebr</strong> / <a href="#removebr">removebr</a> <comment type="action" name="removebr"></comment></li>
-<li><strong>removemember</strong> / <a href="#removemember">removemember</a> <comment type="action" name="removemember"></comment></li>
-<li><strong>removerole</strong> / <a href="#removerole">removerole</a> <comment type="action" name="removerole"></comment></li>
+<li><strong>addrole</strong> / <a href="#addrole">addrole</a> <comment type="action" name="addrole">Add a named `role` to a member of the Bioregion.</comment></li>
+<li><strong>create</strong> / <a href="#create">create</a> <comment type="action" name="create">Creates a new Bioregion.</comment></li>
+<li><strong>join</strong> / <a href="#join">join</a> <comment type="action" name="join">Allows people to join a Bioregion.</comment></li>
+<li><strong>leave</strong> / <a href="#leave">leave</a> <comment type="action" name="leave">This is called when one wants to leave a Bioregion.</comment></li>
+<li><strong>leaverole</strong> / <a href="#leaverole">leaverole</a> <comment type="action" name="leaverole">Allows the account owner to leave a Role.</comment></li>
+<li><strong>removebr</strong> / <a href="#removebr">removebr</a> <comment type="action" name="removebr">The founder will invoke that to remove a Bioregion, removing all members.</comment></li>
+<li><strong>removemember</strong> / <a href="#removemember">removemember</a> <comment type="action" name="removemember">The founder removes a specific Bioregion member.</comment></li>
+<li><strong>removerole</strong> / <a href="#removerole">removerole</a> <comment type="action" name="removerole">The founder removes someone from a Role.</comment></li>
 <li><strong>reset</strong> / <a href="#reset">reset</a> <comment type="action" name="reset"></comment></li>
-<li><strong>setfounder</strong> / <a href="#setfounder">setfounder</a> <comment type="action" name="setfounder"></comment></li>
+<li><strong>setfounder</strong> / <a href="#setfounder">setfounder</a> <comment type="action" name="setfounder">This is called by the founder to change the founder of a Bioregion.</comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
 <ul>
-<li><strong>bioregions</strong> / <a href="#bioregion_table">bioregion_table</a> (i64) <comment type="table" name="bioregions"></comment></li>
-<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) <comment type="table" name="config"></comment></li>
-<li><strong>members</strong> / <a href="#members_table">members_table</a> (i64) <comment type="table" name="members"></comment></li>
-<li><strong>roles</strong> / <a href="#roles_table">roles_table</a> (i64) <comment type="table" name="roles"></comment></li>
-<li><strong>sponsors</strong> / <a href="#sponsors_table">sponsors_table</a> (i64) <comment type="table" name="sponsors"></comment></li>
-<li><strong>users</strong> / <a href="#user_table">user_table</a> (i64) <comment type="table" name="users"></comment></li>
+<li><strong>bioregions</strong> / <a href="#bioregion_table">bioregion_table</a> (i64) <comment type="table" name="bioregions">The main Bioregions table.</comment></li>
+<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) <comment type="table" name="config">Access to the SEEDS config table.</comment></li>
+<li><strong>members</strong> / <a href="#members_table">members_table</a> (i64) <comment type="table" name="members">Bioregion members table.</comment></li>
+<li><strong>roles</strong> / <a href="#roles_table">roles_table</a> (i64) <comment type="table" name="roles">Bioregion roles table.</comment></li>
+<li><strong>sponsors</strong> / <a href="#sponsors_table">sponsors_table</a> (i64) <comment type="table" name="sponsors">Bioregions deposit sponsor table.</comment></li>
+<li><strong>users</strong> / <a href="#user_table">user_table</a> (i64) <comment type="table" name="users">Access to the users table.</comment></li>
 </ul>
 <h2>ABI Extensions</h2>
 <h2>Structs</h2>

--- a/docs/bioregion.html
+++ b/docs/bioregion.html
@@ -1,6 +1,14 @@
 <html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+<!-- Latest compiled and minified CSS -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
+
+<!-- Optional theme -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap-theme.min.css" integrity="sha384-6pzBo3FDv/PJ8r2KRkGHifhEocL+1X2rVCTTkUfGk7/0pbek5mMa1upzvWbrUbOZ" crossorigin="anonymous">
+
+<!-- Latest compiled and minified JavaScript -->
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
 </head><body onload="loadUser()">
   <div id="target"><h1>Smartcontract documentation for bioregion</h1>

--- a/docs/bioregion.html
+++ b/docs/bioregion.html
@@ -1,0 +1,187 @@
+<html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+
+</head><body onload="loadUser()">
+  <div id="target"><h1>Smartcontract documentation for bioregion</h1>
+<p><comment type="main"></comment></p>
+<h2>Actions</h2>
+<ul>
+<li>addrole / <a href="#addrole">addrole</a> - <comment type="action" name="addrole"></comment></li>
+<li>create / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
+<li>join / <a href="#join">join</a> - <comment type="action" name="join"></comment></li>
+<li>leave / <a href="#leave">leave</a> - <comment type="action" name="leave"></comment></li>
+<li>leaverole / <a href="#leaverole">leaverole</a> - <comment type="action" name="leaverole"></comment></li>
+<li>removebr / <a href="#removebr">removebr</a> - <comment type="action" name="removebr"></comment></li>
+<li>removemember / <a href="#removemember">removemember</a> - <comment type="action" name="removemember"></comment></li>
+<li>removerole / <a href="#removerole">removerole</a> - <comment type="action" name="removerole"></comment></li>
+<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li>setfounder / <a href="#setfounder">setfounder</a> - <comment type="action" name="setfounder"></comment></li>
+</ul>
+<h2>Events</h2>
+<h2>Tables</h2>
+<ul>
+<li><strong>bioregions</strong> / <a href="#bioregion_table">bioregion_table</a> (i64) - <comment type="table" name="bioregions"></comment></li>
+<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) - <comment type="table" name="config"></comment></li>
+<li><strong>members</strong> / <a href="#members_table">members_table</a> (i64) - <comment type="table" name="members"></comment></li>
+<li><strong>roles</strong> / <a href="#roles_table">roles_table</a> (i64) - <comment type="table" name="roles"></comment></li>
+<li><strong>sponsors</strong> / <a href="#sponsors_table">sponsors_table</a> (i64) - <comment type="table" name="sponsors"></comment></li>
+<li><strong>users</strong> / <a href="#user_table">user_table</a> (i64) - <comment type="table" name="users"></comment></li>
+</ul>
+<h2>ABI Extensions</h2>
+<h2>Structs</h2>
+<h3 id="addrole"> addrole </h3>
+<ul>
+<li>bioregion / name</li>
+<li>admin / name</li>
+<li>account / name</li>
+<li>role / name</li>
+</ul>
+<h3 id="bioregion_table"> bioregion_table </h3>
+<ul>
+<li>id / name</li>
+<li>founder / name</li>
+<li>status / name</li>
+<li>description / string</li>
+<li>locationjson / string</li>
+<li>latitude / float32</li>
+<li>longitude / float32</li>
+<li>members_count / uint64</li>
+<li>created_at / time_point</li>
+</ul>
+<h3 id="config_table"> config_table </h3>
+<ul>
+<li>param / name</li>
+<li>value / uint64</li>
+<li>description / string</li>
+<li>impact / name</li>
+</ul>
+<h3 id="create"> create </h3>
+<ul>
+<li>founder / name</li>
+<li>bioaccount / name</li>
+<li>description / string</li>
+<li>locationJson / string</li>
+<li>latitude / float32</li>
+<li>longitude / float32</li>
+<li>publicKey / string</li>
+</ul>
+<h3 id="join"> join </h3>
+<ul>
+<li>bioregion / name</li>
+<li>account / name</li>
+</ul>
+<h3 id="leave"> leave </h3>
+<ul>
+<li>bioregion / name</li>
+<li>account / name</li>
+</ul>
+<h3 id="leaverole"> leaverole </h3>
+<ul>
+<li>bioregion / name</li>
+<li>account / name</li>
+</ul>
+<h3 id="members_table"> members_table </h3>
+<ul>
+<li>bioregion / name</li>
+<li>account / name</li>
+<li>joined_date / time_point</li>
+</ul>
+<h3 id="removebr"> removebr </h3>
+<ul>
+<li>bioregion / name</li>
+</ul>
+<h3 id="removemember"> removemember </h3>
+<ul>
+<li>bioregion / name</li>
+<li>admin / name</li>
+<li>account / name</li>
+</ul>
+<h3 id="removerole"> removerole </h3>
+<ul>
+<li>bioregion / name</li>
+<li>admin / name</li>
+<li>account / name</li>
+</ul>
+<h3 id="reset"> reset </h3>
+<h3 id="roles_table"> roles_table </h3>
+<ul>
+<li>account / name</li>
+<li>role / name</li>
+<li>joined_date / time_point</li>
+</ul>
+<h3 id="setfounder"> setfounder </h3>
+<ul>
+<li>bioregion / name</li>
+<li>founder / name</li>
+<li>new_founder / name</li>
+</ul>
+<h3 id="sponsors_table"> sponsors_table </h3>
+<ul>
+<li>account / name</li>
+<li>balance / asset</li>
+</ul>
+<h3 id="user_table"> user_table </h3>
+<ul>
+<li>account / name</li>
+<li>status / name</li>
+<li>type / name</li>
+<li>nickname / string</li>
+<li>image / string</li>
+<li>story / string</li>
+<li>roles / string</li>
+<li>skills / string</li>
+<li>interests / string</li>
+<li>reputation / uint64</li>
+<li>timestamp / uint64</li>
+</ul>
+</div>
+  <script id="template" type="x-tmpl-handlebars">
+# Smartcontract documentation for {{ file }}
+
+<comment type="main">{{comment}}</comment>
+
+{{#if types}}
+## Types
+{{/if}}
+{{#each types}}
+  {{ name }}
+{{/each}}
+
+## Actions
+
+{{#each actions}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Events
+
+{{#each events}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Tables
+
+{{#each tables}}
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## ABI Extensions
+
+{{#each abi_extensions}}
+  - {{ name }}
+{{/each}}
+
+## Structs
+
+{{#each structs}}
+<h3 id={{ name }}> {{ name }} {{#if base}}( {{base}} ){{/if}}</h3>
+  
+  {{#each fields}}
+  - {{ name }} / {{ type }}
+  {{/each}}
+{{/each}}
+
+  </script>
+
+</body></html>

--- a/docs/bioregion.html
+++ b/docs/bioregion.html
@@ -28,26 +28,26 @@ $(function() {
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li><strong>addrole</strong> / <a href="#addrole">addrole</a> - <comment type="action" name="addrole"></comment></li>
-<li><strong>create</strong> / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
-<li><strong>join</strong> / <a href="#join">join</a> - <comment type="action" name="join"></comment></li>
-<li><strong>leave</strong> / <a href="#leave">leave</a> - <comment type="action" name="leave"></comment></li>
-<li><strong>leaverole</strong> / <a href="#leaverole">leaverole</a> - <comment type="action" name="leaverole"></comment></li>
-<li><strong>removebr</strong> / <a href="#removebr">removebr</a> - <comment type="action" name="removebr"></comment></li>
-<li><strong>removemember</strong> / <a href="#removemember">removemember</a> - <comment type="action" name="removemember"></comment></li>
-<li><strong>removerole</strong> / <a href="#removerole">removerole</a> - <comment type="action" name="removerole"></comment></li>
-<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
-<li><strong>setfounder</strong> / <a href="#setfounder">setfounder</a> - <comment type="action" name="setfounder"></comment></li>
+<li><strong>addrole</strong> / <a href="#addrole">addrole</a> <comment type="action" name="addrole"></comment></li>
+<li><strong>create</strong> / <a href="#create">create</a> <comment type="action" name="create"></comment></li>
+<li><strong>join</strong> / <a href="#join">join</a> <comment type="action" name="join"></comment></li>
+<li><strong>leave</strong> / <a href="#leave">leave</a> <comment type="action" name="leave"></comment></li>
+<li><strong>leaverole</strong> / <a href="#leaverole">leaverole</a> <comment type="action" name="leaverole"></comment></li>
+<li><strong>removebr</strong> / <a href="#removebr">removebr</a> <comment type="action" name="removebr"></comment></li>
+<li><strong>removemember</strong> / <a href="#removemember">removemember</a> <comment type="action" name="removemember"></comment></li>
+<li><strong>removerole</strong> / <a href="#removerole">removerole</a> <comment type="action" name="removerole"></comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> <comment type="action" name="reset"></comment></li>
+<li><strong>setfounder</strong> / <a href="#setfounder">setfounder</a> <comment type="action" name="setfounder"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
 <ul>
-<li><strong>bioregions</strong> / <a href="#bioregion_table">bioregion_table</a> (i64) - <comment type="table" name="bioregions"></comment></li>
-<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) - <comment type="table" name="config"></comment></li>
-<li><strong>members</strong> / <a href="#members_table">members_table</a> (i64) - <comment type="table" name="members"></comment></li>
-<li><strong>roles</strong> / <a href="#roles_table">roles_table</a> (i64) - <comment type="table" name="roles"></comment></li>
-<li><strong>sponsors</strong> / <a href="#sponsors_table">sponsors_table</a> (i64) - <comment type="table" name="sponsors"></comment></li>
-<li><strong>users</strong> / <a href="#user_table">user_table</a> (i64) - <comment type="table" name="users"></comment></li>
+<li><strong>bioregions</strong> / <a href="#bioregion_table">bioregion_table</a> (i64) <comment type="table" name="bioregions"></comment></li>
+<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) <comment type="table" name="config"></comment></li>
+<li><strong>members</strong> / <a href="#members_table">members_table</a> (i64) <comment type="table" name="members"></comment></li>
+<li><strong>roles</strong> / <a href="#roles_table">roles_table</a> (i64) <comment type="table" name="roles"></comment></li>
+<li><strong>sponsors</strong> / <a href="#sponsors_table">sponsors_table</a> (i64) <comment type="table" name="sponsors"></comment></li>
+<li><strong>users</strong> / <a href="#user_table">user_table</a> (i64) <comment type="table" name="users"></comment></li>
 </ul>
 <h2>ABI Extensions</h2>
 <h2>Structs</h2>
@@ -172,19 +172,19 @@ $(function() {
 ## Actions
 
 {{#each actions}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/bioregion.html
+++ b/docs/bioregion.html
@@ -10,21 +10,34 @@
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
-</head><body onload="loadUser()">
+<script>
+$(function() {
+  var reader = new commonmark.Parser();
+  var writer = new commonmark.HtmlRenderer();
+
+  $('#target comment').each(function(i, elem) {
+    var parsed = reader.parse($(this).text()); 
+    var result = writer.render(parsed);
+    $(this).html(result);
+  });
+ });
+</script>
+
+</head><body>
   <div id="target"><h1>Smartcontract documentation for bioregion</h1>
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li>addrole / <a href="#addrole">addrole</a> - <comment type="action" name="addrole"></comment></li>
-<li>create / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
-<li>join / <a href="#join">join</a> - <comment type="action" name="join"></comment></li>
-<li>leave / <a href="#leave">leave</a> - <comment type="action" name="leave"></comment></li>
-<li>leaverole / <a href="#leaverole">leaverole</a> - <comment type="action" name="leaverole"></comment></li>
-<li>removebr / <a href="#removebr">removebr</a> - <comment type="action" name="removebr"></comment></li>
-<li>removemember / <a href="#removemember">removemember</a> - <comment type="action" name="removemember"></comment></li>
-<li>removerole / <a href="#removerole">removerole</a> - <comment type="action" name="removerole"></comment></li>
-<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
-<li>setfounder / <a href="#setfounder">setfounder</a> - <comment type="action" name="setfounder"></comment></li>
+<li><strong>addrole</strong> / <a href="#addrole">addrole</a> - <comment type="action" name="addrole"></comment></li>
+<li><strong>create</strong> / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
+<li><strong>join</strong> / <a href="#join">join</a> - <comment type="action" name="join"></comment></li>
+<li><strong>leave</strong> / <a href="#leave">leave</a> - <comment type="action" name="leave"></comment></li>
+<li><strong>leaverole</strong> / <a href="#leaverole">leaverole</a> - <comment type="action" name="leaverole"></comment></li>
+<li><strong>removebr</strong> / <a href="#removebr">removebr</a> - <comment type="action" name="removebr"></comment></li>
+<li><strong>removemember</strong> / <a href="#removemember">removemember</a> - <comment type="action" name="removemember"></comment></li>
+<li><strong>removerole</strong> / <a href="#removerole">removerole</a> - <comment type="action" name="removerole"></comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li><strong>setfounder</strong> / <a href="#setfounder">setfounder</a> - <comment type="action" name="setfounder"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
@@ -147,7 +160,7 @@
   <script id="template" type="x-tmpl-handlebars">
 # Smartcontract documentation for {{ file }}
 
-<comment type="main">{{comment}}</comment>
+<comment type="main"></comment>
 
 {{#if types}}
 ## Types
@@ -159,19 +172,19 @@
 ## Actions
 
 {{#each actions}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/docstemplate.html
+++ b/docs/docstemplate.html
@@ -40,19 +40,19 @@ $(function() {
 ## Actions
 
 {{#each actions}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/docstemplate.html
+++ b/docs/docstemplate.html
@@ -10,12 +10,25 @@
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
-<body onload="loadUser()">
+<script>
+$(function() {
+  var reader = new commonmark.Parser();
+  var writer = new commonmark.HtmlRenderer();
+
+  $('#target comment').each(function(i, elem) {
+    var parsed = reader.parse($(this).text()); 
+    var result = writer.render(parsed);
+    $(this).html(result);
+  });
+ });
+</script>
+
+<body>
   <div id="target">Loading...</div>
   <script id="template" type="x-tmpl-handlebars">
 # Smartcontract documentation for {{ file }}
 
-<comment type="main">{{comment}}</comment>
+<comment type="main"></comment>
 
 {{#if types}}
 ## Types
@@ -27,19 +40,19 @@
 ## Actions
 
 {{#each actions}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/docstemplate.html
+++ b/docs/docstemplate.html
@@ -1,0 +1,12 @@
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/3.0.0/mustache.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+
+<body onload="loadUser()">
+  <div id="target">Loading...</div>
+  <script id="template" type="x-tmpl-mustache">
+# Documentation Template  
+
+{{ version }}!
+  </script>
+</body>

--- a/docs/docstemplate.html
+++ b/docs/docstemplate.html
@@ -1,12 +1,54 @@
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/3.0.0/mustache.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
 
 <body onload="loadUser()">
   <div id="target">Loading...</div>
-  <script id="template" type="x-tmpl-mustache">
-# Documentation Template  
+  <script id="template" type="x-tmpl-handlebars">
+# Smartcontract documentation for {{ file }}
 
-{{ version }}!
+<comment type="main">{{comment}}</comment>
+
+{{#if types}}
+## Types
+{{/if}}
+{{#each types}}
+  {{ name }}
+{{/each}}
+
+## Actions
+
+{{#each actions}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Events
+
+{{#each events}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Tables
+
+{{#each tables}}
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## ABI Extensions
+
+{{#each abi_extensions}}
+  - {{ name }}
+{{/each}}
+
+## Structs
+
+{{#each structs}}
+<h3 id={{ name }}> {{ name }} {{#if base}}( {{base}} ){{/if}}</h3>
+  
+  {{#each fields}}
+  - {{ name }} / {{ type }}
+  {{/each}}
+{{/each}}
+
   </script>
 </body>

--- a/docs/docstemplate.html
+++ b/docs/docstemplate.html
@@ -1,6 +1,14 @@
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+<!-- Latest compiled and minified CSS -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
+
+<!-- Optional theme -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap-theme.min.css" integrity="sha384-6pzBo3FDv/PJ8r2KRkGHifhEocL+1X2rVCTTkUfGk7/0pbek5mMa1upzvWbrUbOZ" crossorigin="anonymous">
+
+<!-- Latest compiled and minified JavaScript -->
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
 <body onload="loadUser()">
   <div id="target">Loading...</div>

--- a/docs/escrow.html
+++ b/docs/escrow.html
@@ -10,17 +10,30 @@
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
-</head><body onload="loadUser()">
+<script>
+$(function() {
+  var reader = new commonmark.Parser();
+  var writer = new commonmark.HtmlRenderer();
+
+  $('#target comment').each(function(i, elem) {
+    var parsed = reader.parse($(this).text()); 
+    var result = writer.render(parsed);
+    $(this).html(result);
+  });
+ });
+</script>
+
+</head><body>
   <div id="target"><h1>Smartcontract documentation for escrow</h1>
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li>cancellock / <a href="#cancellock">cancellock</a> - <comment type="action" name="cancellock"></comment></li>
-<li>claim / <a href="#claim">claim</a> - <comment type="action" name="claim"></comment></li>
-<li>lock / <a href="#lock">lock</a> - <comment type="action" name="lock"></comment></li>
-<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
-<li>trigger / <a href="#trigger">trigger</a> - <comment type="action" name="trigger"></comment></li>
-<li>withdraw / <a href="#withdraw">withdraw</a> - <comment type="action" name="withdraw"></comment></li>
+<li><strong>cancellock</strong> / <a href="#cancellock">cancellock</a> - <comment type="action" name="cancellock"></comment></li>
+<li><strong>claim</strong> / <a href="#claim">claim</a> - <comment type="action" name="claim"></comment></li>
+<li><strong>lock</strong> / <a href="#lock">lock</a> - <comment type="action" name="lock"></comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li><strong>trigger</strong> / <a href="#trigger">trigger</a> - <comment type="action" name="trigger"></comment></li>
+<li><strong>withdraw</strong> / <a href="#withdraw">withdraw</a> - <comment type="action" name="withdraw"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
@@ -92,7 +105,7 @@
   <script id="template" type="x-tmpl-handlebars">
 # Smartcontract documentation for {{ file }}
 
-<comment type="main">{{comment}}</comment>
+<comment type="main"></comment>
 
 {{#if types}}
 ## Types
@@ -104,19 +117,19 @@
 ## Actions
 
 {{#each actions}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/escrow.html
+++ b/docs/escrow.html
@@ -1,6 +1,14 @@
 <html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+<!-- Latest compiled and minified CSS -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
+
+<!-- Optional theme -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap-theme.min.css" integrity="sha384-6pzBo3FDv/PJ8r2KRkGHifhEocL+1X2rVCTTkUfGk7/0pbek5mMa1upzvWbrUbOZ" crossorigin="anonymous">
+
+<!-- Latest compiled and minified JavaScript -->
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
 </head><body onload="loadUser()">
   <div id="target"><h1>Smartcontract documentation for escrow</h1>

--- a/docs/escrow.html
+++ b/docs/escrow.html
@@ -1,0 +1,132 @@
+<html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+
+</head><body onload="loadUser()">
+  <div id="target"><h1>Smartcontract documentation for escrow</h1>
+<p><comment type="main"></comment></p>
+<h2>Actions</h2>
+<ul>
+<li>cancellock / <a href="#cancellock">cancellock</a> - <comment type="action" name="cancellock"></comment></li>
+<li>claim / <a href="#claim">claim</a> - <comment type="action" name="claim"></comment></li>
+<li>lock / <a href="#lock">lock</a> - <comment type="action" name="lock"></comment></li>
+<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li>trigger / <a href="#trigger">trigger</a> - <comment type="action" name="trigger"></comment></li>
+<li>withdraw / <a href="#withdraw">withdraw</a> - <comment type="action" name="withdraw"></comment></li>
+</ul>
+<h2>Events</h2>
+<h2>Tables</h2>
+<ul>
+<li><strong>events</strong> / <a href="#event">event</a> (i64) - <comment type="table" name="events"></comment></li>
+<li><strong>locks</strong> / <a href="#token_lock">token_lock</a> (i64) - <comment type="table" name="locks"></comment></li>
+<li><strong>sponsors</strong> / <a href="#sponsors_table">sponsors_table</a> (i64) - <comment type="table" name="sponsors"></comment></li>
+</ul>
+<h2>ABI Extensions</h2>
+<h2>Structs</h2>
+<h3 id="cancellock"> cancellock </h3>
+<ul>
+<li>lock_id / uint64</li>
+</ul>
+<h3 id="claim"> claim </h3>
+<ul>
+<li>beneficiary / name</li>
+</ul>
+<h3 id="event"> event </h3>
+<ul>
+<li>event_name / name</li>
+<li>event_date / time_point</li>
+<li>notes / string</li>
+</ul>
+<h3 id="lock"> lock </h3>
+<ul>
+<li>lock_type / name</li>
+<li>sponsor / name</li>
+<li>beneficiary / name</li>
+<li>quantity / asset</li>
+<li>trigger_event / name</li>
+<li>trigger_source / name</li>
+<li>vesting_date / time_point</li>
+<li>notes / string</li>
+</ul>
+<h3 id="reset"> reset </h3>
+<h3 id="sponsors_table"> sponsors_table </h3>
+<ul>
+<li>sponsor / name</li>
+<li>locked_balance / asset</li>
+<li>liquid_balance / asset</li>
+</ul>
+<h3 id="token_lock"> token_lock </h3>
+<ul>
+<li>id / uint64</li>
+<li>lock_type / name</li>
+<li>sponsor / name</li>
+<li>beneficiary / name</li>
+<li>quantity / asset</li>
+<li>trigger_event / name</li>
+<li>trigger_source / name</li>
+<li>vesting_date / time_point</li>
+<li>notes / string</li>
+<li>created_date / time_point</li>
+<li>updated_date / time_point</li>
+</ul>
+<h3 id="trigger"> trigger </h3>
+<ul>
+<li>trigger_source / name</li>
+<li>event_name / name</li>
+<li>notes / string</li>
+</ul>
+<h3 id="withdraw"> withdraw </h3>
+<ul>
+<li>sponsor / name</li>
+<li>quantity / asset</li>
+</ul>
+</div>
+  <script id="template" type="x-tmpl-handlebars">
+# Smartcontract documentation for {{ file }}
+
+<comment type="main">{{comment}}</comment>
+
+{{#if types}}
+## Types
+{{/if}}
+{{#each types}}
+  {{ name }}
+{{/each}}
+
+## Actions
+
+{{#each actions}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Events
+
+{{#each events}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Tables
+
+{{#each tables}}
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## ABI Extensions
+
+{{#each abi_extensions}}
+  - {{ name }}
+{{/each}}
+
+## Structs
+
+{{#each structs}}
+<h3 id={{ name }}> {{ name }} {{#if base}}( {{base}} ){{/if}}</h3>
+  
+  {{#each fields}}
+  - {{ name }} / {{ type }}
+  {{/each}}
+{{/each}}
+
+  </script>
+
+</body></html>

--- a/docs/escrow.html
+++ b/docs/escrow.html
@@ -28,19 +28,19 @@ $(function() {
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li><strong>cancellock</strong> / <a href="#cancellock">cancellock</a> - <comment type="action" name="cancellock"></comment></li>
-<li><strong>claim</strong> / <a href="#claim">claim</a> - <comment type="action" name="claim"></comment></li>
-<li><strong>lock</strong> / <a href="#lock">lock</a> - <comment type="action" name="lock"></comment></li>
-<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
-<li><strong>trigger</strong> / <a href="#trigger">trigger</a> - <comment type="action" name="trigger"></comment></li>
-<li><strong>withdraw</strong> / <a href="#withdraw">withdraw</a> - <comment type="action" name="withdraw"></comment></li>
+<li><strong>cancellock</strong> / <a href="#cancellock">cancellock</a> <comment type="action" name="cancellock"></comment></li>
+<li><strong>claim</strong> / <a href="#claim">claim</a> <comment type="action" name="claim"></comment></li>
+<li><strong>lock</strong> / <a href="#lock">lock</a> <comment type="action" name="lock"></comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> <comment type="action" name="reset"></comment></li>
+<li><strong>trigger</strong> / <a href="#trigger">trigger</a> <comment type="action" name="trigger"></comment></li>
+<li><strong>withdraw</strong> / <a href="#withdraw">withdraw</a> <comment type="action" name="withdraw"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
 <ul>
-<li><strong>events</strong> / <a href="#event">event</a> (i64) - <comment type="table" name="events"></comment></li>
-<li><strong>locks</strong> / <a href="#token_lock">token_lock</a> (i64) - <comment type="table" name="locks"></comment></li>
-<li><strong>sponsors</strong> / <a href="#sponsors_table">sponsors_table</a> (i64) - <comment type="table" name="sponsors"></comment></li>
+<li><strong>events</strong> / <a href="#event">event</a> (i64) <comment type="table" name="events"></comment></li>
+<li><strong>locks</strong> / <a href="#token_lock">token_lock</a> (i64) <comment type="table" name="locks"></comment></li>
+<li><strong>sponsors</strong> / <a href="#sponsors_table">sponsors_table</a> (i64) <comment type="table" name="sponsors"></comment></li>
 </ul>
 <h2>ABI Extensions</h2>
 <h2>Structs</h2>
@@ -117,19 +117,19 @@ $(function() {
 ## Actions
 
 {{#each actions}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/exchange.html
+++ b/docs/exchange.html
@@ -1,0 +1,187 @@
+<html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+
+</head><body onload="loadUser()">
+  <div id="target"><h1>Smartcontract documentation for exchange</h1>
+<p><comment type="main"></comment></p>
+<h2>Actions</h2>
+<ul>
+<li>addround / <a href="#addround">addround</a> - <comment type="action" name="addround"></comment></li>
+<li>incprice / <a href="#incprice">incprice</a> - <comment type="action" name="incprice"></comment></li>
+<li>initrounds / <a href="#initrounds">initrounds</a> - <comment type="action" name="initrounds"></comment></li>
+<li>initsale / <a href="#initsale">initsale</a> - <comment type="action" name="initsale"></comment></li>
+<li>migrate / <a href="#migrate">migrate</a> - <comment type="action" name="migrate"></comment></li>
+<li>newpayment / <a href="#newpayment">newpayment</a> - <comment type="action" name="newpayment"></comment></li>
+<li>onperiod / <a href="#onperiod">onperiod</a> - <comment type="action" name="onperiod"></comment></li>
+<li>ontransfer / <a href="#ontransfer">ontransfer</a> - <comment type="action" name="ontransfer"></comment></li>
+<li>pause / <a href="#pause">pause</a> - <comment type="action" name="pause"></comment></li>
+<li>priceupdate / <a href="#priceupdate">priceupdate</a> - <comment type="action" name="priceupdate"></comment></li>
+<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li>setflag / <a href="#setflag">setflag</a> - <comment type="action" name="setflag"></comment></li>
+<li>unpause / <a href="#unpause">unpause</a> - <comment type="action" name="unpause"></comment></li>
+<li>updatelimit / <a href="#updatelimit">updatelimit</a> - <comment type="action" name="updatelimit"></comment></li>
+<li>updatetlos / <a href="#updatetlos">updatetlos</a> - <comment type="action" name="updatetlos"></comment></li>
+</ul>
+<h2>Events</h2>
+<h2>Tables</h2>
+<ul>
+<li><strong>config</strong> / <a href="#configtable">configtable</a> (i64) - <comment type="table" name="config"></comment></li>
+<li><strong>dailystats</strong> / <a href="#stattable">stattable</a> (i64) - <comment type="table" name="dailystats"></comment></li>
+<li><strong>flags</strong> / <a href="#flags_table">flags_table</a> (i64) - <comment type="table" name="flags"></comment></li>
+<li><strong>payhistory</strong> / <a href="#payhistory_table">payhistory_table</a> (i64) - <comment type="table" name="payhistory"></comment></li>
+<li><strong>price</strong> / <a href="#price_table">price_table</a> (i64) - <comment type="table" name="price"></comment></li>
+<li><strong>pricehistory</strong> / <a href="#price_history_table">price_history_table</a> (i64) - <comment type="table" name="pricehistory"></comment></li>
+<li><strong>rounds</strong> / <a href="#round_table">round_table</a> (i64) - <comment type="table" name="rounds"></comment></li>
+<li><strong>sold</strong> / <a href="#soldtable">soldtable</a> (i64) - <comment type="table" name="sold"></comment></li>
+</ul>
+<h2>ABI Extensions</h2>
+<h2>Structs</h2>
+<h3 id="addround"> addround </h3>
+<ul>
+<li>volume / uint64</li>
+<li>seeds_per_usd / asset</li>
+</ul>
+<h3 id="configtable"> configtable </h3>
+<ul>
+<li>seeds_per_usd / asset</li>
+<li>tlos_per_usd / asset</li>
+<li>citizen_limit / asset</li>
+<li>resident_limit / asset</li>
+<li>visitor_limit / asset</li>
+<li>timestamp / uint64</li>
+</ul>
+<h3 id="flags_table"> flags_table </h3>
+<ul>
+<li>param / name</li>
+<li>value / uint64</li>
+</ul>
+<h3 id="incprice"> incprice </h3>
+<h3 id="initrounds"> initrounds </h3>
+<ul>
+<li>volume_per_round / uint64</li>
+<li>initial_seeds_per_usd / asset</li>
+</ul>
+<h3 id="initsale"> initsale </h3>
+<h3 id="migrate"> migrate </h3>
+<h3 id="newpayment"> newpayment </h3>
+<ul>
+<li>recipientAccount / name</li>
+<li>paymentSymbol / string</li>
+<li>paymentId / string</li>
+<li>multipliedUsdValue / uint64</li>
+</ul>
+<h3 id="onperiod"> onperiod </h3>
+<h3 id="ontransfer"> ontransfer </h3>
+<ul>
+<li>buyer / name</li>
+<li>contract / name</li>
+<li>tlos_quantity / asset</li>
+<li>memo / string</li>
+</ul>
+<h3 id="pause"> pause </h3>
+<h3 id="payhistory_table"> payhistory_table </h3>
+<ul>
+<li>id / uint64</li>
+<li>recipientAccount / name</li>
+<li>paymentSymbol / string</li>
+<li>paymentId / string</li>
+<li>multipliedUsdValue / uint64</li>
+</ul>
+<h3 id="price_history_table"> price_history_table </h3>
+<ul>
+<li>id / uint64</li>
+<li>seeds_usd / asset</li>
+<li>date / time_point</li>
+</ul>
+<h3 id="price_table"> price_table </h3>
+<ul>
+<li>id / uint64</li>
+<li>current_round_id / uint64</li>
+<li>current_seeds_per_usd / asset</li>
+<li>remaining / uint64</li>
+</ul>
+<h3 id="priceupdate"> priceupdate </h3>
+<h3 id="reset"> reset </h3>
+<h3 id="round_table"> round_table </h3>
+<ul>
+<li>id / uint64</li>
+<li>max_sold / uint64</li>
+<li>seeds_per_usd / asset</li>
+</ul>
+<h3 id="setflag"> setflag </h3>
+<ul>
+<li>flagname / name</li>
+<li>value / uint64</li>
+</ul>
+<h3 id="soldtable"> soldtable </h3>
+<ul>
+<li>id / uint64</li>
+<li>total_sold / uint64</li>
+</ul>
+<h3 id="stattable"> stattable </h3>
+<ul>
+<li>buyer_account / name</li>
+<li>seeds_purchased / uint64</li>
+</ul>
+<h3 id="unpause"> unpause </h3>
+<h3 id="updatelimit"> updatelimit </h3>
+<ul>
+<li>citizen_limit / asset</li>
+<li>resident_limit / asset</li>
+<li>visitor_limit / asset</li>
+</ul>
+<h3 id="updatetlos"> updatetlos </h3>
+<ul>
+<li>tlos_per_usd / asset</li>
+</ul>
+</div>
+  <script id="template" type="x-tmpl-handlebars">
+# Smartcontract documentation for {{ file }}
+
+<comment type="main">{{comment}}</comment>
+
+{{#if types}}
+## Types
+{{/if}}
+{{#each types}}
+  {{ name }}
+{{/each}}
+
+## Actions
+
+{{#each actions}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Events
+
+{{#each events}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Tables
+
+{{#each tables}}
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## ABI Extensions
+
+{{#each abi_extensions}}
+  - {{ name }}
+{{/each}}
+
+## Structs
+
+{{#each structs}}
+<h3 id={{ name }}> {{ name }} {{#if base}}( {{base}} ){{/if}}</h3>
+  
+  {{#each fields}}
+  - {{ name }} / {{ type }}
+  {{/each}}
+{{/each}}
+
+  </script>
+
+</body></html>

--- a/docs/exchange.html
+++ b/docs/exchange.html
@@ -28,33 +28,33 @@ $(function() {
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li><strong>addround</strong> / <a href="#addround">addround</a> - <comment type="action" name="addround"></comment></li>
-<li><strong>incprice</strong> / <a href="#incprice">incprice</a> - <comment type="action" name="incprice"></comment></li>
-<li><strong>initrounds</strong> / <a href="#initrounds">initrounds</a> - <comment type="action" name="initrounds"></comment></li>
-<li><strong>initsale</strong> / <a href="#initsale">initsale</a> - <comment type="action" name="initsale"></comment></li>
-<li><strong>migrate</strong> / <a href="#migrate">migrate</a> - <comment type="action" name="migrate"></comment></li>
-<li><strong>newpayment</strong> / <a href="#newpayment">newpayment</a> - <comment type="action" name="newpayment"></comment></li>
-<li><strong>onperiod</strong> / <a href="#onperiod">onperiod</a> - <comment type="action" name="onperiod"></comment></li>
-<li><strong>ontransfer</strong> / <a href="#ontransfer">ontransfer</a> - <comment type="action" name="ontransfer"></comment></li>
-<li><strong>pause</strong> / <a href="#pause">pause</a> - <comment type="action" name="pause"></comment></li>
-<li><strong>priceupdate</strong> / <a href="#priceupdate">priceupdate</a> - <comment type="action" name="priceupdate"></comment></li>
-<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
-<li><strong>setflag</strong> / <a href="#setflag">setflag</a> - <comment type="action" name="setflag"></comment></li>
-<li><strong>unpause</strong> / <a href="#unpause">unpause</a> - <comment type="action" name="unpause"></comment></li>
-<li><strong>updatelimit</strong> / <a href="#updatelimit">updatelimit</a> - <comment type="action" name="updatelimit"></comment></li>
-<li><strong>updatetlos</strong> / <a href="#updatetlos">updatetlos</a> - <comment type="action" name="updatetlos"></comment></li>
+<li><strong>addround</strong> / <a href="#addround">addround</a> <comment type="action" name="addround"></comment></li>
+<li><strong>incprice</strong> / <a href="#incprice">incprice</a> <comment type="action" name="incprice"></comment></li>
+<li><strong>initrounds</strong> / <a href="#initrounds">initrounds</a> <comment type="action" name="initrounds"></comment></li>
+<li><strong>initsale</strong> / <a href="#initsale">initsale</a> <comment type="action" name="initsale"></comment></li>
+<li><strong>migrate</strong> / <a href="#migrate">migrate</a> <comment type="action" name="migrate"></comment></li>
+<li><strong>newpayment</strong> / <a href="#newpayment">newpayment</a> <comment type="action" name="newpayment"></comment></li>
+<li><strong>onperiod</strong> / <a href="#onperiod">onperiod</a> <comment type="action" name="onperiod"></comment></li>
+<li><strong>ontransfer</strong> / <a href="#ontransfer">ontransfer</a> <comment type="action" name="ontransfer"></comment></li>
+<li><strong>pause</strong> / <a href="#pause">pause</a> <comment type="action" name="pause"></comment></li>
+<li><strong>priceupdate</strong> / <a href="#priceupdate">priceupdate</a> <comment type="action" name="priceupdate"></comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> <comment type="action" name="reset"></comment></li>
+<li><strong>setflag</strong> / <a href="#setflag">setflag</a> <comment type="action" name="setflag"></comment></li>
+<li><strong>unpause</strong> / <a href="#unpause">unpause</a> <comment type="action" name="unpause"></comment></li>
+<li><strong>updatelimit</strong> / <a href="#updatelimit">updatelimit</a> <comment type="action" name="updatelimit"></comment></li>
+<li><strong>updatetlos</strong> / <a href="#updatetlos">updatetlos</a> <comment type="action" name="updatetlos"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
 <ul>
-<li><strong>config</strong> / <a href="#configtable">configtable</a> (i64) - <comment type="table" name="config"></comment></li>
-<li><strong>dailystats</strong> / <a href="#stattable">stattable</a> (i64) - <comment type="table" name="dailystats"></comment></li>
-<li><strong>flags</strong> / <a href="#flags_table">flags_table</a> (i64) - <comment type="table" name="flags"></comment></li>
-<li><strong>payhistory</strong> / <a href="#payhistory_table">payhistory_table</a> (i64) - <comment type="table" name="payhistory"></comment></li>
-<li><strong>price</strong> / <a href="#price_table">price_table</a> (i64) - <comment type="table" name="price"></comment></li>
-<li><strong>pricehistory</strong> / <a href="#price_history_table">price_history_table</a> (i64) - <comment type="table" name="pricehistory"></comment></li>
-<li><strong>rounds</strong> / <a href="#round_table">round_table</a> (i64) - <comment type="table" name="rounds"></comment></li>
-<li><strong>sold</strong> / <a href="#soldtable">soldtable</a> (i64) - <comment type="table" name="sold"></comment></li>
+<li><strong>config</strong> / <a href="#configtable">configtable</a> (i64) <comment type="table" name="config"></comment></li>
+<li><strong>dailystats</strong> / <a href="#stattable">stattable</a> (i64) <comment type="table" name="dailystats"></comment></li>
+<li><strong>flags</strong> / <a href="#flags_table">flags_table</a> (i64) <comment type="table" name="flags"></comment></li>
+<li><strong>payhistory</strong> / <a href="#payhistory_table">payhistory_table</a> (i64) <comment type="table" name="payhistory"></comment></li>
+<li><strong>price</strong> / <a href="#price_table">price_table</a> (i64) <comment type="table" name="price"></comment></li>
+<li><strong>pricehistory</strong> / <a href="#price_history_table">price_history_table</a> (i64) <comment type="table" name="pricehistory"></comment></li>
+<li><strong>rounds</strong> / <a href="#round_table">round_table</a> (i64) <comment type="table" name="rounds"></comment></li>
+<li><strong>sold</strong> / <a href="#soldtable">soldtable</a> (i64) <comment type="table" name="sold"></comment></li>
 </ul>
 <h2>ABI Extensions</h2>
 <h2>Structs</h2>
@@ -172,19 +172,19 @@ $(function() {
 ## Actions
 
 {{#each actions}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/exchange.html
+++ b/docs/exchange.html
@@ -1,6 +1,14 @@
 <html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+<!-- Latest compiled and minified CSS -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
+
+<!-- Optional theme -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap-theme.min.css" integrity="sha384-6pzBo3FDv/PJ8r2KRkGHifhEocL+1X2rVCTTkUfGk7/0pbek5mMa1upzvWbrUbOZ" crossorigin="anonymous">
+
+<!-- Latest compiled and minified JavaScript -->
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
 </head><body onload="loadUser()">
   <div id="target"><h1>Smartcontract documentation for exchange</h1>

--- a/docs/exchange.html
+++ b/docs/exchange.html
@@ -10,26 +10,39 @@
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
-</head><body onload="loadUser()">
+<script>
+$(function() {
+  var reader = new commonmark.Parser();
+  var writer = new commonmark.HtmlRenderer();
+
+  $('#target comment').each(function(i, elem) {
+    var parsed = reader.parse($(this).text()); 
+    var result = writer.render(parsed);
+    $(this).html(result);
+  });
+ });
+</script>
+
+</head><body>
   <div id="target"><h1>Smartcontract documentation for exchange</h1>
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li>addround / <a href="#addround">addround</a> - <comment type="action" name="addround"></comment></li>
-<li>incprice / <a href="#incprice">incprice</a> - <comment type="action" name="incprice"></comment></li>
-<li>initrounds / <a href="#initrounds">initrounds</a> - <comment type="action" name="initrounds"></comment></li>
-<li>initsale / <a href="#initsale">initsale</a> - <comment type="action" name="initsale"></comment></li>
-<li>migrate / <a href="#migrate">migrate</a> - <comment type="action" name="migrate"></comment></li>
-<li>newpayment / <a href="#newpayment">newpayment</a> - <comment type="action" name="newpayment"></comment></li>
-<li>onperiod / <a href="#onperiod">onperiod</a> - <comment type="action" name="onperiod"></comment></li>
-<li>ontransfer / <a href="#ontransfer">ontransfer</a> - <comment type="action" name="ontransfer"></comment></li>
-<li>pause / <a href="#pause">pause</a> - <comment type="action" name="pause"></comment></li>
-<li>priceupdate / <a href="#priceupdate">priceupdate</a> - <comment type="action" name="priceupdate"></comment></li>
-<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
-<li>setflag / <a href="#setflag">setflag</a> - <comment type="action" name="setflag"></comment></li>
-<li>unpause / <a href="#unpause">unpause</a> - <comment type="action" name="unpause"></comment></li>
-<li>updatelimit / <a href="#updatelimit">updatelimit</a> - <comment type="action" name="updatelimit"></comment></li>
-<li>updatetlos / <a href="#updatetlos">updatetlos</a> - <comment type="action" name="updatetlos"></comment></li>
+<li><strong>addround</strong> / <a href="#addround">addround</a> - <comment type="action" name="addround"></comment></li>
+<li><strong>incprice</strong> / <a href="#incprice">incprice</a> - <comment type="action" name="incprice"></comment></li>
+<li><strong>initrounds</strong> / <a href="#initrounds">initrounds</a> - <comment type="action" name="initrounds"></comment></li>
+<li><strong>initsale</strong> / <a href="#initsale">initsale</a> - <comment type="action" name="initsale"></comment></li>
+<li><strong>migrate</strong> / <a href="#migrate">migrate</a> - <comment type="action" name="migrate"></comment></li>
+<li><strong>newpayment</strong> / <a href="#newpayment">newpayment</a> - <comment type="action" name="newpayment"></comment></li>
+<li><strong>onperiod</strong> / <a href="#onperiod">onperiod</a> - <comment type="action" name="onperiod"></comment></li>
+<li><strong>ontransfer</strong> / <a href="#ontransfer">ontransfer</a> - <comment type="action" name="ontransfer"></comment></li>
+<li><strong>pause</strong> / <a href="#pause">pause</a> - <comment type="action" name="pause"></comment></li>
+<li><strong>priceupdate</strong> / <a href="#priceupdate">priceupdate</a> - <comment type="action" name="priceupdate"></comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li><strong>setflag</strong> / <a href="#setflag">setflag</a> - <comment type="action" name="setflag"></comment></li>
+<li><strong>unpause</strong> / <a href="#unpause">unpause</a> - <comment type="action" name="unpause"></comment></li>
+<li><strong>updatelimit</strong> / <a href="#updatelimit">updatelimit</a> - <comment type="action" name="updatelimit"></comment></li>
+<li><strong>updatetlos</strong> / <a href="#updatetlos">updatetlos</a> - <comment type="action" name="updatetlos"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
@@ -147,7 +160,7 @@
   <script id="template" type="x-tmpl-handlebars">
 # Smartcontract documentation for {{ file }}
 
-<comment type="main">{{comment}}</comment>
+<comment type="main"></comment>
 
 {{#if types}}
 ## Types
@@ -159,19 +172,19 @@
 ## Actions
 
 {{#each actions}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/forum.html
+++ b/docs/forum.html
@@ -10,28 +10,41 @@
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
-</head><body onload="loadUser()">
+<script>
+$(function() {
+  var reader = new commonmark.Parser();
+  var writer = new commonmark.HtmlRenderer();
+
+  $('#target comment').each(function(i, elem) {
+    var parsed = reader.parse($(this).text()); 
+    var result = writer.render(parsed);
+    $(this).html(result);
+  });
+ });
+</script>
+
+</head><body>
   <div id="target"><h1>Smartcontract documentation for forum</h1>
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li>createcomt / <a href="#createcomt">createcomt</a> - <comment type="action" name="createcomt"></comment></li>
-<li>createpost / <a href="#createpost">createpost</a> - <comment type="action" name="createpost"></comment></li>
-<li>deleteactive / <a href="#deleteactive">deleteactive</a> - <comment type="action" name="deleteactive"></comment></li>
-<li>delteactives / <a href="#delteactives">delteactives</a> - <comment type="action" name="delteactives"></comment></li>
-<li>downvotecomt / <a href="#downvotecomt">downvotecomt</a> - <comment type="action" name="downvotecomt"></comment></li>
-<li>downvotepost / <a href="#downvotepost">downvotepost</a> - <comment type="action" name="downvotepost"></comment></li>
-<li>giverep / <a href="#giverep">giverep</a> - <comment type="action" name="giverep"></comment></li>
-<li>givereps / <a href="#givereps">givereps</a> - <comment type="action" name="givereps"></comment></li>
-<li>newday / <a href="#newday">newday</a> - <comment type="action" name="newday"></comment></li>
-<li>onperiod / <a href="#onperiod">onperiod</a> - <comment type="action" name="onperiod"></comment></li>
-<li>rankforum / <a href="#rankforum">rankforum</a> - <comment type="action" name="rankforum"></comment></li>
-<li>rankforums / <a href="#rankforums">rankforums</a> - <comment type="action" name="rankforums"></comment></li>
-<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
-<li>testapoints / <a href="#testapoints">testapoints</a> - <comment type="action" name="testapoints"></comment></li>
-<li>testsize / <a href="#testsize">testsize</a> - <comment type="action" name="testsize"></comment></li>
-<li>upvotecomt / <a href="#upvotecomt">upvotecomt</a> - <comment type="action" name="upvotecomt"></comment></li>
-<li>upvotepost / <a href="#upvotepost">upvotepost</a> - <comment type="action" name="upvotepost"></comment></li>
+<li><strong>createcomt</strong> / <a href="#createcomt">createcomt</a> - <comment type="action" name="createcomt"></comment></li>
+<li><strong>createpost</strong> / <a href="#createpost">createpost</a> - <comment type="action" name="createpost"></comment></li>
+<li><strong>deleteactive</strong> / <a href="#deleteactive">deleteactive</a> - <comment type="action" name="deleteactive"></comment></li>
+<li><strong>delteactives</strong> / <a href="#delteactives">delteactives</a> - <comment type="action" name="delteactives"></comment></li>
+<li><strong>downvotecomt</strong> / <a href="#downvotecomt">downvotecomt</a> - <comment type="action" name="downvotecomt"></comment></li>
+<li><strong>downvotepost</strong> / <a href="#downvotepost">downvotepost</a> - <comment type="action" name="downvotepost"></comment></li>
+<li><strong>giverep</strong> / <a href="#giverep">giverep</a> - <comment type="action" name="giverep"></comment></li>
+<li><strong>givereps</strong> / <a href="#givereps">givereps</a> - <comment type="action" name="givereps"></comment></li>
+<li><strong>newday</strong> / <a href="#newday">newday</a> - <comment type="action" name="newday"></comment></li>
+<li><strong>onperiod</strong> / <a href="#onperiod">onperiod</a> - <comment type="action" name="onperiod"></comment></li>
+<li><strong>rankforum</strong> / <a href="#rankforum">rankforum</a> - <comment type="action" name="rankforum"></comment></li>
+<li><strong>rankforums</strong> / <a href="#rankforums">rankforums</a> - <comment type="action" name="rankforums"></comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li><strong>testapoints</strong> / <a href="#testapoints">testapoints</a> - <comment type="action" name="testapoints"></comment></li>
+<li><strong>testsize</strong> / <a href="#testsize">testsize</a> - <comment type="action" name="testsize"></comment></li>
+<li><strong>upvotecomt</strong> / <a href="#upvotecomt">upvotecomt</a> - <comment type="action" name="upvotecomt"></comment></li>
+<li><strong>upvotepost</strong> / <a href="#upvotepost">upvotepost</a> - <comment type="action" name="upvotepost"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
@@ -187,7 +200,7 @@
   <script id="template" type="x-tmpl-handlebars">
 # Smartcontract documentation for {{ file }}
 
-<comment type="main">{{comment}}</comment>
+<comment type="main"></comment>
 
 {{#if types}}
 ## Types
@@ -199,19 +212,19 @@
 ## Actions
 
 {{#each actions}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/forum.html
+++ b/docs/forum.html
@@ -1,0 +1,227 @@
+<html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+
+</head><body onload="loadUser()">
+  <div id="target"><h1>Smartcontract documentation for forum</h1>
+<p><comment type="main"></comment></p>
+<h2>Actions</h2>
+<ul>
+<li>createcomt / <a href="#createcomt">createcomt</a> - <comment type="action" name="createcomt"></comment></li>
+<li>createpost / <a href="#createpost">createpost</a> - <comment type="action" name="createpost"></comment></li>
+<li>deleteactive / <a href="#deleteactive">deleteactive</a> - <comment type="action" name="deleteactive"></comment></li>
+<li>delteactives / <a href="#delteactives">delteactives</a> - <comment type="action" name="delteactives"></comment></li>
+<li>downvotecomt / <a href="#downvotecomt">downvotecomt</a> - <comment type="action" name="downvotecomt"></comment></li>
+<li>downvotepost / <a href="#downvotepost">downvotepost</a> - <comment type="action" name="downvotepost"></comment></li>
+<li>giverep / <a href="#giverep">giverep</a> - <comment type="action" name="giverep"></comment></li>
+<li>givereps / <a href="#givereps">givereps</a> - <comment type="action" name="givereps"></comment></li>
+<li>newday / <a href="#newday">newday</a> - <comment type="action" name="newday"></comment></li>
+<li>onperiod / <a href="#onperiod">onperiod</a> - <comment type="action" name="onperiod"></comment></li>
+<li>rankforum / <a href="#rankforum">rankforum</a> - <comment type="action" name="rankforum"></comment></li>
+<li>rankforums / <a href="#rankforums">rankforums</a> - <comment type="action" name="rankforums"></comment></li>
+<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li>testapoints / <a href="#testapoints">testapoints</a> - <comment type="action" name="testapoints"></comment></li>
+<li>testsize / <a href="#testsize">testsize</a> - <comment type="action" name="testsize"></comment></li>
+<li>upvotecomt / <a href="#upvotecomt">upvotecomt</a> - <comment type="action" name="upvotecomt"></comment></li>
+<li>upvotepost / <a href="#upvotepost">upvotepost</a> - <comment type="action" name="upvotepost"></comment></li>
+</ul>
+<h2>Events</h2>
+<h2>Tables</h2>
+<ul>
+<li><strong>actives</strong> / <a href="#active_table">active_table</a> (i64) - <comment type="table" name="actives"></comment></li>
+<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) - <comment type="table" name="config"></comment></li>
+<li><strong>forumrep</strong> / <a href="#forum_rep_table">forum_rep_table</a> (i64) - <comment type="table" name="forumrep"></comment></li>
+<li><strong>operations</strong> / <a href="#operations_table">operations_table</a> (i64) - <comment type="table" name="operations"></comment></li>
+<li><strong>postcomment</strong> / <a href="#postcomment_table">postcomment_table</a> (i64) - <comment type="table" name="postcomment"></comment></li>
+<li><strong>sizes</strong> / <a href="#size_table">size_table</a> (i64) - <comment type="table" name="sizes"></comment></li>
+<li><strong>users</strong> / <a href="#user_table">user_table</a> (i64) - <comment type="table" name="users"></comment></li>
+<li><strong>vote</strong> / <a href="#vote_table">vote_table</a> (i64) - <comment type="table" name="vote"></comment></li>
+<li><strong>votepower</strong> / <a href="#vote_power_table">vote_power_table</a> (i64) - <comment type="table" name="votepower"></comment></li>
+</ul>
+<h2>ABI Extensions</h2>
+<h2>Structs</h2>
+<h3 id="active_table"> active_table </h3>
+<ul>
+<li>account / name</li>
+</ul>
+<h3 id="config_table"> config_table </h3>
+<ul>
+<li>param / name</li>
+<li>value / uint64</li>
+<li>description / string</li>
+<li>impact / name</li>
+</ul>
+<h3 id="createcomt"> createcomt </h3>
+<ul>
+<li>account / name</li>
+<li>post_id / uint64</li>
+<li>backend_id / uint64</li>
+<li>url / string</li>
+<li>body / string</li>
+</ul>
+<h3 id="createpost"> createpost </h3>
+<ul>
+<li>account / name</li>
+<li>backend_id / uint64</li>
+<li>url / string</li>
+<li>body / string</li>
+</ul>
+<h3 id="deleteactive"> deleteactive </h3>
+<ul>
+<li>chunksize / uint64</li>
+</ul>
+<h3 id="delteactives"> delteactives </h3>
+<h3 id="downvotecomt"> downvotecomt </h3>
+<ul>
+<li>account / name</li>
+<li>post_id / uint64</li>
+<li>comment_id / uint64</li>
+</ul>
+<h3 id="downvotepost"> downvotepost </h3>
+<ul>
+<li>account / name</li>
+<li>id / uint64</li>
+</ul>
+<h3 id="forum_rep_table"> forum_rep_table </h3>
+<ul>
+<li>account / name</li>
+<li>reputation / int64</li>
+<li>rank / uint64</li>
+</ul>
+<h3 id="giverep"> giverep </h3>
+<ul>
+<li>start / uint64</li>
+<li>chunksize / uint64</li>
+<li>available_points / uint64</li>
+</ul>
+<h3 id="givereps"> givereps </h3>
+<h3 id="newday"> newday </h3>
+<h3 id="onperiod"> onperiod </h3>
+<h3 id="operations_table"> operations_table </h3>
+<ul>
+<li>operation / name</li>
+<li>contract / name</li>
+<li>period / uint64</li>
+<li>timestamp / uint64</li>
+</ul>
+<h3 id="postcomment_table"> postcomment_table </h3>
+<ul>
+<li>id / uint64</li>
+<li>parent_id / uint64</li>
+<li>backend_id / uint64</li>
+<li>author_name_account / name</li>
+<li>url / string</li>
+<li>body_content / string</li>
+<li>timestamp / uint64</li>
+<li>reputation / int64</li>
+</ul>
+<h3 id="rankforum"> rankforum </h3>
+<ul>
+<li>start / uint64</li>
+<li>chunksize / uint64</li>
+<li>chunk / uint64</li>
+</ul>
+<h3 id="rankforums"> rankforums </h3>
+<h3 id="reset"> reset </h3>
+<h3 id="size_table"> size_table </h3>
+<ul>
+<li>id / name</li>
+<li>size / uint64</li>
+</ul>
+<h3 id="testapoints"> testapoints </h3>
+<h3 id="testsize"> testsize </h3>
+<ul>
+<li>id / name</li>
+<li>size / uint64</li>
+</ul>
+<h3 id="upvotecomt"> upvotecomt </h3>
+<ul>
+<li>account / name</li>
+<li>post_id / uint64</li>
+<li>comment_id / uint64</li>
+</ul>
+<h3 id="upvotepost"> upvotepost </h3>
+<ul>
+<li>account / name</li>
+<li>id / uint64</li>
+</ul>
+<h3 id="user_table"> user_table </h3>
+<ul>
+<li>account / name</li>
+<li>status / name</li>
+<li>type / name</li>
+<li>nickname / string</li>
+<li>image / string</li>
+<li>story / string</li>
+<li>roles / string</li>
+<li>skills / string</li>
+<li>interests / string</li>
+<li>reputation / uint64</li>
+<li>timestamp / uint64</li>
+</ul>
+<h3 id="vote_power_table"> vote_power_table </h3>
+<ul>
+<li>account / name</li>
+<li>num_votes / uint32</li>
+<li>points_left / int64</li>
+<li>max_points / int64</li>
+</ul>
+<h3 id="vote_table"> vote_table </h3>
+<ul>
+<li>account / name</li>
+<li>timestamp / uint64</li>
+<li>author / name</li>
+<li>post_id / uint64</li>
+<li>comment_id / uint64</li>
+<li>points / int64</li>
+</ul>
+</div>
+  <script id="template" type="x-tmpl-handlebars">
+# Smartcontract documentation for {{ file }}
+
+<comment type="main">{{comment}}</comment>
+
+{{#if types}}
+## Types
+{{/if}}
+{{#each types}}
+  {{ name }}
+{{/each}}
+
+## Actions
+
+{{#each actions}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Events
+
+{{#each events}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Tables
+
+{{#each tables}}
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## ABI Extensions
+
+{{#each abi_extensions}}
+  - {{ name }}
+{{/each}}
+
+## Structs
+
+{{#each structs}}
+<h3 id={{ name }}> {{ name }} {{#if base}}( {{base}} ){{/if}}</h3>
+  
+  {{#each fields}}
+  - {{ name }} / {{ type }}
+  {{/each}}
+{{/each}}
+
+  </script>
+
+</body></html>

--- a/docs/forum.html
+++ b/docs/forum.html
@@ -1,6 +1,14 @@
 <html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+<!-- Latest compiled and minified CSS -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
+
+<!-- Optional theme -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap-theme.min.css" integrity="sha384-6pzBo3FDv/PJ8r2KRkGHifhEocL+1X2rVCTTkUfGk7/0pbek5mMa1upzvWbrUbOZ" crossorigin="anonymous">
+
+<!-- Latest compiled and minified JavaScript -->
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
 </head><body onload="loadUser()">
   <div id="target"><h1>Smartcontract documentation for forum</h1>

--- a/docs/forum.html
+++ b/docs/forum.html
@@ -28,36 +28,36 @@ $(function() {
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li><strong>createcomt</strong> / <a href="#createcomt">createcomt</a> - <comment type="action" name="createcomt"></comment></li>
-<li><strong>createpost</strong> / <a href="#createpost">createpost</a> - <comment type="action" name="createpost"></comment></li>
-<li><strong>deleteactive</strong> / <a href="#deleteactive">deleteactive</a> - <comment type="action" name="deleteactive"></comment></li>
-<li><strong>delteactives</strong> / <a href="#delteactives">delteactives</a> - <comment type="action" name="delteactives"></comment></li>
-<li><strong>downvotecomt</strong> / <a href="#downvotecomt">downvotecomt</a> - <comment type="action" name="downvotecomt"></comment></li>
-<li><strong>downvotepost</strong> / <a href="#downvotepost">downvotepost</a> - <comment type="action" name="downvotepost"></comment></li>
-<li><strong>giverep</strong> / <a href="#giverep">giverep</a> - <comment type="action" name="giverep"></comment></li>
-<li><strong>givereps</strong> / <a href="#givereps">givereps</a> - <comment type="action" name="givereps"></comment></li>
-<li><strong>newday</strong> / <a href="#newday">newday</a> - <comment type="action" name="newday"></comment></li>
-<li><strong>onperiod</strong> / <a href="#onperiod">onperiod</a> - <comment type="action" name="onperiod"></comment></li>
-<li><strong>rankforum</strong> / <a href="#rankforum">rankforum</a> - <comment type="action" name="rankforum"></comment></li>
-<li><strong>rankforums</strong> / <a href="#rankforums">rankforums</a> - <comment type="action" name="rankforums"></comment></li>
-<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
-<li><strong>testapoints</strong> / <a href="#testapoints">testapoints</a> - <comment type="action" name="testapoints"></comment></li>
-<li><strong>testsize</strong> / <a href="#testsize">testsize</a> - <comment type="action" name="testsize"></comment></li>
-<li><strong>upvotecomt</strong> / <a href="#upvotecomt">upvotecomt</a> - <comment type="action" name="upvotecomt"></comment></li>
-<li><strong>upvotepost</strong> / <a href="#upvotepost">upvotepost</a> - <comment type="action" name="upvotepost"></comment></li>
+<li><strong>createcomt</strong> / <a href="#createcomt">createcomt</a> <comment type="action" name="createcomt"></comment></li>
+<li><strong>createpost</strong> / <a href="#createpost">createpost</a> <comment type="action" name="createpost"></comment></li>
+<li><strong>deleteactive</strong> / <a href="#deleteactive">deleteactive</a> <comment type="action" name="deleteactive"></comment></li>
+<li><strong>delteactives</strong> / <a href="#delteactives">delteactives</a> <comment type="action" name="delteactives"></comment></li>
+<li><strong>downvotecomt</strong> / <a href="#downvotecomt">downvotecomt</a> <comment type="action" name="downvotecomt"></comment></li>
+<li><strong>downvotepost</strong> / <a href="#downvotepost">downvotepost</a> <comment type="action" name="downvotepost"></comment></li>
+<li><strong>giverep</strong> / <a href="#giverep">giverep</a> <comment type="action" name="giverep"></comment></li>
+<li><strong>givereps</strong> / <a href="#givereps">givereps</a> <comment type="action" name="givereps"></comment></li>
+<li><strong>newday</strong> / <a href="#newday">newday</a> <comment type="action" name="newday"></comment></li>
+<li><strong>onperiod</strong> / <a href="#onperiod">onperiod</a> <comment type="action" name="onperiod"></comment></li>
+<li><strong>rankforum</strong> / <a href="#rankforum">rankforum</a> <comment type="action" name="rankforum"></comment></li>
+<li><strong>rankforums</strong> / <a href="#rankforums">rankforums</a> <comment type="action" name="rankforums"></comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> <comment type="action" name="reset"></comment></li>
+<li><strong>testapoints</strong> / <a href="#testapoints">testapoints</a> <comment type="action" name="testapoints"></comment></li>
+<li><strong>testsize</strong> / <a href="#testsize">testsize</a> <comment type="action" name="testsize"></comment></li>
+<li><strong>upvotecomt</strong> / <a href="#upvotecomt">upvotecomt</a> <comment type="action" name="upvotecomt"></comment></li>
+<li><strong>upvotepost</strong> / <a href="#upvotepost">upvotepost</a> <comment type="action" name="upvotepost"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
 <ul>
-<li><strong>actives</strong> / <a href="#active_table">active_table</a> (i64) - <comment type="table" name="actives"></comment></li>
-<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) - <comment type="table" name="config"></comment></li>
-<li><strong>forumrep</strong> / <a href="#forum_rep_table">forum_rep_table</a> (i64) - <comment type="table" name="forumrep"></comment></li>
-<li><strong>operations</strong> / <a href="#operations_table">operations_table</a> (i64) - <comment type="table" name="operations"></comment></li>
-<li><strong>postcomment</strong> / <a href="#postcomment_table">postcomment_table</a> (i64) - <comment type="table" name="postcomment"></comment></li>
-<li><strong>sizes</strong> / <a href="#size_table">size_table</a> (i64) - <comment type="table" name="sizes"></comment></li>
-<li><strong>users</strong> / <a href="#user_table">user_table</a> (i64) - <comment type="table" name="users"></comment></li>
-<li><strong>vote</strong> / <a href="#vote_table">vote_table</a> (i64) - <comment type="table" name="vote"></comment></li>
-<li><strong>votepower</strong> / <a href="#vote_power_table">vote_power_table</a> (i64) - <comment type="table" name="votepower"></comment></li>
+<li><strong>actives</strong> / <a href="#active_table">active_table</a> (i64) <comment type="table" name="actives"></comment></li>
+<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) <comment type="table" name="config"></comment></li>
+<li><strong>forumrep</strong> / <a href="#forum_rep_table">forum_rep_table</a> (i64) <comment type="table" name="forumrep"></comment></li>
+<li><strong>operations</strong> / <a href="#operations_table">operations_table</a> (i64) <comment type="table" name="operations"></comment></li>
+<li><strong>postcomment</strong> / <a href="#postcomment_table">postcomment_table</a> (i64) <comment type="table" name="postcomment"></comment></li>
+<li><strong>sizes</strong> / <a href="#size_table">size_table</a> (i64) <comment type="table" name="sizes"></comment></li>
+<li><strong>users</strong> / <a href="#user_table">user_table</a> (i64) <comment type="table" name="users"></comment></li>
+<li><strong>vote</strong> / <a href="#vote_table">vote_table</a> (i64) <comment type="table" name="vote"></comment></li>
+<li><strong>votepower</strong> / <a href="#vote_power_table">vote_power_table</a> (i64) <comment type="table" name="votepower"></comment></li>
 </ul>
 <h2>ABI Extensions</h2>
 <h2>Structs</h2>
@@ -212,19 +212,19 @@ $(function() {
 ## Actions
 
 {{#each actions}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/harvest.html
+++ b/docs/harvest.html
@@ -10,37 +10,50 @@
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
-</head><body onload="loadUser()">
+<script>
+$(function() {
+  var reader = new commonmark.Parser();
+  var writer = new commonmark.HtmlRenderer();
+
+  $('#target comment').each(function(i, elem) {
+    var parsed = reader.parse($(this).text()); 
+    var result = writer.render(parsed);
+    $(this).html(result);
+  });
+ });
+</script>
+
+</head><body>
   <div id="target"><h1>Smartcontract documentation for harvest</h1>
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li>calccs / <a href="#calccs">calccs</a> - <comment type="action" name="calccs"></comment></li>
-<li>calccss / <a href="#calccss">calccss</a> - <comment type="action" name="calccss"></comment></li>
-<li>calctotal / <a href="#calctotal">calctotal</a> - <comment type="action" name="calctotal"></comment></li>
-<li>calctrxpt / <a href="#calctrxpt">calctrxpt</a> - <comment type="action" name="calctrxpt"></comment></li>
-<li>calctrxpts / <a href="#calctrxpts">calctrxpts</a> - <comment type="action" name="calctrxpts"></comment></li>
-<li>cancelrefund / <a href="#cancelrefund">cancelrefund</a> - <comment type="action" name="cancelrefund"></comment></li>
-<li>claimrefund / <a href="#claimrefund">claimrefund</a> - <comment type="action" name="claimrefund"></comment></li>
-<li>payforcpu / <a href="#payforcpu">payforcpu</a> - <comment type="action" name="payforcpu"></comment></li>
-<li>plant / <a href="#plant">plant</a> - <comment type="action" name="plant"></comment></li>
-<li>rankcs / <a href="#rankcs">rankcs</a> - <comment type="action" name="rankcs"></comment></li>
-<li>rankcss / <a href="#rankcss">rankcss</a> - <comment type="action" name="rankcss"></comment></li>
-<li>rankorgtxs / <a href="#rankorgtxs">rankorgtxs</a> - <comment type="action" name="rankorgtxs"></comment></li>
-<li>rankplanted / <a href="#rankplanted">rankplanted</a> - <comment type="action" name="rankplanted"></comment></li>
-<li>rankplanteds / <a href="#rankplanteds">rankplanteds</a> - <comment type="action" name="rankplanteds"></comment></li>
-<li>ranktx / <a href="#ranktx">ranktx</a> - <comment type="action" name="ranktx"></comment></li>
-<li>ranktxs / <a href="#ranktxs">ranktxs</a> - <comment type="action" name="ranktxs"></comment></li>
-<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
-<li>runharvest / <a href="#runharvest">runharvest</a> - <comment type="action" name="runharvest"></comment></li>
-<li>setorgtxpt / <a href="#setorgtxpt">setorgtxpt</a> - <comment type="action" name="setorgtxpt"></comment></li>
-<li>sow / <a href="#sow">sow</a> - <comment type="action" name="sow"></comment></li>
-<li>testclaim / <a href="#testclaim">testclaim</a> - <comment type="action" name="testclaim"></comment></li>
-<li>testupdatecs / <a href="#testupdatecs">testupdatecs</a> - <comment type="action" name="testupdatecs"></comment></li>
-<li>unplant / <a href="#unplant">unplant</a> - <comment type="action" name="unplant"></comment></li>
-<li>updatecs / <a href="#updatecs">updatecs</a> - <comment type="action" name="updatecs"></comment></li>
-<li>updatetxpt / <a href="#updatetxpt">updatetxpt</a> - <comment type="action" name="updatetxpt"></comment></li>
-<li>updtotal / <a href="#updtotal">updtotal</a> - <comment type="action" name="updtotal"></comment></li>
+<li><strong>calccs</strong> / <a href="#calccs">calccs</a> - <comment type="action" name="calccs"></comment></li>
+<li><strong>calccss</strong> / <a href="#calccss">calccss</a> - <comment type="action" name="calccss"></comment></li>
+<li><strong>calctotal</strong> / <a href="#calctotal">calctotal</a> - <comment type="action" name="calctotal"></comment></li>
+<li><strong>calctrxpt</strong> / <a href="#calctrxpt">calctrxpt</a> - <comment type="action" name="calctrxpt"></comment></li>
+<li><strong>calctrxpts</strong> / <a href="#calctrxpts">calctrxpts</a> - <comment type="action" name="calctrxpts"></comment></li>
+<li><strong>cancelrefund</strong> / <a href="#cancelrefund">cancelrefund</a> - <comment type="action" name="cancelrefund"></comment></li>
+<li><strong>claimrefund</strong> / <a href="#claimrefund">claimrefund</a> - <comment type="action" name="claimrefund"></comment></li>
+<li><strong>payforcpu</strong> / <a href="#payforcpu">payforcpu</a> - <comment type="action" name="payforcpu"></comment></li>
+<li><strong>plant</strong> / <a href="#plant">plant</a> - <comment type="action" name="plant"></comment></li>
+<li><strong>rankcs</strong> / <a href="#rankcs">rankcs</a> - <comment type="action" name="rankcs"></comment></li>
+<li><strong>rankcss</strong> / <a href="#rankcss">rankcss</a> - <comment type="action" name="rankcss"></comment></li>
+<li><strong>rankorgtxs</strong> / <a href="#rankorgtxs">rankorgtxs</a> - <comment type="action" name="rankorgtxs"></comment></li>
+<li><strong>rankplanted</strong> / <a href="#rankplanted">rankplanted</a> - <comment type="action" name="rankplanted"></comment></li>
+<li><strong>rankplanteds</strong> / <a href="#rankplanteds">rankplanteds</a> - <comment type="action" name="rankplanteds"></comment></li>
+<li><strong>ranktx</strong> / <a href="#ranktx">ranktx</a> - <comment type="action" name="ranktx"></comment></li>
+<li><strong>ranktxs</strong> / <a href="#ranktxs">ranktxs</a> - <comment type="action" name="ranktxs"></comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li><strong>runharvest</strong> / <a href="#runharvest">runharvest</a> - <comment type="action" name="runharvest"></comment></li>
+<li><strong>setorgtxpt</strong> / <a href="#setorgtxpt">setorgtxpt</a> - <comment type="action" name="setorgtxpt"></comment></li>
+<li><strong>sow</strong> / <a href="#sow">sow</a> - <comment type="action" name="sow"></comment></li>
+<li><strong>testclaim</strong> / <a href="#testclaim">testclaim</a> - <comment type="action" name="testclaim"></comment></li>
+<li><strong>testupdatecs</strong> / <a href="#testupdatecs">testupdatecs</a> - <comment type="action" name="testupdatecs"></comment></li>
+<li><strong>unplant</strong> / <a href="#unplant">unplant</a> - <comment type="action" name="unplant"></comment></li>
+<li><strong>updatecs</strong> / <a href="#updatecs">updatecs</a> - <comment type="action" name="updatecs"></comment></li>
+<li><strong>updatetxpt</strong> / <a href="#updatetxpt">updatetxpt</a> - <comment type="action" name="updatetxpt"></comment></li>
+<li><strong>updtotal</strong> / <a href="#updtotal">updtotal</a> - <comment type="action" name="updtotal"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
@@ -262,7 +275,7 @@
   <script id="template" type="x-tmpl-handlebars">
 # Smartcontract documentation for {{ file }}
 
-<comment type="main">{{comment}}</comment>
+<comment type="main"></comment>
 
 {{#if types}}
 ## Types
@@ -274,19 +287,19 @@
 ## Actions
 
 {{#each actions}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/harvest.html
+++ b/docs/harvest.html
@@ -28,49 +28,49 @@ $(function() {
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li><strong>calccs</strong> / <a href="#calccs">calccs</a> - <comment type="action" name="calccs"></comment></li>
-<li><strong>calccss</strong> / <a href="#calccss">calccss</a> - <comment type="action" name="calccss"></comment></li>
-<li><strong>calctotal</strong> / <a href="#calctotal">calctotal</a> - <comment type="action" name="calctotal"></comment></li>
-<li><strong>calctrxpt</strong> / <a href="#calctrxpt">calctrxpt</a> - <comment type="action" name="calctrxpt"></comment></li>
-<li><strong>calctrxpts</strong> / <a href="#calctrxpts">calctrxpts</a> - <comment type="action" name="calctrxpts"></comment></li>
-<li><strong>cancelrefund</strong> / <a href="#cancelrefund">cancelrefund</a> - <comment type="action" name="cancelrefund"></comment></li>
-<li><strong>claimrefund</strong> / <a href="#claimrefund">claimrefund</a> - <comment type="action" name="claimrefund"></comment></li>
-<li><strong>payforcpu</strong> / <a href="#payforcpu">payforcpu</a> - <comment type="action" name="payforcpu"></comment></li>
-<li><strong>plant</strong> / <a href="#plant">plant</a> - <comment type="action" name="plant"></comment></li>
-<li><strong>rankcs</strong> / <a href="#rankcs">rankcs</a> - <comment type="action" name="rankcs"></comment></li>
-<li><strong>rankcss</strong> / <a href="#rankcss">rankcss</a> - <comment type="action" name="rankcss"></comment></li>
-<li><strong>rankorgtxs</strong> / <a href="#rankorgtxs">rankorgtxs</a> - <comment type="action" name="rankorgtxs"></comment></li>
-<li><strong>rankplanted</strong> / <a href="#rankplanted">rankplanted</a> - <comment type="action" name="rankplanted"></comment></li>
-<li><strong>rankplanteds</strong> / <a href="#rankplanteds">rankplanteds</a> - <comment type="action" name="rankplanteds"></comment></li>
-<li><strong>ranktx</strong> / <a href="#ranktx">ranktx</a> - <comment type="action" name="ranktx"></comment></li>
-<li><strong>ranktxs</strong> / <a href="#ranktxs">ranktxs</a> - <comment type="action" name="ranktxs"></comment></li>
-<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
-<li><strong>runharvest</strong> / <a href="#runharvest">runharvest</a> - <comment type="action" name="runharvest"></comment></li>
-<li><strong>setorgtxpt</strong> / <a href="#setorgtxpt">setorgtxpt</a> - <comment type="action" name="setorgtxpt"></comment></li>
-<li><strong>sow</strong> / <a href="#sow">sow</a> - <comment type="action" name="sow"></comment></li>
-<li><strong>testclaim</strong> / <a href="#testclaim">testclaim</a> - <comment type="action" name="testclaim"></comment></li>
-<li><strong>testupdatecs</strong> / <a href="#testupdatecs">testupdatecs</a> - <comment type="action" name="testupdatecs"></comment></li>
-<li><strong>unplant</strong> / <a href="#unplant">unplant</a> - <comment type="action" name="unplant"></comment></li>
-<li><strong>updatecs</strong> / <a href="#updatecs">updatecs</a> - <comment type="action" name="updatecs"></comment></li>
-<li><strong>updatetxpt</strong> / <a href="#updatetxpt">updatetxpt</a> - <comment type="action" name="updatetxpt"></comment></li>
-<li><strong>updtotal</strong> / <a href="#updtotal">updtotal</a> - <comment type="action" name="updtotal"></comment></li>
+<li><strong>calccs</strong> / <a href="#calccs">calccs</a> <comment type="action" name="calccs"></comment></li>
+<li><strong>calccss</strong> / <a href="#calccss">calccss</a> <comment type="action" name="calccss"></comment></li>
+<li><strong>calctotal</strong> / <a href="#calctotal">calctotal</a> <comment type="action" name="calctotal"></comment></li>
+<li><strong>calctrxpt</strong> / <a href="#calctrxpt">calctrxpt</a> <comment type="action" name="calctrxpt"></comment></li>
+<li><strong>calctrxpts</strong> / <a href="#calctrxpts">calctrxpts</a> <comment type="action" name="calctrxpts"></comment></li>
+<li><strong>cancelrefund</strong> / <a href="#cancelrefund">cancelrefund</a> <comment type="action" name="cancelrefund"></comment></li>
+<li><strong>claimrefund</strong> / <a href="#claimrefund">claimrefund</a> <comment type="action" name="claimrefund"></comment></li>
+<li><strong>payforcpu</strong> / <a href="#payforcpu">payforcpu</a> <comment type="action" name="payforcpu"></comment></li>
+<li><strong>plant</strong> / <a href="#plant">plant</a> <comment type="action" name="plant"></comment></li>
+<li><strong>rankcs</strong> / <a href="#rankcs">rankcs</a> <comment type="action" name="rankcs"></comment></li>
+<li><strong>rankcss</strong> / <a href="#rankcss">rankcss</a> <comment type="action" name="rankcss"></comment></li>
+<li><strong>rankorgtxs</strong> / <a href="#rankorgtxs">rankorgtxs</a> <comment type="action" name="rankorgtxs"></comment></li>
+<li><strong>rankplanted</strong> / <a href="#rankplanted">rankplanted</a> <comment type="action" name="rankplanted"></comment></li>
+<li><strong>rankplanteds</strong> / <a href="#rankplanteds">rankplanteds</a> <comment type="action" name="rankplanteds"></comment></li>
+<li><strong>ranktx</strong> / <a href="#ranktx">ranktx</a> <comment type="action" name="ranktx"></comment></li>
+<li><strong>ranktxs</strong> / <a href="#ranktxs">ranktxs</a> <comment type="action" name="ranktxs"></comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> <comment type="action" name="reset"></comment></li>
+<li><strong>runharvest</strong> / <a href="#runharvest">runharvest</a> <comment type="action" name="runharvest"></comment></li>
+<li><strong>setorgtxpt</strong> / <a href="#setorgtxpt">setorgtxpt</a> <comment type="action" name="setorgtxpt"></comment></li>
+<li><strong>sow</strong> / <a href="#sow">sow</a> <comment type="action" name="sow"></comment></li>
+<li><strong>testclaim</strong> / <a href="#testclaim">testclaim</a> <comment type="action" name="testclaim"></comment></li>
+<li><strong>testupdatecs</strong> / <a href="#testupdatecs">testupdatecs</a> <comment type="action" name="testupdatecs"></comment></li>
+<li><strong>unplant</strong> / <a href="#unplant">unplant</a> <comment type="action" name="unplant"></comment></li>
+<li><strong>updatecs</strong> / <a href="#updatecs">updatecs</a> <comment type="action" name="updatecs"></comment></li>
+<li><strong>updatetxpt</strong> / <a href="#updatetxpt">updatetxpt</a> <comment type="action" name="updatetxpt"></comment></li>
+<li><strong>updtotal</strong> / <a href="#updtotal">updtotal</a> <comment type="action" name="updtotal"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
 <ul>
-<li><strong>balances</strong> / <a href="#balance_table">balance_table</a> (i64) - <comment type="table" name="balances"></comment></li>
-<li><strong>cbs</strong> / <a href="#cbs_table">cbs_table</a> (i64) - <comment type="table" name="cbs"></comment></li>
-<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) - <comment type="table" name="config"></comment></li>
-<li><strong>cspoints</strong> / <a href="#cs_points_table">cs_points_table</a> (i64) - <comment type="table" name="cspoints"></comment></li>
-<li><strong>harvest</strong> / <a href="#harvest_table">harvest_table</a> (i64) - <comment type="table" name="harvest"></comment></li>
-<li><strong>planted</strong> / <a href="#planted_table">planted_table</a> (i64) - <comment type="table" name="planted"></comment></li>
-<li><strong>refunds</strong> / <a href="#refund_table">refund_table</a> (i64) - <comment type="table" name="refunds"></comment></li>
-<li><strong>rep</strong> / <a href="#rep_table">rep_table</a> (i64) - <comment type="table" name="rep"></comment></li>
-<li><strong>sizes</strong> / <a href="#size_table">size_table</a> (i64) - <comment type="table" name="sizes"></comment></li>
-<li><strong>total</strong> / <a href="#total_table">total_table</a> (i64) - <comment type="table" name="total"></comment></li>
-<li><strong>transactions</strong> / <a href="#transaction_table">transaction_table</a> (i64) - <comment type="table" name="transactions"></comment></li>
-<li><strong>txpoints</strong> / <a href="#tx_points_table">tx_points_table</a> (i64) - <comment type="table" name="txpoints"></comment></li>
-<li><strong>users</strong> / <a href="#user_table">user_table</a> (i64) - <comment type="table" name="users"></comment></li>
+<li><strong>balances</strong> / <a href="#balance_table">balance_table</a> (i64) <comment type="table" name="balances"></comment></li>
+<li><strong>cbs</strong> / <a href="#cbs_table">cbs_table</a> (i64) <comment type="table" name="cbs"></comment></li>
+<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) <comment type="table" name="config"></comment></li>
+<li><strong>cspoints</strong> / <a href="#cs_points_table">cs_points_table</a> (i64) <comment type="table" name="cspoints"></comment></li>
+<li><strong>harvest</strong> / <a href="#harvest_table">harvest_table</a> (i64) <comment type="table" name="harvest"></comment></li>
+<li><strong>planted</strong> / <a href="#planted_table">planted_table</a> (i64) <comment type="table" name="planted"></comment></li>
+<li><strong>refunds</strong> / <a href="#refund_table">refund_table</a> (i64) <comment type="table" name="refunds"></comment></li>
+<li><strong>rep</strong> / <a href="#rep_table">rep_table</a> (i64) <comment type="table" name="rep"></comment></li>
+<li><strong>sizes</strong> / <a href="#size_table">size_table</a> (i64) <comment type="table" name="sizes"></comment></li>
+<li><strong>total</strong> / <a href="#total_table">total_table</a> (i64) <comment type="table" name="total"></comment></li>
+<li><strong>transactions</strong> / <a href="#transaction_table">transaction_table</a> (i64) <comment type="table" name="transactions"></comment></li>
+<li><strong>txpoints</strong> / <a href="#tx_points_table">tx_points_table</a> (i64) <comment type="table" name="txpoints"></comment></li>
+<li><strong>users</strong> / <a href="#user_table">user_table</a> (i64) <comment type="table" name="users"></comment></li>
 </ul>
 <h2>ABI Extensions</h2>
 <h2>Structs</h2>
@@ -287,19 +287,19 @@ $(function() {
 ## Actions
 
 {{#each actions}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/harvest.html
+++ b/docs/harvest.html
@@ -1,0 +1,302 @@
+<html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+
+</head><body onload="loadUser()">
+  <div id="target"><h1>Smartcontract documentation for harvest</h1>
+<p><comment type="main"></comment></p>
+<h2>Actions</h2>
+<ul>
+<li>calccs / <a href="#calccs">calccs</a> - <comment type="action" name="calccs"></comment></li>
+<li>calccss / <a href="#calccss">calccss</a> - <comment type="action" name="calccss"></comment></li>
+<li>calctotal / <a href="#calctotal">calctotal</a> - <comment type="action" name="calctotal"></comment></li>
+<li>calctrxpt / <a href="#calctrxpt">calctrxpt</a> - <comment type="action" name="calctrxpt"></comment></li>
+<li>calctrxpts / <a href="#calctrxpts">calctrxpts</a> - <comment type="action" name="calctrxpts"></comment></li>
+<li>cancelrefund / <a href="#cancelrefund">cancelrefund</a> - <comment type="action" name="cancelrefund"></comment></li>
+<li>claimrefund / <a href="#claimrefund">claimrefund</a> - <comment type="action" name="claimrefund"></comment></li>
+<li>payforcpu / <a href="#payforcpu">payforcpu</a> - <comment type="action" name="payforcpu"></comment></li>
+<li>plant / <a href="#plant">plant</a> - <comment type="action" name="plant"></comment></li>
+<li>rankcs / <a href="#rankcs">rankcs</a> - <comment type="action" name="rankcs"></comment></li>
+<li>rankcss / <a href="#rankcss">rankcss</a> - <comment type="action" name="rankcss"></comment></li>
+<li>rankorgtxs / <a href="#rankorgtxs">rankorgtxs</a> - <comment type="action" name="rankorgtxs"></comment></li>
+<li>rankplanted / <a href="#rankplanted">rankplanted</a> - <comment type="action" name="rankplanted"></comment></li>
+<li>rankplanteds / <a href="#rankplanteds">rankplanteds</a> - <comment type="action" name="rankplanteds"></comment></li>
+<li>ranktx / <a href="#ranktx">ranktx</a> - <comment type="action" name="ranktx"></comment></li>
+<li>ranktxs / <a href="#ranktxs">ranktxs</a> - <comment type="action" name="ranktxs"></comment></li>
+<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li>runharvest / <a href="#runharvest">runharvest</a> - <comment type="action" name="runharvest"></comment></li>
+<li>setorgtxpt / <a href="#setorgtxpt">setorgtxpt</a> - <comment type="action" name="setorgtxpt"></comment></li>
+<li>sow / <a href="#sow">sow</a> - <comment type="action" name="sow"></comment></li>
+<li>testclaim / <a href="#testclaim">testclaim</a> - <comment type="action" name="testclaim"></comment></li>
+<li>testupdatecs / <a href="#testupdatecs">testupdatecs</a> - <comment type="action" name="testupdatecs"></comment></li>
+<li>unplant / <a href="#unplant">unplant</a> - <comment type="action" name="unplant"></comment></li>
+<li>updatecs / <a href="#updatecs">updatecs</a> - <comment type="action" name="updatecs"></comment></li>
+<li>updatetxpt / <a href="#updatetxpt">updatetxpt</a> - <comment type="action" name="updatetxpt"></comment></li>
+<li>updtotal / <a href="#updtotal">updtotal</a> - <comment type="action" name="updtotal"></comment></li>
+</ul>
+<h2>Events</h2>
+<h2>Tables</h2>
+<ul>
+<li><strong>balances</strong> / <a href="#balance_table">balance_table</a> (i64) - <comment type="table" name="balances"></comment></li>
+<li><strong>cbs</strong> / <a href="#cbs_table">cbs_table</a> (i64) - <comment type="table" name="cbs"></comment></li>
+<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) - <comment type="table" name="config"></comment></li>
+<li><strong>cspoints</strong> / <a href="#cs_points_table">cs_points_table</a> (i64) - <comment type="table" name="cspoints"></comment></li>
+<li><strong>harvest</strong> / <a href="#harvest_table">harvest_table</a> (i64) - <comment type="table" name="harvest"></comment></li>
+<li><strong>planted</strong> / <a href="#planted_table">planted_table</a> (i64) - <comment type="table" name="planted"></comment></li>
+<li><strong>refunds</strong> / <a href="#refund_table">refund_table</a> (i64) - <comment type="table" name="refunds"></comment></li>
+<li><strong>rep</strong> / <a href="#rep_table">rep_table</a> (i64) - <comment type="table" name="rep"></comment></li>
+<li><strong>sizes</strong> / <a href="#size_table">size_table</a> (i64) - <comment type="table" name="sizes"></comment></li>
+<li><strong>total</strong> / <a href="#total_table">total_table</a> (i64) - <comment type="table" name="total"></comment></li>
+<li><strong>transactions</strong> / <a href="#transaction_table">transaction_table</a> (i64) - <comment type="table" name="transactions"></comment></li>
+<li><strong>txpoints</strong> / <a href="#tx_points_table">tx_points_table</a> (i64) - <comment type="table" name="txpoints"></comment></li>
+<li><strong>users</strong> / <a href="#user_table">user_table</a> (i64) - <comment type="table" name="users"></comment></li>
+</ul>
+<h2>ABI Extensions</h2>
+<h2>Structs</h2>
+<h3 id="balance_table"> balance_table </h3>
+<ul>
+<li>account / name</li>
+<li>planted / asset</li>
+<li>reward / asset</li>
+</ul>
+<h3 id="calccs"> calccs </h3>
+<ul>
+<li>start_val / uint64</li>
+<li>chunk / uint64</li>
+<li>chunksize / uint64</li>
+</ul>
+<h3 id="calccss"> calccss </h3>
+<h3 id="calctotal"> calctotal </h3>
+<ul>
+<li>startval / uint64</li>
+</ul>
+<h3 id="calctrxpt"> calctrxpt </h3>
+<ul>
+<li>start_val / uint64</li>
+<li>chunk / uint64</li>
+<li>chunksize / uint64</li>
+</ul>
+<h3 id="calctrxpts"> calctrxpts </h3>
+<h3 id="cancelrefund"> cancelrefund </h3>
+<ul>
+<li>from / name</li>
+<li>request_id / uint64</li>
+</ul>
+<h3 id="cbs_table"> cbs_table </h3>
+<ul>
+<li>account / name</li>
+<li>community_building_score / uint32</li>
+<li>rank / uint64</li>
+</ul>
+<h3 id="claimrefund"> claimrefund </h3>
+<ul>
+<li>from / name</li>
+<li>request_id / uint64</li>
+</ul>
+<h3 id="config_table"> config_table </h3>
+<ul>
+<li>param / name</li>
+<li>value / uint64</li>
+<li>description / string</li>
+<li>impact / name</li>
+</ul>
+<h3 id="cs_points_table"> cs_points_table </h3>
+<ul>
+<li>account / name</li>
+<li>contribution_points / uint32</li>
+<li>rank / uint64</li>
+</ul>
+<h3 id="harvest_table"> harvest_table </h3>
+<ul>
+<li>account / name</li>
+<li>planted_score / uint64</li>
+<li>planted_timestamp / uint64</li>
+<li>transactions_score / uint64</li>
+<li>tx_timestamp / uint64</li>
+<li>reputation_score / uint64</li>
+<li>rep_timestamp / uint64</li>
+<li>community_building_score / uint64</li>
+<li>community_building_timestamp / uint64</li>
+<li>contribution_score / uint64</li>
+<li>contrib_timestamp / uint64</li>
+</ul>
+<h3 id="payforcpu"> payforcpu </h3>
+<ul>
+<li>account / name</li>
+</ul>
+<h3 id="plant"> plant </h3>
+<ul>
+<li>from / name</li>
+<li>to / name</li>
+<li>quantity / asset</li>
+<li>memo / string</li>
+</ul>
+<h3 id="planted_table"> planted_table </h3>
+<ul>
+<li>account / name</li>
+<li>planted / asset</li>
+<li>rank / uint64</li>
+</ul>
+<h3 id="rankcs"> rankcs </h3>
+<ul>
+<li>start_val / uint64</li>
+<li>chunk / uint64</li>
+<li>chunksize / uint64</li>
+</ul>
+<h3 id="rankcss"> rankcss </h3>
+<h3 id="rankorgtxs"> rankorgtxs </h3>
+<h3 id="rankplanted"> rankplanted </h3>
+<ul>
+<li>start_val / uint128</li>
+<li>chunk / uint64</li>
+<li>chunksize / uint64</li>
+</ul>
+<h3 id="rankplanteds"> rankplanteds </h3>
+<h3 id="ranktx"> ranktx </h3>
+<ul>
+<li>start_val / uint64</li>
+<li>chunk / uint64</li>
+<li>chunksize / uint64</li>
+<li>table / name</li>
+</ul>
+<h3 id="ranktxs"> ranktxs </h3>
+<h3 id="refund_table"> refund_table </h3>
+<ul>
+<li>request_id / uint64</li>
+<li>refund_id / uint64</li>
+<li>account / name</li>
+<li>amount / asset</li>
+<li>weeks_delay / uint32</li>
+<li>request_time / uint32</li>
+</ul>
+<h3 id="rep_table"> rep_table </h3>
+<ul>
+<li>account / name</li>
+<li>rep / uint32</li>
+<li>rank / uint64</li>
+</ul>
+<h3 id="reset"> reset </h3>
+<h3 id="runharvest"> runharvest </h3>
+<h3 id="setorgtxpt"> setorgtxpt </h3>
+<ul>
+<li>organization / name</li>
+<li>tx_points / uint64</li>
+</ul>
+<h3 id="size_table"> size_table </h3>
+<ul>
+<li>id / name</li>
+<li>size / uint64</li>
+</ul>
+<h3 id="sow"> sow </h3>
+<ul>
+<li>from / name</li>
+<li>to / name</li>
+<li>quantity / asset</li>
+</ul>
+<h3 id="testclaim"> testclaim </h3>
+<ul>
+<li>from / name</li>
+<li>request_id / uint64</li>
+<li>sec_rewind / uint64</li>
+</ul>
+<h3 id="testupdatecs"> testupdatecs </h3>
+<ul>
+<li>account / name</li>
+<li>contribution_score / uint64</li>
+</ul>
+<h3 id="total_table"> total_table </h3>
+<ul>
+<li>id / uint64</li>
+<li>total_planted / asset</li>
+</ul>
+<h3 id="transaction_table"> transaction_table </h3>
+<ul>
+<li>id / uint64</li>
+<li>to / name</li>
+<li>quantity / asset</li>
+<li>timestamp / uint64</li>
+</ul>
+<h3 id="tx_points_table"> tx_points_table </h3>
+<ul>
+<li>account / name</li>
+<li>points / uint32</li>
+<li>rank / uint64</li>
+</ul>
+<h3 id="unplant"> unplant </h3>
+<ul>
+<li>from / name</li>
+<li>quantity / asset</li>
+</ul>
+<h3 id="updatecs"> updatecs </h3>
+<ul>
+<li>account / name</li>
+</ul>
+<h3 id="updatetxpt"> updatetxpt </h3>
+<ul>
+<li>account / name</li>
+</ul>
+<h3 id="updtotal"> updtotal </h3>
+<h3 id="user_table"> user_table </h3>
+<ul>
+<li>account / name</li>
+<li>status / name</li>
+<li>type / name</li>
+<li>nickname / string</li>
+<li>image / string</li>
+<li>story / string</li>
+<li>roles / string</li>
+<li>skills / string</li>
+<li>interests / string</li>
+<li>reputation / uint64</li>
+<li>timestamp / uint64</li>
+</ul>
+</div>
+  <script id="template" type="x-tmpl-handlebars">
+# Smartcontract documentation for {{ file }}
+
+<comment type="main">{{comment}}</comment>
+
+{{#if types}}
+## Types
+{{/if}}
+{{#each types}}
+  {{ name }}
+{{/each}}
+
+## Actions
+
+{{#each actions}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Events
+
+{{#each events}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Tables
+
+{{#each tables}}
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## ABI Extensions
+
+{{#each abi_extensions}}
+  - {{ name }}
+{{/each}}
+
+## Structs
+
+{{#each structs}}
+<h3 id={{ name }}> {{ name }} {{#if base}}( {{base}} ){{/if}}</h3>
+  
+  {{#each fields}}
+  - {{ name }} / {{ type }}
+  {{/each}}
+{{/each}}
+
+  </script>
+
+</body></html>

--- a/docs/harvest.html
+++ b/docs/harvest.html
@@ -1,6 +1,14 @@
 <html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+<!-- Latest compiled and minified CSS -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
+
+<!-- Optional theme -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap-theme.min.css" integrity="sha384-6pzBo3FDv/PJ8r2KRkGHifhEocL+1X2rVCTTkUfGk7/0pbek5mMa1upzvWbrUbOZ" crossorigin="anonymous">
+
+<!-- Latest compiled and minified JavaScript -->
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
 </head><body onload="loadUser()">
   <div id="target"><h1>Smartcontract documentation for harvest</h1>

--- a/docs/history.html
+++ b/docs/history.html
@@ -28,28 +28,28 @@ $(function() {
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li><strong>addcitizen</strong> / <a href="#addcitizen">addcitizen</a> - <comment type="action" name="addcitizen"></comment></li>
-<li><strong>addregen</strong> / <a href="#addregen">addregen</a> - <comment type="action" name="addregen"></comment></li>
-<li><strong>addreputable</strong> / <a href="#addreputable">addreputable</a> - <comment type="action" name="addreputable"></comment></li>
-<li><strong>addresident</strong> / <a href="#addresident">addresident</a> - <comment type="action" name="addresident"></comment></li>
-<li><strong>historyentry</strong> / <a href="#historyentry">historyentry</a> - <comment type="action" name="historyentry"></comment></li>
-<li><strong>numtrx</strong> / <a href="#numtrx">numtrx</a> - <comment type="action" name="numtrx"></comment></li>
-<li><strong>orgtxpoints</strong> / <a href="#orgtxpoints">orgtxpoints</a> - <comment type="action" name="orgtxpoints"></comment></li>
-<li><strong>orgtxpt</strong> / <a href="#orgtxpt">orgtxpt</a> - <comment type="action" name="orgtxpt"></comment></li>
-<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
-<li><strong>trxentry</strong> / <a href="#trxentry">trxentry</a> - <comment type="action" name="trxentry"></comment></li>
+<li><strong>addcitizen</strong> / <a href="#addcitizen">addcitizen</a> <comment type="action" name="addcitizen"></comment></li>
+<li><strong>addregen</strong> / <a href="#addregen">addregen</a> <comment type="action" name="addregen"></comment></li>
+<li><strong>addreputable</strong> / <a href="#addreputable">addreputable</a> <comment type="action" name="addreputable"></comment></li>
+<li><strong>addresident</strong> / <a href="#addresident">addresident</a> <comment type="action" name="addresident"></comment></li>
+<li><strong>historyentry</strong> / <a href="#historyentry">historyentry</a> <comment type="action" name="historyentry"></comment></li>
+<li><strong>numtrx</strong> / <a href="#numtrx">numtrx</a> <comment type="action" name="numtrx"></comment></li>
+<li><strong>orgtxpoints</strong> / <a href="#orgtxpoints">orgtxpoints</a> <comment type="action" name="orgtxpoints"></comment></li>
+<li><strong>orgtxpt</strong> / <a href="#orgtxpt">orgtxpt</a> <comment type="action" name="orgtxpt"></comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> <comment type="action" name="reset"></comment></li>
+<li><strong>trxentry</strong> / <a href="#trxentry">trxentry</a> <comment type="action" name="trxentry"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
 <ul>
-<li><strong>citizens</strong> / <a href="#citizen_table">citizen_table</a> (i64) - <comment type="table" name="citizens"></comment></li>
-<li><strong>history</strong> / <a href="#history_table">history_table</a> (i64) - <comment type="table" name="history"></comment></li>
-<li><strong>orgtx</strong> / <a href="#org_tx_table">org_tx_table</a> (i64) - <comment type="table" name="orgtx"></comment></li>
-<li><strong>regens</strong> / <a href="#regenerative_table">regenerative_table</a> (i64) - <comment type="table" name="regens"></comment></li>
-<li><strong>reputables</strong> / <a href="#reputable_table">reputable_table</a> (i64) - <comment type="table" name="reputables"></comment></li>
-<li><strong>residents</strong> / <a href="#resident_table">resident_table</a> (i64) - <comment type="table" name="residents"></comment></li>
-<li><strong>transactions</strong> / <a href="#transaction_table">transaction_table</a> (i64) - <comment type="table" name="transactions"></comment></li>
-<li><strong>users</strong> / <a href="#user_table">user_table</a> (i64) - <comment type="table" name="users"></comment></li>
+<li><strong>citizens</strong> / <a href="#citizen_table">citizen_table</a> (i64) <comment type="table" name="citizens"></comment></li>
+<li><strong>history</strong> / <a href="#history_table">history_table</a> (i64) <comment type="table" name="history"></comment></li>
+<li><strong>orgtx</strong> / <a href="#org_tx_table">org_tx_table</a> (i64) <comment type="table" name="orgtx"></comment></li>
+<li><strong>regens</strong> / <a href="#regenerative_table">regenerative_table</a> (i64) <comment type="table" name="regens"></comment></li>
+<li><strong>reputables</strong> / <a href="#reputable_table">reputable_table</a> (i64) <comment type="table" name="reputables"></comment></li>
+<li><strong>residents</strong> / <a href="#resident_table">resident_table</a> (i64) <comment type="table" name="residents"></comment></li>
+<li><strong>transactions</strong> / <a href="#transaction_table">transaction_table</a> (i64) <comment type="table" name="transactions"></comment></li>
+<li><strong>users</strong> / <a href="#user_table">user_table</a> (i64) <comment type="table" name="users"></comment></li>
 </ul>
 <h2>ABI Extensions</h2>
 <h2>Structs</h2>
@@ -179,19 +179,19 @@ $(function() {
 ## Actions
 
 {{#each actions}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/history.html
+++ b/docs/history.html
@@ -1,6 +1,14 @@
 <html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+<!-- Latest compiled and minified CSS -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
+
+<!-- Optional theme -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap-theme.min.css" integrity="sha384-6pzBo3FDv/PJ8r2KRkGHifhEocL+1X2rVCTTkUfGk7/0pbek5mMa1upzvWbrUbOZ" crossorigin="anonymous">
+
+<!-- Latest compiled and minified JavaScript -->
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
 </head><body onload="loadUser()">
   <div id="target"><h1>Smartcontract documentation for history</h1>

--- a/docs/history.html
+++ b/docs/history.html
@@ -1,0 +1,194 @@
+<html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+
+</head><body onload="loadUser()">
+  <div id="target"><h1>Smartcontract documentation for history</h1>
+<p><comment type="main"></comment></p>
+<h2>Actions</h2>
+<ul>
+<li>addcitizen / <a href="#addcitizen">addcitizen</a> - <comment type="action" name="addcitizen"></comment></li>
+<li>addregen / <a href="#addregen">addregen</a> - <comment type="action" name="addregen"></comment></li>
+<li>addreputable / <a href="#addreputable">addreputable</a> - <comment type="action" name="addreputable"></comment></li>
+<li>addresident / <a href="#addresident">addresident</a> - <comment type="action" name="addresident"></comment></li>
+<li>historyentry / <a href="#historyentry">historyentry</a> - <comment type="action" name="historyentry"></comment></li>
+<li>numtrx / <a href="#numtrx">numtrx</a> - <comment type="action" name="numtrx"></comment></li>
+<li>orgtxpoints / <a href="#orgtxpoints">orgtxpoints</a> - <comment type="action" name="orgtxpoints"></comment></li>
+<li>orgtxpt / <a href="#orgtxpt">orgtxpt</a> - <comment type="action" name="orgtxpt"></comment></li>
+<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li>trxentry / <a href="#trxentry">trxentry</a> - <comment type="action" name="trxentry"></comment></li>
+</ul>
+<h2>Events</h2>
+<h2>Tables</h2>
+<ul>
+<li><strong>citizens</strong> / <a href="#citizen_table">citizen_table</a> (i64) - <comment type="table" name="citizens"></comment></li>
+<li><strong>history</strong> / <a href="#history_table">history_table</a> (i64) - <comment type="table" name="history"></comment></li>
+<li><strong>orgtx</strong> / <a href="#org_tx_table">org_tx_table</a> (i64) - <comment type="table" name="orgtx"></comment></li>
+<li><strong>regens</strong> / <a href="#regenerative_table">regenerative_table</a> (i64) - <comment type="table" name="regens"></comment></li>
+<li><strong>reputables</strong> / <a href="#reputable_table">reputable_table</a> (i64) - <comment type="table" name="reputables"></comment></li>
+<li><strong>residents</strong> / <a href="#resident_table">resident_table</a> (i64) - <comment type="table" name="residents"></comment></li>
+<li><strong>transactions</strong> / <a href="#transaction_table">transaction_table</a> (i64) - <comment type="table" name="transactions"></comment></li>
+<li><strong>users</strong> / <a href="#user_table">user_table</a> (i64) - <comment type="table" name="users"></comment></li>
+</ul>
+<h2>ABI Extensions</h2>
+<h2>Structs</h2>
+<h3 id="addcitizen"> addcitizen </h3>
+<ul>
+<li>account / name</li>
+</ul>
+<h3 id="addregen"> addregen </h3>
+<ul>
+<li>organization / name</li>
+</ul>
+<h3 id="addreputable"> addreputable </h3>
+<ul>
+<li>organization / name</li>
+</ul>
+<h3 id="addresident"> addresident </h3>
+<ul>
+<li>account / name</li>
+</ul>
+<h3 id="citizen_table"> citizen_table </h3>
+<ul>
+<li>id / uint64</li>
+<li>account / name</li>
+<li>timestamp / uint64</li>
+</ul>
+<h3 id="history_table"> history_table </h3>
+<ul>
+<li>history_id / uint64</li>
+<li>account / name</li>
+<li>action / string</li>
+<li>amount / uint64</li>
+<li>meta / string</li>
+<li>timestamp / uint64</li>
+</ul>
+<h3 id="historyentry"> historyentry </h3>
+<ul>
+<li>account / name</li>
+<li>action / string</li>
+<li>amount / uint64</li>
+<li>meta / string</li>
+</ul>
+<h3 id="numtrx"> numtrx </h3>
+<ul>
+<li>account / name</li>
+</ul>
+<h3 id="org_tx_table"> org_tx_table </h3>
+<ul>
+<li>id / uint64</li>
+<li>other / name</li>
+<li>in / bool</li>
+<li>quantity / asset</li>
+<li>timestamp / uint64</li>
+</ul>
+<h3 id="orgtxpoints"> orgtxpoints </h3>
+<ul>
+<li>organization / name</li>
+</ul>
+<h3 id="orgtxpt"> orgtxpt </h3>
+<ul>
+<li>organization / name</li>
+<li>start_val / uint128</li>
+<li>chunksize / uint64</li>
+<li>running_total / uint64</li>
+</ul>
+<h3 id="regenerative_table"> regenerative_table </h3>
+<ul>
+<li>id / uint64</li>
+<li>organization / name</li>
+<li>timestamp / uint64</li>
+</ul>
+<h3 id="reputable_table"> reputable_table </h3>
+<ul>
+<li>id / uint64</li>
+<li>organization / name</li>
+<li>timestamp / uint64</li>
+</ul>
+<h3 id="reset"> reset </h3>
+<ul>
+<li>account / name</li>
+</ul>
+<h3 id="resident_table"> resident_table </h3>
+<ul>
+<li>id / uint64</li>
+<li>account / name</li>
+<li>timestamp / uint64</li>
+</ul>
+<h3 id="transaction_table"> transaction_table </h3>
+<ul>
+<li>id / uint64</li>
+<li>to / name</li>
+<li>quantity / asset</li>
+<li>timestamp / uint64</li>
+</ul>
+<h3 id="trxentry"> trxentry </h3>
+<ul>
+<li>from / name</li>
+<li>to / name</li>
+<li>quantity / asset</li>
+</ul>
+<h3 id="user_table"> user_table </h3>
+<ul>
+<li>account / name</li>
+<li>status / name</li>
+<li>type / name</li>
+<li>nickname / string</li>
+<li>image / string</li>
+<li>story / string</li>
+<li>roles / string</li>
+<li>skills / string</li>
+<li>interests / string</li>
+<li>reputation / uint64</li>
+<li>timestamp / uint64</li>
+</ul>
+</div>
+  <script id="template" type="x-tmpl-handlebars">
+# Smartcontract documentation for {{ file }}
+
+<comment type="main">{{comment}}</comment>
+
+{{#if types}}
+## Types
+{{/if}}
+{{#each types}}
+  {{ name }}
+{{/each}}
+
+## Actions
+
+{{#each actions}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Events
+
+{{#each events}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Tables
+
+{{#each tables}}
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## ABI Extensions
+
+{{#each abi_extensions}}
+  - {{ name }}
+{{/each}}
+
+## Structs
+
+{{#each structs}}
+<h3 id={{ name }}> {{ name }} {{#if base}}( {{base}} ){{/if}}</h3>
+  
+  {{#each fields}}
+  - {{ name }} / {{ type }}
+  {{/each}}
+{{/each}}
+
+  </script>
+
+</body></html>

--- a/docs/history.html
+++ b/docs/history.html
@@ -10,21 +10,34 @@
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
-</head><body onload="loadUser()">
+<script>
+$(function() {
+  var reader = new commonmark.Parser();
+  var writer = new commonmark.HtmlRenderer();
+
+  $('#target comment').each(function(i, elem) {
+    var parsed = reader.parse($(this).text()); 
+    var result = writer.render(parsed);
+    $(this).html(result);
+  });
+ });
+</script>
+
+</head><body>
   <div id="target"><h1>Smartcontract documentation for history</h1>
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li>addcitizen / <a href="#addcitizen">addcitizen</a> - <comment type="action" name="addcitizen"></comment></li>
-<li>addregen / <a href="#addregen">addregen</a> - <comment type="action" name="addregen"></comment></li>
-<li>addreputable / <a href="#addreputable">addreputable</a> - <comment type="action" name="addreputable"></comment></li>
-<li>addresident / <a href="#addresident">addresident</a> - <comment type="action" name="addresident"></comment></li>
-<li>historyentry / <a href="#historyentry">historyentry</a> - <comment type="action" name="historyentry"></comment></li>
-<li>numtrx / <a href="#numtrx">numtrx</a> - <comment type="action" name="numtrx"></comment></li>
-<li>orgtxpoints / <a href="#orgtxpoints">orgtxpoints</a> - <comment type="action" name="orgtxpoints"></comment></li>
-<li>orgtxpt / <a href="#orgtxpt">orgtxpt</a> - <comment type="action" name="orgtxpt"></comment></li>
-<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
-<li>trxentry / <a href="#trxentry">trxentry</a> - <comment type="action" name="trxentry"></comment></li>
+<li><strong>addcitizen</strong> / <a href="#addcitizen">addcitizen</a> - <comment type="action" name="addcitizen"></comment></li>
+<li><strong>addregen</strong> / <a href="#addregen">addregen</a> - <comment type="action" name="addregen"></comment></li>
+<li><strong>addreputable</strong> / <a href="#addreputable">addreputable</a> - <comment type="action" name="addreputable"></comment></li>
+<li><strong>addresident</strong> / <a href="#addresident">addresident</a> - <comment type="action" name="addresident"></comment></li>
+<li><strong>historyentry</strong> / <a href="#historyentry">historyentry</a> - <comment type="action" name="historyentry"></comment></li>
+<li><strong>numtrx</strong> / <a href="#numtrx">numtrx</a> - <comment type="action" name="numtrx"></comment></li>
+<li><strong>orgtxpoints</strong> / <a href="#orgtxpoints">orgtxpoints</a> - <comment type="action" name="orgtxpoints"></comment></li>
+<li><strong>orgtxpt</strong> / <a href="#orgtxpt">orgtxpt</a> - <comment type="action" name="orgtxpt"></comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li><strong>trxentry</strong> / <a href="#trxentry">trxentry</a> - <comment type="action" name="trxentry"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
@@ -154,7 +167,7 @@
   <script id="template" type="x-tmpl-handlebars">
 # Smartcontract documentation for {{ file }}
 
-<comment type="main">{{comment}}</comment>
+<comment type="main"></comment>
 
 {{#if types}}
 ## Types
@@ -166,19 +179,19 @@
 ## Actions
 
 {{#each actions}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/index.html
+++ b/docs/index.html
@@ -32,22 +32,22 @@ Here you will find all about the existing contracts and how you can call them on
 </comment></p>
 <h2>Index</h2>
 <ul>
-<li><strong>accounts</strong> / <a href="./accounts.html">accounts.html</a> - <comment type="contract" name="accounts"></comment></li>
-<li><strong>acctcreator</strong> / <a href="./acctcreator.html">acctcreator.html</a> - <comment type="contract" name="acctcreator"></comment></li>
-<li><strong>bioregion</strong> / <a href="./bioregion.html">bioregion.html</a> - <comment type="contract" name="bioregion"></comment></li>
-<li><strong>escrow</strong> / <a href="./escrow.html">escrow.html</a> - <comment type="contract" name="escrow"></comment></li>
-<li><strong>exchange</strong> / <a href="./exchange.html">exchange.html</a> - <comment type="contract" name="exchange"></comment></li>
-<li><strong>forum</strong> / <a href="./forum.html">forum.html</a> - <comment type="contract" name="forum"></comment></li>
-<li><strong>harvest</strong> / <a href="./harvest.html">harvest.html</a> - <comment type="contract" name="harvest"></comment></li>
-<li><strong>history</strong> / <a href="./history.html">history.html</a> - <comment type="contract" name="history"></comment></li>
-<li><strong>onboarding</strong> / <a href="./onboarding.html">onboarding.html</a> - <comment type="contract" name="onboarding"></comment></li>
-<li><strong>organization</strong> / <a href="./organization.html">organization.html</a> - <comment type="contract" name="organization"></comment></li>
-<li><strong>policy</strong> / <a href="./policy.html">policy.html</a> - <comment type="contract" name="policy"></comment></li>
-<li><strong>proposals</strong> / <a href="./proposals.html">proposals.html</a> - <comment type="contract" name="proposals"></comment></li>
-<li><strong>referendums</strong> / <a href="./referendums.html">referendums.html</a> - <comment type="contract" name="referendums"></comment></li>
-<li><strong>scheduler</strong> / <a href="./scheduler.html">scheduler.html</a> - <comment type="contract" name="scheduler"></comment></li>
-<li><strong>settings</strong> / <a href="./settings.html">settings.html</a> - <comment type="contract" name="settings"></comment></li>
-<li><strong>token</strong> / <a href="./token.html">token.html</a> - <comment type="contract" name="token"></comment></li>
+<li><strong>seeds.accounts</strong> / <a href="./accounts.html">accounts.html</a> <comment type="contract" name="accounts">For most account interactions, including moving from visitor to citizen, vouching, rewards and user ranking.</comment></li>
+<li><strong>seeds.acctcreator</strong> / <a href="./acctcreator.html">acctcreator.html</a> <comment type="contract" name="acctcreator">Focused on TELOS account creation and binding to SEEDS account.</comment></li>
+<li><strong>seeds.bioregion</strong> / <a href="./bioregion.html">bioregion.html</a> <comment type="contract" name="bioregion">Bioregion general rules, from creation, activation and governance.</comment></li>
+<li><strong>seeds.escrow</strong> / <a href="./escrow.html">escrow.html</a> <comment type="contract" name="escrow">Escrow contract to keep SEEDS reserved for the future launch.</comment></li>
+<li><strong>seeds.exchange</strong> / <a href="./exchange.html">exchange.html</a> <comment type="contract" name="exchange">The exchange contract is responsible for selling SEEDS in rounds and keeping reference TLOS/SEEDS pricing.</comment></li>
+<li><strong>seeds.forum</strong> / <a href="./forum.html">forum.html</a> <comment type="contract" name="forum">The forum contract implements a rankable forum used for resident proposal discussions.</comment></li>
+<li><strong>seeds.harvest</strong> / <a href="./harvest.html">harvest.html</a> <comment type="contract" name="harvest">This contract implements the Harvest protocol to distribute SEEDS based on the monetary variation.</comment></li>
+<li><strong>seeds.history</strong> / <a href="./history.html">history.html</a> <comment type="contract" name="history">The history contract keeps all stats and metrics for the evolution of citizens, orgs and transactions, generating data used by other contracts.</comment></li>
+<li><strong>seeds.onboarding</strong> / <a href="./onboarding.html">onboarding.html</a> <comment type="contract" name="onboarding">The onboarding contract is responsible for generating invites for new individual users and also organization.</comment></li>
+<li><strong>seeds.organization</strong> / <a href="./organization.html">organization.html</a> <comment type="contract" name="organization">The main contract used for managing organizations, voting and assets.</comment></li>
+<li><strong>seeds.policy</strong> / <a href="./policy.html">policy.html</a> <comment type="contract" name="policy">A contract for managing SEEDS policy creation and updates.</comment></li>
+<li><strong>seeds.proposals</strong> / <a href="./proposals.html">proposals.html</a> <comment type="contract" name="proposals">The contract for dealing with SEEDS proposals, and voting rules.</comment></li>
+<li><strong>seeds.referendums</strong> / <a href="./referendums.html">referendums.html</a> <comment type="contract" name="referendums">A contract for managing SEEDS constitution referendum creation and updates.</comment></li>
+<li><strong>seeds.scheduler</strong> / <a href="./scheduler.html">scheduler.html</a> <comment type="contract" name="scheduler">A general contract for time based contract execution scheduling based on moon cycles.</comment></li>
+<li><strong>seeds.settings</strong> / <a href="./settings.html">settings.html</a> <comment type="contract" name="settings">The SEEDS settings contract.</comment></li>
+<li><strong>seeds.token</strong> / <a href="./token.html">token.html</a> <comment type="contract" name="token">The main SEEDS token contract.</comment></li>
 </ul>
 </div>
 
@@ -59,7 +59,7 @@ Here you will find all about the existing contracts and how you can call them on
 ## Index
 
 {{#each contracts}}
-- **{{ name }}** / [{{ file }}](./{{ file }}) - <comment type="contract" name="{{name}}"></comment>
-{{/each}}    
+- **{{ contract }}** / [{{ file }}](./{{ file }}) <comment type="contract" name="{{name}}"></comment>
+{{/each}}
 </script>    
 </body></html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -32,21 +32,21 @@ Here you will find all about the existing contracts and how you can call them on
 </comment></p>
 <h2>Index</h2>
 <ul>
-<li><strong>seeds.accounts</strong> / <a href="./accounts.html">accounts.html</a> <comment type="contract" name="accounts">For most account interactions, including moving from visitor to citizen, vouching, rewards and user ranking.</comment></li>
-<li><strong>seeds.acctcreator</strong> / <a href="./acctcreator.html">acctcreator.html</a> <comment type="contract" name="acctcreator">Focused on TELOS account creation and binding to SEEDS account.</comment></li>
-<li><strong>seeds.bioregion</strong> / <a href="./bioregion.html">bioregion.html</a> <comment type="contract" name="bioregion">Bioregion general rules, from creation, activation and governance.</comment></li>
-<li><strong>seeds.escrow</strong> / <a href="./escrow.html">escrow.html</a> <comment type="contract" name="escrow">Escrow contract to keep SEEDS reserved for the future launch.</comment></li>
+<li><strong>seeds.accounts</strong> / <a href="./accounts.html">accounts.html</a> <comment type="contract" name="accounts">For most account interactions, including promoting from visitor to citizen, vouching, rewards and user ranking.</comment></li>
+<li><strong>seeds.acctcreator</strong> / <a href="./acctcreator.html">acctcreator.html</a> <comment type="contract" name="acctcreator">Focused on TELOS account creation and binding to SEEDS account. (Not used right now)</comment></li>
+<li><strong>seeds.bioregion</strong> / <a href="./bioregion.html">bioregion.html</a> <comment type="contract" name="bioregion">Bioregion creation, activation and governance.</comment></li>
+<li><strong>seeds.escrow</strong> / <a href="./escrow.html">escrow.html</a> <comment type="contract" name="escrow">SEEDS escrow contract to keep currency reserves, with time locks and event locks.</comment></li>
 <li><strong>seeds.exchange</strong> / <a href="./exchange.html">exchange.html</a> <comment type="contract" name="exchange">The exchange contract is responsible for selling SEEDS in rounds and keeping reference TLOS/SEEDS pricing.</comment></li>
 <li><strong>seeds.forum</strong> / <a href="./forum.html">forum.html</a> <comment type="contract" name="forum">The forum contract implements a rankable forum used for resident proposal discussions.</comment></li>
 <li><strong>seeds.harvest</strong> / <a href="./harvest.html">harvest.html</a> <comment type="contract" name="harvest">This contract implements the Harvest protocol to distribute SEEDS based on the monetary variation.</comment></li>
 <li><strong>seeds.history</strong> / <a href="./history.html">history.html</a> <comment type="contract" name="history">The history contract keeps all stats and metrics for the evolution of citizens, orgs and transactions, generating data used by other contracts.</comment></li>
-<li><strong>seeds.onboarding</strong> / <a href="./onboarding.html">onboarding.html</a> <comment type="contract" name="onboarding">The onboarding contract is responsible for generating invites for new individual users and also organization.</comment></li>
-<li><strong>seeds.organization</strong> / <a href="./organization.html">organization.html</a> <comment type="contract" name="organization">The main contract used for managing organizations, voting and assets.</comment></li>
+<li><strong>seeds.onboarding</strong> / <a href="./onboarding.html">onboarding.html</a> <comment type="contract" name="onboarding">The onboarding contract is responsible for generating invites for new individual users, bioregions and also organizations.</comment></li>
+<li><strong>seeds.organization</strong> / <a href="./organization.html">organization.html</a> <comment type="contract" name="organization">The main contract used for managing organizations, scores and apps.</comment></li>
 <li><strong>seeds.policy</strong> / <a href="./policy.html">policy.html</a> <comment type="contract" name="policy">A contract for managing SEEDS policy creation and updates.</comment></li>
-<li><strong>seeds.proposals</strong> / <a href="./proposals.html">proposals.html</a> <comment type="contract" name="proposals">The contract for dealing with SEEDS proposals, and voting rules.</comment></li>
+<li><strong>seeds.proposals</strong> / <a href="./proposals.html">proposals.html</a> <comment type="contract" name="proposals">The contract for dealing with SEEDS governance proposals, and voting rules.</comment></li>
 <li><strong>seeds.referendums</strong> / <a href="./referendums.html">referendums.html</a> <comment type="contract" name="referendums">A contract for managing SEEDS constitution referendum creation and updates.</comment></li>
-<li><strong>seeds.scheduler</strong> / <a href="./scheduler.html">scheduler.html</a> <comment type="contract" name="scheduler">A general contract for time based contract execution scheduling based on moon cycles.</comment></li>
-<li><strong>seeds.settings</strong> / <a href="./settings.html">settings.html</a> <comment type="contract" name="settings">The SEEDS settings contract.</comment></li>
+<li><strong>seeds.scheduler</strong> / <a href="./scheduler.html">scheduler.html</a> <comment type="contract" name="scheduler">A general contract for time based contract execution scheduling that can be based on moon cycles.</comment></li>
+<li><strong>seeds.settings</strong> / <a href="./settings.html">settings.html</a> <comment type="contract" name="settings">The SEEDS settings contract with all values that can be changed by referendums.</comment></li>
 <li><strong>seeds.token</strong> / <a href="./token.html">token.html</a> <comment type="contract" name="token">The main SEEDS token contract.</comment></li>
 </ul>
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,65 @@
+<html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
+    
+    <!-- Optional theme -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap-theme.min.css" integrity="sha384-6pzBo3FDv/PJ8r2KRkGHifhEocL+1X2rVCTTkUfGk7/0pbek5mMa1upzvWbrUbOZ" crossorigin="anonymous">
+    
+    <!-- Latest compiled and minified JavaScript -->
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
+    
+    <script>
+    $(function() {
+      var reader = new commonmark.Parser();
+      var writer = new commonmark.HtmlRenderer();
+    
+      $('#target comment').each(function(i, elem) {
+        var parsed = reader.parse($(this).text()); 
+        var result = writer.render(parsed);
+        $(this).html(result);
+      });
+     });
+    </script>
+    
+    </head><body>
+      <div id="target"><h1>SEEDS Smartcontract documentation</h1>
+<p><comment type="main">
+Welcome to the SEEDS smartcontract documentation library.
+
+Here you will find all about the existing contracts and how you can call them on you blockchain application.
+</comment></p>
+<h2>Index</h2>
+<ul>
+<li><strong>accounts</strong> / <a href="./accounts.html">accounts.html</a> - <comment type="contract" name="accounts"></comment></li>
+<li><strong>acctcreator</strong> / <a href="./acctcreator.html">acctcreator.html</a> - <comment type="contract" name="acctcreator"></comment></li>
+<li><strong>bioregion</strong> / <a href="./bioregion.html">bioregion.html</a> - <comment type="contract" name="bioregion"></comment></li>
+<li><strong>escrow</strong> / <a href="./escrow.html">escrow.html</a> - <comment type="contract" name="escrow"></comment></li>
+<li><strong>exchange</strong> / <a href="./exchange.html">exchange.html</a> - <comment type="contract" name="exchange"></comment></li>
+<li><strong>forum</strong> / <a href="./forum.html">forum.html</a> - <comment type="contract" name="forum"></comment></li>
+<li><strong>harvest</strong> / <a href="./harvest.html">harvest.html</a> - <comment type="contract" name="harvest"></comment></li>
+<li><strong>history</strong> / <a href="./history.html">history.html</a> - <comment type="contract" name="history"></comment></li>
+<li><strong>onboarding</strong> / <a href="./onboarding.html">onboarding.html</a> - <comment type="contract" name="onboarding"></comment></li>
+<li><strong>organization</strong> / <a href="./organization.html">organization.html</a> - <comment type="contract" name="organization"></comment></li>
+<li><strong>policy</strong> / <a href="./policy.html">policy.html</a> - <comment type="contract" name="policy"></comment></li>
+<li><strong>proposals</strong> / <a href="./proposals.html">proposals.html</a> - <comment type="contract" name="proposals"></comment></li>
+<li><strong>referendums</strong> / <a href="./referendums.html">referendums.html</a> - <comment type="contract" name="referendums"></comment></li>
+<li><strong>scheduler</strong> / <a href="./scheduler.html">scheduler.html</a> - <comment type="contract" name="scheduler"></comment></li>
+<li><strong>settings</strong> / <a href="./settings.html">settings.html</a> - <comment type="contract" name="settings"></comment></li>
+<li><strong>token</strong> / <a href="./token.html">token.html</a> - <comment type="contract" name="token"></comment></li>
+</ul>
+</div>
+
+<script id="template" type="x-tmpl-handlebars">
+# SEEDS Smartcontract documentation
+
+<comment type="main"></comment>
+
+## Index
+
+{{#each contracts}}
+- **{{ name }}** / [{{ file }}](./{{ file }}) - <comment type="contract" name="{{name}}"></comment>
+{{/each}}    
+</script>    
+</body></html>

--- a/docs/onboarding.html
+++ b/docs/onboarding.html
@@ -1,0 +1,166 @@
+<html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+
+</head><body onload="loadUser()">
+  <div id="target"><h1>Smartcontract documentation for onboarding</h1>
+<p><comment type="main"></comment></p>
+<h2>Actions</h2>
+<ul>
+<li>accept / <a href="#accept">accept</a> - <comment type="action" name="accept"></comment></li>
+<li>acceptexist / <a href="#acceptexist">acceptexist</a> - <comment type="action" name="acceptexist"></comment></li>
+<li>acceptnew / <a href="#acceptnew">acceptnew</a> - <comment type="action" name="acceptnew"></comment></li>
+<li>cancel / <a href="#cancel">cancel</a> - <comment type="action" name="cancel"></comment></li>
+<li>cleanup / <a href="#cleanup">cleanup</a> - <comment type="action" name="cleanup"></comment></li>
+<li>createbio / <a href="#createbio">createbio</a> - <comment type="action" name="createbio"></comment></li>
+<li>deposit / <a href="#deposit">deposit</a> - <comment type="action" name="deposit"></comment></li>
+<li>invite / <a href="#invite">invite</a> - <comment type="action" name="invite"></comment></li>
+<li>invitefor / <a href="#invitefor">invitefor</a> - <comment type="action" name="invitefor"></comment></li>
+<li>onboardorg / <a href="#onboardorg">onboardorg</a> - <comment type="action" name="onboardorg"></comment></li>
+<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+</ul>
+<h2>Events</h2>
+<h2>Tables</h2>
+<ul>
+<li><strong>invites</strong> / <a href="#invite_table">invite_table</a> (i64) - <comment type="table" name="invites"></comment></li>
+<li><strong>referrers</strong> / <a href="#referrer_table">referrer_table</a> (i64) - <comment type="table" name="referrers"></comment></li>
+<li><strong>sponsors</strong> / <a href="#sponsor_table">sponsor_table</a> (i64) - <comment type="table" name="sponsors"></comment></li>
+</ul>
+<h2>ABI Extensions</h2>
+<h2>Structs</h2>
+<h3 id="accept"> accept </h3>
+<ul>
+<li>account / name</li>
+<li>invite_secret / checksum256</li>
+<li>publicKey / string</li>
+</ul>
+<h3 id="acceptexist"> acceptexist </h3>
+<ul>
+<li>account / name</li>
+<li>invite_secret / checksum256</li>
+<li>publicKey / string</li>
+</ul>
+<h3 id="acceptnew"> acceptnew </h3>
+<ul>
+<li>account / name</li>
+<li>invite_secret / checksum256</li>
+<li>publicKey / string</li>
+<li>fullname / string</li>
+</ul>
+<h3 id="cancel"> cancel </h3>
+<ul>
+<li>sponsor / name</li>
+<li>invite_hash / checksum256</li>
+</ul>
+<h3 id="cleanup"> cleanup </h3>
+<ul>
+<li>start_id / uint64</li>
+<li>max_id / uint64</li>
+<li>batch_size / uint64</li>
+</ul>
+<h3 id="createbio"> createbio </h3>
+<ul>
+<li>sponsor / name</li>
+<li>bioregion / name</li>
+<li>publicKey / string</li>
+</ul>
+<h3 id="deposit"> deposit </h3>
+<ul>
+<li>from / name</li>
+<li>to / name</li>
+<li>quantity / asset</li>
+<li>memo / string</li>
+</ul>
+<h3 id="invite"> invite </h3>
+<ul>
+<li>sponsor / name</li>
+<li>transfer_quantity / asset</li>
+<li>sow_quantity / asset</li>
+<li>invite_hash / checksum256</li>
+</ul>
+<h3 id="invite_table"> invite_table </h3>
+<ul>
+<li>invite_id / uint64</li>
+<li>transfer_quantity / asset</li>
+<li>sow_quantity / asset</li>
+<li>sponsor / name</li>
+<li>account / name</li>
+<li>invite_hash / checksum256</li>
+<li>invite_secret / checksum256</li>
+</ul>
+<h3 id="invitefor"> invitefor </h3>
+<ul>
+<li>sponsor / name</li>
+<li>referrer / name</li>
+<li>transfer_quantity / asset</li>
+<li>sow_quantity / asset</li>
+<li>invite_hash / checksum256</li>
+</ul>
+<h3 id="onboardorg"> onboardorg </h3>
+<ul>
+<li>sponsor / name</li>
+<li>account / name</li>
+<li>fullname / string</li>
+<li>publicKey / string</li>
+</ul>
+<h3 id="referrer_table"> referrer_table </h3>
+<ul>
+<li>invite_id / uint64</li>
+<li>referrer / name</li>
+</ul>
+<h3 id="reset"> reset </h3>
+<h3 id="sponsor_table"> sponsor_table </h3>
+<ul>
+<li>account / name</li>
+<li>balance / asset</li>
+</ul>
+</div>
+  <script id="template" type="x-tmpl-handlebars">
+# Smartcontract documentation for {{ file }}
+
+<comment type="main">{{comment}}</comment>
+
+{{#if types}}
+## Types
+{{/if}}
+{{#each types}}
+  {{ name }}
+{{/each}}
+
+## Actions
+
+{{#each actions}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Events
+
+{{#each events}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Tables
+
+{{#each tables}}
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## ABI Extensions
+
+{{#each abi_extensions}}
+  - {{ name }}
+{{/each}}
+
+## Structs
+
+{{#each structs}}
+<h3 id={{ name }}> {{ name }} {{#if base}}( {{base}} ){{/if}}</h3>
+  
+  {{#each fields}}
+  - {{ name }} / {{ type }}
+  {{/each}}
+{{/each}}
+
+  </script>
+
+</body></html>

--- a/docs/onboarding.html
+++ b/docs/onboarding.html
@@ -1,6 +1,14 @@
 <html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+<!-- Latest compiled and minified CSS -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
+
+<!-- Optional theme -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap-theme.min.css" integrity="sha384-6pzBo3FDv/PJ8r2KRkGHifhEocL+1X2rVCTTkUfGk7/0pbek5mMa1upzvWbrUbOZ" crossorigin="anonymous">
+
+<!-- Latest compiled and minified JavaScript -->
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
 </head><body onload="loadUser()">
   <div id="target"><h1>Smartcontract documentation for onboarding</h1>

--- a/docs/onboarding.html
+++ b/docs/onboarding.html
@@ -10,22 +10,42 @@
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
-</head><body onload="loadUser()">
+<script>
+$(function() {
+  var reader = new commonmark.Parser();
+  var writer = new commonmark.HtmlRenderer();
+
+  $('#target comment').each(function(i, elem) {
+    var parsed = reader.parse($(this).text()); 
+    var result = writer.render(parsed);
+    $(this).html(result);
+  });
+ });
+</script>
+
+</head><body>
   <div id="target"><h1>Smartcontract documentation for onboarding</h1>
-<p><comment type="main"></comment></p>
+<p><comment type="main">
+  The onboarding contract is responsible for managing the invitations for ambassadors, bioregions and organizations.
+
+  Here&apos;s the process for ambassadors invitations:
+
+  - call `invite(sponsor, transfer_quantity, sow_quantity, invite_hash)`
+  - the other end calls `accept(account, invite_secret, publicKey)`
+</comment></p>
 <h2>Actions</h2>
 <ul>
-<li>accept / <a href="#accept">accept</a> - <comment type="action" name="accept"></comment></li>
-<li>acceptexist / <a href="#acceptexist">acceptexist</a> - <comment type="action" name="acceptexist"></comment></li>
-<li>acceptnew / <a href="#acceptnew">acceptnew</a> - <comment type="action" name="acceptnew"></comment></li>
-<li>cancel / <a href="#cancel">cancel</a> - <comment type="action" name="cancel"></comment></li>
-<li>cleanup / <a href="#cleanup">cleanup</a> - <comment type="action" name="cleanup"></comment></li>
-<li>createbio / <a href="#createbio">createbio</a> - <comment type="action" name="createbio"></comment></li>
-<li>deposit / <a href="#deposit">deposit</a> - <comment type="action" name="deposit"></comment></li>
-<li>invite / <a href="#invite">invite</a> - <comment type="action" name="invite"></comment></li>
-<li>invitefor / <a href="#invitefor">invitefor</a> - <comment type="action" name="invitefor"></comment></li>
-<li>onboardorg / <a href="#onboardorg">onboardorg</a> - <comment type="action" name="onboardorg"></comment></li>
-<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li><strong>accept</strong> / <a href="#accept">accept</a> - <comment type="action" name="accept">Accepts an invitation based on provided `invite_secret`.</comment></li>
+<li><strong>acceptexist</strong> / <a href="#acceptexist">acceptexist</a> - <comment type="action" name="acceptexist"></comment></li>
+<li><strong>acceptnew</strong> / <a href="#acceptnew">acceptnew</a> - <comment type="action" name="acceptnew"></comment></li>
+<li><strong>cancel</strong> / <a href="#cancel">cancel</a> - <comment type="action" name="cancel">Cancels an invitation based on `invite_hash`.</comment></li>
+<li><strong>cleanup</strong> / <a href="#cleanup">cleanup</a> - <comment type="action" name="cleanup"></comment></li>
+<li><strong>createbio</strong> / <a href="#createbio">createbio</a> - <comment type="action" name="createbio">Creates a new bioregion.</comment></li>
+<li><strong>deposit</strong> / <a href="#deposit">deposit</a> - <comment type="action" name="deposit"></comment></li>
+<li><strong>invite</strong> / <a href="#invite">invite</a> - <comment type="action" name="invite"></comment></li>
+<li><strong>invitefor</strong> / <a href="#invitefor">invitefor</a> - <comment type="action" name="invitefor"></comment></li>
+<li><strong>onboardorg</strong> / <a href="#onboardorg">onboardorg</a> - <comment type="action" name="onboardorg">Onboards a new organization.</comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
@@ -126,7 +146,7 @@
   <script id="template" type="x-tmpl-handlebars">
 # Smartcontract documentation for {{ file }}
 
-<comment type="main">{{comment}}</comment>
+<comment type="main"></comment>
 
 {{#if types}}
 ## Types
@@ -138,19 +158,19 @@
 ## Actions
 
 {{#each actions}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/onboarding.html
+++ b/docs/onboarding.html
@@ -30,29 +30,30 @@ $(function() {
 
   Here&apos;s the process for ambassadors invitations:
 
-  - call `invite(sponsor, transfer_quantity, sow_quantity, invite_hash)`
-  - the other end calls `accept(account, invite_secret, publicKey)`
+  - to initiate an invitation, push action `invite` with paramenters `[sponsor, transfer_quantity, sow_quantity, invite_hash]`
+  - the receiving user then pushes action `accept` with parameters `[account, invite_secret=invite_hash, publicKey]`
+
 </comment></p>
 <h2>Actions</h2>
 <ul>
-<li><strong>accept</strong> / <a href="#accept">accept</a> <comment type="action" name="accept">Accepts an invitation based on provided `invite_secret`.</comment></li>
-<li><strong>acceptexist</strong> / <a href="#acceptexist">acceptexist</a> <comment type="action" name="acceptexist"></comment></li>
-<li><strong>acceptnew</strong> / <a href="#acceptnew">acceptnew</a> <comment type="action" name="acceptnew"></comment></li>
+<li><strong>accept</strong> / <a href="#accept">accept</a> <comment type="action" name="accept">Accepts an invitation invite using already existing account or creating new account, based on provided `invite_secret`.</comment></li>
+<li><strong>acceptexist</strong> / <a href="#acceptexist">acceptexist</a> <comment type="action" name="acceptexist">Accepts an invitation using existing account.</comment></li>
+<li><strong>acceptnew</strong> / <a href="#acceptnew">acceptnew</a> <comment type="action" name="acceptnew">Accepts an invitation creating a new account.</comment></li>
 <li><strong>cancel</strong> / <a href="#cancel">cancel</a> <comment type="action" name="cancel">Cancels an invitation based on `invite_hash`.</comment></li>
-<li><strong>cleanup</strong> / <a href="#cleanup">cleanup</a> <comment type="action" name="cleanup"></comment></li>
+<li><strong>cleanup</strong> / <a href="#cleanup">cleanup</a> <comment type="action" name="cleanup">Cleanup very old invites</comment></li>
 <li><strong>createbio</strong> / <a href="#createbio">createbio</a> <comment type="action" name="createbio">Creates a new bioregion.</comment></li>
-<li><strong>deposit</strong> / <a href="#deposit">deposit</a> <comment type="action" name="deposit"></comment></li>
-<li><strong>invite</strong> / <a href="#invite">invite</a> <comment type="action" name="invite"></comment></li>
-<li><strong>invitefor</strong> / <a href="#invitefor">invitefor</a> <comment type="action" name="invitefor"></comment></li>
+<li><strong>deposit</strong> / <a href="#deposit">deposit</a> <comment type="action" name="deposit">Deposit funds using another account as sponsor account</comment></li>
+<li><strong>invite</strong> / <a href="#invite">invite</a> <comment type="action" name="invite">Creates an invitation, specifying the `sponsor`, `transfer_quantity`, `sow_quantity`(planted amount) and the unique `invite_hash`</comment></li>
+<li><strong>invitefor</strong> / <a href="#invitefor">invitefor</a> <comment type="action" name="invitefor">Invite in the name of the referer account.</comment></li>
 <li><strong>onboardorg</strong> / <a href="#onboardorg">onboardorg</a> <comment type="action" name="onboardorg">Onboards a new organization.</comment></li>
 <li><strong>reset</strong> / <a href="#reset">reset</a> <comment type="action" name="reset"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
 <ul>
-<li><strong>invites</strong> / <a href="#invite_table">invite_table</a> (i64) <comment type="table" name="invites"></comment></li>
-<li><strong>referrers</strong> / <a href="#referrer_table">referrer_table</a> (i64) <comment type="table" name="referrers"></comment></li>
-<li><strong>sponsors</strong> / <a href="#sponsor_table">sponsor_table</a> (i64) <comment type="table" name="sponsors"></comment></li>
+<li><strong>invites</strong> / <a href="#invite_table">invite_table</a> (i64) <comment type="table" name="invites">Table holding the invitations.</comment></li>
+<li><strong>referrers</strong> / <a href="#referrer_table">referrer_table</a> (i64) <comment type="table" name="referrers">Table with the referrer for each invitation.</comment></li>
+<li><strong>sponsors</strong> / <a href="#sponsor_table">sponsor_table</a> (i64) <comment type="table" name="sponsors">Table for storing the deposit sponsors and the balance they commited.</comment></li>
 </ul>
 <h2>ABI Extensions</h2>
 <h2>Structs</h2>

--- a/docs/onboarding.html
+++ b/docs/onboarding.html
@@ -35,24 +35,24 @@ $(function() {
 </comment></p>
 <h2>Actions</h2>
 <ul>
-<li><strong>accept</strong> / <a href="#accept">accept</a> - <comment type="action" name="accept">Accepts an invitation based on provided `invite_secret`.</comment></li>
-<li><strong>acceptexist</strong> / <a href="#acceptexist">acceptexist</a> - <comment type="action" name="acceptexist"></comment></li>
-<li><strong>acceptnew</strong> / <a href="#acceptnew">acceptnew</a> - <comment type="action" name="acceptnew"></comment></li>
-<li><strong>cancel</strong> / <a href="#cancel">cancel</a> - <comment type="action" name="cancel">Cancels an invitation based on `invite_hash`.</comment></li>
-<li><strong>cleanup</strong> / <a href="#cleanup">cleanup</a> - <comment type="action" name="cleanup"></comment></li>
-<li><strong>createbio</strong> / <a href="#createbio">createbio</a> - <comment type="action" name="createbio">Creates a new bioregion.</comment></li>
-<li><strong>deposit</strong> / <a href="#deposit">deposit</a> - <comment type="action" name="deposit"></comment></li>
-<li><strong>invite</strong> / <a href="#invite">invite</a> - <comment type="action" name="invite"></comment></li>
-<li><strong>invitefor</strong> / <a href="#invitefor">invitefor</a> - <comment type="action" name="invitefor"></comment></li>
-<li><strong>onboardorg</strong> / <a href="#onboardorg">onboardorg</a> - <comment type="action" name="onboardorg">Onboards a new organization.</comment></li>
-<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li><strong>accept</strong> / <a href="#accept">accept</a> <comment type="action" name="accept">Accepts an invitation based on provided `invite_secret`.</comment></li>
+<li><strong>acceptexist</strong> / <a href="#acceptexist">acceptexist</a> <comment type="action" name="acceptexist"></comment></li>
+<li><strong>acceptnew</strong> / <a href="#acceptnew">acceptnew</a> <comment type="action" name="acceptnew"></comment></li>
+<li><strong>cancel</strong> / <a href="#cancel">cancel</a> <comment type="action" name="cancel">Cancels an invitation based on `invite_hash`.</comment></li>
+<li><strong>cleanup</strong> / <a href="#cleanup">cleanup</a> <comment type="action" name="cleanup"></comment></li>
+<li><strong>createbio</strong> / <a href="#createbio">createbio</a> <comment type="action" name="createbio">Creates a new bioregion.</comment></li>
+<li><strong>deposit</strong> / <a href="#deposit">deposit</a> <comment type="action" name="deposit"></comment></li>
+<li><strong>invite</strong> / <a href="#invite">invite</a> <comment type="action" name="invite"></comment></li>
+<li><strong>invitefor</strong> / <a href="#invitefor">invitefor</a> <comment type="action" name="invitefor"></comment></li>
+<li><strong>onboardorg</strong> / <a href="#onboardorg">onboardorg</a> <comment type="action" name="onboardorg">Onboards a new organization.</comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> <comment type="action" name="reset"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
 <ul>
-<li><strong>invites</strong> / <a href="#invite_table">invite_table</a> (i64) - <comment type="table" name="invites"></comment></li>
-<li><strong>referrers</strong> / <a href="#referrer_table">referrer_table</a> (i64) - <comment type="table" name="referrers"></comment></li>
-<li><strong>sponsors</strong> / <a href="#sponsor_table">sponsor_table</a> (i64) - <comment type="table" name="sponsors"></comment></li>
+<li><strong>invites</strong> / <a href="#invite_table">invite_table</a> (i64) <comment type="table" name="invites"></comment></li>
+<li><strong>referrers</strong> / <a href="#referrer_table">referrer_table</a> (i64) <comment type="table" name="referrers"></comment></li>
+<li><strong>sponsors</strong> / <a href="#sponsor_table">sponsor_table</a> (i64) <comment type="table" name="sponsors"></comment></li>
 </ul>
 <h2>ABI Extensions</h2>
 <h2>Structs</h2>
@@ -158,19 +158,19 @@ $(function() {
 ## Actions
 
 {{#each actions}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/organization.html
+++ b/docs/organization.html
@@ -25,36 +25,57 @@ $(function() {
 
 </head><body>
   <div id="target"><h1>Smartcontract documentation for organization</h1>
-<p><comment type="main"></comment></p>
+<p><comment type="main">
+Organizations are an essential part of SEEDS, enabling regeneration to take place in the many contexts the new society will need.
+
+They are covered on the SEEDS COnstitution, Part 2, Section 1 **Organization Accounts**.
+
+A new Organization can be created by pushing the `create` action, after doing the `deposit` (from onboarding contract) for the sponsoring amount.
+
+Organizations can get **Reputable** and **Regenerative** status, if they meet the Constitution requisites in terms of
+Contribution Scores and Regen Scores, this is started using the `makeregen` and `makereptable` actions.
+
+The Org owner can add people invoking the `addmember` action, and remove using the `removemember` action.
+
+The owner / manager can also change member roles using the `changerole` action.
+
+Another very important aspect of Organization are their APPs, that can be used to track usage and allow the Org to get more bonus.
+
+To create an APP, the manager / owner calls `registerapp` (and then `banapp` to remove).
+Each daily use by the APP must call the `appuse` action to inform that.
+
+
+
+</comment></p>
 <h2>Actions</h2>
 <ul>
-<li><strong>addcbpoints</strong> / <a href="#addcbpoints">addcbpoints</a> <comment type="action" name="addcbpoints"></comment></li>
-<li><strong>addmember</strong> / <a href="#addmember">addmember</a> <comment type="action" name="addmember"></comment></li>
-<li><strong>addregen</strong> / <a href="#addregen">addregen</a> <comment type="action" name="addregen"></comment></li>
-<li><strong>appuse</strong> / <a href="#appuse">appuse</a> <comment type="action" name="appuse"></comment></li>
-<li><strong>banapp</strong> / <a href="#banapp">banapp</a> <comment type="action" name="banapp"></comment></li>
-<li><strong>changeowner</strong> / <a href="#changeowner">changeowner</a> <comment type="action" name="changeowner"></comment></li>
-<li><strong>changerole</strong> / <a href="#changerole">changerole</a> <comment type="action" name="changerole"></comment></li>
-<li><strong>cleandau</strong> / <a href="#cleandau">cleandau</a> <comment type="action" name="cleandau"></comment></li>
-<li><strong>cleandaus</strong> / <a href="#cleandaus">cleandaus</a> <comment type="action" name="cleandaus"></comment></li>
-<li><strong>create</strong> / <a href="#create">create</a> <comment type="action" name="create"></comment></li>
-<li><strong>destroy</strong> / <a href="#destroy">destroy</a> <comment type="action" name="destroy"></comment></li>
-<li><strong>makeregen</strong> / <a href="#makeregen">makeregen</a> <comment type="action" name="makeregen"></comment></li>
-<li><strong>makereptable</strong> / <a href="#makereptable">makereptable</a> <comment type="action" name="makereptable"></comment></li>
-<li><strong>rankcbsorg</strong> / <a href="#rankcbsorg">rankcbsorg</a> <comment type="action" name="rankcbsorg"></comment></li>
-<li><strong>rankcbsorgs</strong> / <a href="#rankcbsorgs">rankcbsorgs</a> <comment type="action" name="rankcbsorgs"></comment></li>
-<li><strong>rankregen</strong> / <a href="#rankregen">rankregen</a> <comment type="action" name="rankregen"></comment></li>
-<li><strong>rankregens</strong> / <a href="#rankregens">rankregens</a> <comment type="action" name="rankregens"></comment></li>
-<li><strong>refund</strong> / <a href="#refund">refund</a> <comment type="action" name="refund"></comment></li>
-<li><strong>registerapp</strong> / <a href="#registerapp">registerapp</a> <comment type="action" name="registerapp"></comment></li>
-<li><strong>removemember</strong> / <a href="#removemember">removemember</a> <comment type="action" name="removemember"></comment></li>
+<li><strong>addcbpoints</strong> / <a href="#addcbpoints">addcbpoints</a> <comment type="action" name="addcbpoints">Adds Contribution points to the Org score.</comment></li>
+<li><strong>addmember</strong> / <a href="#addmember">addmember</a> <comment type="action" name="addmember">Adds a member to the Organization</comment></li>
+<li><strong>addregen</strong> / <a href="#addregen">addregen</a> <comment type="action" name="addregen">Adds Regenerative score to the Organization.</comment></li>
+<li><strong>appuse</strong> / <a href="#appuse">appuse</a> <comment type="action" name="appuse">Called to indicate daily Org APP usage.</comment></li>
+<li><strong>banapp</strong> / <a href="#banapp">banapp</a> <comment type="action" name="banapp">Bans an APP from the Organization.</comment></li>
+<li><strong>changeowner</strong> / <a href="#changeowner">changeowner</a> <comment type="action" name="changeowner">Let's the Org owner pass it along to some other account.</comment></li>
+<li><strong>changerole</strong> / <a href="#changerole">changerole</a> <comment type="action" name="changerole">Change the role for an Org member.</comment></li>
+<li><strong>cleandau</strong> / <a href="#cleandau">cleandau</a> <comment type="action" name="cleandau"></comment>Cleans the DAU from a batch of Org APPs.</li>
+<li><strong>cleandaus</strong> / <a href="#cleandaus">cleandaus</a> <comment type="action" name="cleandaus">Batch cleans the DAU from all Org apps.</comment></li>
+<li><strong>create</strong> / <a href="#create">create</a> <comment type="action" name="create">Creates a new Organization, proving the sponsor has allocated enough funds</comment></li>
+<li><strong>destroy</strong> / <a href="#destroy">destroy</a> <comment type="action" name="destroy">Destroys an Organization, called by the owner.</comment></li>
+<li><strong>makeregen</strong> / <a href="#makeregen">makeregen</a> <comment type="action" name="makeregen">Converts and Org status to Regenerative if all pre-requisites are met.</comment></li>
+<li><strong>makereptable</strong> / <a href="#makereptable">makereptable</a> <comment type="action" name="makereptable">Converts and Org status to Reputable if all pre-requisites are met.</comment></li>
+<li><strong>rankcbsorg</strong> / <a href="#rankcbsorg">rankcbsorg</a> <comment type="action" name="rankcbsorg">Ranks a batch or Orgs in terms of Contribution score.</comment></li>
+<li><strong>rankcbsorgs</strong> / <a href="#rankcbsorgs">rankcbsorgs</a> <comment type="action" name="rankcbsorgs">Batch ranks all Orgs based on Contribution score.</comment></li>
+<li><strong>rankregen</strong> / <a href="#rankregen">rankregen</a> <comment type="action" name="rankregen">Ranks a batch or Orgs in terms of Regenerative score.</comment></li>
+<li><strong>rankregens</strong> / <a href="#rankregens">rankregens</a> <comment type="action" name="rankregens">Batch ranks all Orgs based on Regenerative score.</comment></li>
+<li><strong>refund</strong> / <a href="#refund">refund</a> <comment type="action" name="refund">Refunds the Org creation fees.</comment></li>
+<li><strong>registerapp</strong> / <a href="#registerapp">registerapp</a> <comment type="action" name="registerapp">Registers a new APP to the Org.</comment></li>
+<li><strong>removemember</strong> / <a href="#removemember">removemember</a> <comment type="action" name="removemember">Removes a member from the Org.</comment></li>
 <li><strong>reset</strong> / <a href="#reset">reset</a> <comment type="action" name="reset"></comment></li>
-<li><strong>scoreorgs</strong> / <a href="#scoreorgs">scoreorgs</a> <comment type="action" name="scoreorgs"></comment></li>
-<li><strong>scoretrxs</strong> / <a href="#scoretrxs">scoretrxs</a> <comment type="action" name="scoretrxs"></comment></li>
-<li><strong>subcbpoints</strong> / <a href="#subcbpoints">subcbpoints</a> <comment type="action" name="subcbpoints"></comment></li>
-<li><strong>subregen</strong> / <a href="#subregen">subregen</a> <comment type="action" name="subregen"></comment></li>
-<li><strong>testregen</strong> / <a href="#testregen">testregen</a> <comment type="action" name="testregen"></comment></li>
-<li><strong>testreptable</strong> / <a href="#testreptable">testreptable</a> <comment type="action" name="testreptable"></comment></li>
+<li><strong>scoreorgs</strong> / <a href="#scoreorgs">scoreorgs</a> <comment type="action" name="scoreorgs">Called periodically to calculate Org scores.</comment></li>
+<li><strong>scoretrxs</strong> / <a href="#scoretrxs">scoretrxs</a> <comment type="action" name="scoretrxs">Called to recalculate Org transaction scores.</comment></li>
+<li><strong>subcbpoints</strong> / <a href="#subcbpoints">subcbpoints</a> <comment type="action" name="subcbpoints">Subtracts Contribution points from the Org score.</comment></li>
+<li><strong>subregen</strong> / <a href="#subregen">subregen</a> <comment type="action" name="subregen">Subtracts Regenerative points from the Org score.</comment></li>
+<li><strong>testregen</strong> / <a href="#testregen">testregen</a> <comment type="action" name="testregen">Converts the org to Regenerative, used only for testing.</comment></li>
+<li><strong>testreptable</strong> / <a href="#testreptable">testreptable</a> <comment type="action" name="testreptable">Converts the org to Reputable, used only for testing.</comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>

--- a/docs/organization.html
+++ b/docs/organization.html
@@ -1,0 +1,322 @@
+<html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+
+</head><body onload="loadUser()">
+  <div id="target"><h1>Smartcontract documentation for organization</h1>
+<p><comment type="main"></comment></p>
+<h2>Actions</h2>
+<ul>
+<li>addcbpoints / <a href="#addcbpoints">addcbpoints</a> - <comment type="action" name="addcbpoints"></comment></li>
+<li>addmember / <a href="#addmember">addmember</a> - <comment type="action" name="addmember"></comment></li>
+<li>addregen / <a href="#addregen">addregen</a> - <comment type="action" name="addregen"></comment></li>
+<li>appuse / <a href="#appuse">appuse</a> - <comment type="action" name="appuse"></comment></li>
+<li>banapp / <a href="#banapp">banapp</a> - <comment type="action" name="banapp"></comment></li>
+<li>changeowner / <a href="#changeowner">changeowner</a> - <comment type="action" name="changeowner"></comment></li>
+<li>changerole / <a href="#changerole">changerole</a> - <comment type="action" name="changerole"></comment></li>
+<li>cleandau / <a href="#cleandau">cleandau</a> - <comment type="action" name="cleandau"></comment></li>
+<li>cleandaus / <a href="#cleandaus">cleandaus</a> - <comment type="action" name="cleandaus"></comment></li>
+<li>create / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
+<li>destroy / <a href="#destroy">destroy</a> - <comment type="action" name="destroy"></comment></li>
+<li>makeregen / <a href="#makeregen">makeregen</a> - <comment type="action" name="makeregen"></comment></li>
+<li>makereptable / <a href="#makereptable">makereptable</a> - <comment type="action" name="makereptable"></comment></li>
+<li>rankcbsorg / <a href="#rankcbsorg">rankcbsorg</a> - <comment type="action" name="rankcbsorg"></comment></li>
+<li>rankcbsorgs / <a href="#rankcbsorgs">rankcbsorgs</a> - <comment type="action" name="rankcbsorgs"></comment></li>
+<li>rankregen / <a href="#rankregen">rankregen</a> - <comment type="action" name="rankregen"></comment></li>
+<li>rankregens / <a href="#rankregens">rankregens</a> - <comment type="action" name="rankregens"></comment></li>
+<li>refund / <a href="#refund">refund</a> - <comment type="action" name="refund"></comment></li>
+<li>registerapp / <a href="#registerapp">registerapp</a> - <comment type="action" name="registerapp"></comment></li>
+<li>removemember / <a href="#removemember">removemember</a> - <comment type="action" name="removemember"></comment></li>
+<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li>scoreorgs / <a href="#scoreorgs">scoreorgs</a> - <comment type="action" name="scoreorgs"></comment></li>
+<li>scoretrxs / <a href="#scoretrxs">scoretrxs</a> - <comment type="action" name="scoretrxs"></comment></li>
+<li>subcbpoints / <a href="#subcbpoints">subcbpoints</a> - <comment type="action" name="subcbpoints"></comment></li>
+<li>subregen / <a href="#subregen">subregen</a> - <comment type="action" name="subregen"></comment></li>
+<li>testregen / <a href="#testregen">testregen</a> - <comment type="action" name="testregen"></comment></li>
+<li>testreptable / <a href="#testreptable">testreptable</a> - <comment type="action" name="testreptable"></comment></li>
+</ul>
+<h2>Events</h2>
+<h2>Tables</h2>
+<ul>
+<li><strong>apps</strong> / <a href="#app_table">app_table</a> (i64) - <comment type="table" name="apps"></comment></li>
+<li><strong>avgvotes</strong> / <a href="#avg_vote_table">avg_vote_table</a> (i64) - <comment type="table" name="avgvotes"></comment></li>
+<li><strong>cbsorgs</strong> / <a href="#cbs_organization_table">cbs_organization_table</a> (i64) - <comment type="table" name="cbsorgs"></comment></li>
+<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) - <comment type="table" name="config"></comment></li>
+<li><strong>dauhistory</strong> / <a href="#dau_history_table">dau_history_table</a> (i64) - <comment type="table" name="dauhistory"></comment></li>
+<li><strong>daus</strong> / <a href="#dau_table">dau_table</a> (i64) - <comment type="table" name="daus"></comment></li>
+<li><strong>members</strong> / <a href="#members_table">members_table</a> (i64) - <comment type="table" name="members"></comment></li>
+<li><strong>organization</strong> / <a href="#organization_table">organization_table</a> (i64) - <comment type="table" name="organization"></comment></li>
+<li><strong>orgtx</strong> / <a href="#org_tx_table">org_tx_table</a> (i64) - <comment type="table" name="orgtx"></comment></li>
+<li><strong>refs</strong> / <a href="#ref_table">ref_table</a> (i64) - <comment type="table" name="refs"></comment></li>
+<li><strong>regenscores</strong> / <a href="#regen_score_table">regen_score_table</a> (i64) - <comment type="table" name="regenscores"></comment></li>
+<li><strong>sizes</strong> / <a href="#size_table">size_table</a> (i64) - <comment type="table" name="sizes"></comment></li>
+<li><strong>sponsors</strong> / <a href="#sponsors_table">sponsors_table</a> (i64) - <comment type="table" name="sponsors"></comment></li>
+<li><strong>votes</strong> / <a href="#vote_table">vote_table</a> (i64) - <comment type="table" name="votes"></comment></li>
+</ul>
+<h2>ABI Extensions</h2>
+<h2>Structs</h2>
+<h3 id="addcbpoints"> addcbpoints </h3>
+<ul>
+<li>organization / name</li>
+<li>cbscore / uint32</li>
+</ul>
+<h3 id="addmember"> addmember </h3>
+<ul>
+<li>organization / name</li>
+<li>owner / name</li>
+<li>account / name</li>
+<li>role / name</li>
+</ul>
+<h3 id="addregen"> addregen </h3>
+<ul>
+<li>organization / name</li>
+<li>account / name</li>
+<li>amount / uint64</li>
+</ul>
+<h3 id="app_table"> app_table </h3>
+<ul>
+<li>app_name / name</li>
+<li>org_name / name</li>
+<li>app_long_name / string</li>
+<li>is_banned / bool</li>
+<li>number_of_uses / uint64</li>
+</ul>
+<h3 id="appuse"> appuse </h3>
+<ul>
+<li>appname / name</li>
+<li>account / name</li>
+</ul>
+<h3 id="avg_vote_table"> avg_vote_table </h3>
+<ul>
+<li>org_name / name</li>
+<li>total_sum / int64</li>
+<li>num_votes / uint64</li>
+<li>average / int64</li>
+</ul>
+<h3 id="banapp"> banapp </h3>
+<ul>
+<li>appname / name</li>
+</ul>
+<h3 id="cbs_organization_table"> cbs_organization_table </h3>
+<ul>
+<li>org_name / name</li>
+<li>community_building_score / uint32</li>
+<li>rank / uint64</li>
+</ul>
+<h3 id="changeowner"> changeowner </h3>
+<ul>
+<li>organization / name</li>
+<li>owner / name</li>
+<li>account / name</li>
+</ul>
+<h3 id="changerole"> changerole </h3>
+<ul>
+<li>organization / name</li>
+<li>owner / name</li>
+<li>account / name</li>
+<li>new_role / name</li>
+</ul>
+<h3 id="cleandau"> cleandau </h3>
+<ul>
+<li>appname / name</li>
+<li>timestamp / uint64</li>
+<li>start / uint64</li>
+</ul>
+<h3 id="cleandaus"> cleandaus </h3>
+<h3 id="config_table"> config_table </h3>
+<ul>
+<li>param / name</li>
+<li>value / uint64</li>
+<li>description / string</li>
+<li>impact / name</li>
+</ul>
+<h3 id="create"> create </h3>
+<ul>
+<li>sponsor / name</li>
+<li>orgaccount / name</li>
+<li>orgfullname / string</li>
+<li>publicKey / string</li>
+</ul>
+<h3 id="dau_history_table"> dau_history_table </h3>
+<ul>
+<li>dau_history_id / uint64</li>
+<li>account / name</li>
+<li>date / uint64</li>
+<li>number_app_uses / uint64</li>
+</ul>
+<h3 id="dau_table"> dau_table </h3>
+<ul>
+<li>account / name</li>
+<li>date / uint64</li>
+<li>number_app_uses / uint64</li>
+</ul>
+<h3 id="destroy"> destroy </h3>
+<ul>
+<li>orgname / name</li>
+<li>sponsor / name</li>
+</ul>
+<h3 id="makeregen"> makeregen </h3>
+<ul>
+<li>organization / name</li>
+</ul>
+<h3 id="makereptable"> makereptable </h3>
+<ul>
+<li>organization / name</li>
+</ul>
+<h3 id="members_table"> members_table </h3>
+<ul>
+<li>account / name</li>
+<li>role / name</li>
+</ul>
+<h3 id="org_tx_table"> org_tx_table </h3>
+<ul>
+<li>id / uint64</li>
+<li>other / name</li>
+<li>in / bool</li>
+<li>quantity / asset</li>
+<li>timestamp / uint64</li>
+</ul>
+<h3 id="organization_table"> organization_table </h3>
+<ul>
+<li>org_name / name</li>
+<li>owner / name</li>
+<li>status / uint64</li>
+<li>regen / int64</li>
+<li>reputation / uint64</li>
+<li>voice / uint64</li>
+<li>planted / asset</li>
+</ul>
+<h3 id="rankcbsorg"> rankcbsorg </h3>
+<ul>
+<li>start / uint64</li>
+<li>chunk / uint64</li>
+<li>chunksize / uint64</li>
+</ul>
+<h3 id="rankcbsorgs"> rankcbsorgs </h3>
+<h3 id="rankregen"> rankregen </h3>
+<ul>
+<li>start / uint64</li>
+<li>chunk / uint64</li>
+<li>chunksize / uint64</li>
+</ul>
+<h3 id="rankregens"> rankregens </h3>
+<h3 id="ref_table"> ref_table </h3>
+<ul>
+<li>referrer / name</li>
+<li>invited / name</li>
+</ul>
+<h3 id="refund"> refund </h3>
+<ul>
+<li>beneficiary / name</li>
+<li>quantity / asset</li>
+</ul>
+<h3 id="regen_score_table"> regen_score_table </h3>
+<ul>
+<li>org_name / name</li>
+<li>regen_avg / int64</li>
+<li>rank / uint64</li>
+</ul>
+<h3 id="registerapp"> registerapp </h3>
+<ul>
+<li>owner / name</li>
+<li>organization / name</li>
+<li>appname / name</li>
+<li>applongname / string</li>
+</ul>
+<h3 id="removemember"> removemember </h3>
+<ul>
+<li>organization / name</li>
+<li>owner / name</li>
+<li>account / name</li>
+</ul>
+<h3 id="reset"> reset </h3>
+<h3 id="scoreorgs"> scoreorgs </h3>
+<ul>
+<li>next / name</li>
+</ul>
+<h3 id="scoretrxs"> scoretrxs </h3>
+<h3 id="size_table"> size_table </h3>
+<ul>
+<li>id / name</li>
+<li>size / uint64</li>
+</ul>
+<h3 id="sponsors_table"> sponsors_table </h3>
+<ul>
+<li>account / name</li>
+<li>balance / asset</li>
+</ul>
+<h3 id="subcbpoints"> subcbpoints </h3>
+<ul>
+<li>organization / name</li>
+<li>cbscore / uint32</li>
+</ul>
+<h3 id="subregen"> subregen </h3>
+<ul>
+<li>organization / name</li>
+<li>account / name</li>
+<li>amount / uint64</li>
+</ul>
+<h3 id="testregen"> testregen </h3>
+<ul>
+<li>organization / name</li>
+</ul>
+<h3 id="testreptable"> testreptable </h3>
+<ul>
+<li>organization / name</li>
+</ul>
+<h3 id="vote_table"> vote_table </h3>
+<ul>
+<li>account / name</li>
+<li>timestamp / uint64</li>
+<li>regen_points / int64</li>
+</ul>
+</div>
+  <script id="template" type="x-tmpl-handlebars">
+# Smartcontract documentation for {{ file }}
+
+<comment type="main">{{comment}}</comment>
+
+{{#if types}}
+## Types
+{{/if}}
+{{#each types}}
+  {{ name }}
+{{/each}}
+
+## Actions
+
+{{#each actions}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Events
+
+{{#each events}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Tables
+
+{{#each tables}}
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## ABI Extensions
+
+{{#each abi_extensions}}
+  - {{ name }}
+{{/each}}
+
+## Structs
+
+{{#each structs}}
+<h3 id={{ name }}> {{ name }} {{#if base}}( {{base}} ){{/if}}</h3>
+  
+  {{#each fields}}
+  - {{ name }} / {{ type }}
+  {{/each}}
+{{/each}}
+
+  </script>
+
+</body></html>

--- a/docs/organization.html
+++ b/docs/organization.html
@@ -1,6 +1,14 @@
 <html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+<!-- Latest compiled and minified CSS -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
+
+<!-- Optional theme -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap-theme.min.css" integrity="sha384-6pzBo3FDv/PJ8r2KRkGHifhEocL+1X2rVCTTkUfGk7/0pbek5mMa1upzvWbrUbOZ" crossorigin="anonymous">
+
+<!-- Latest compiled and minified JavaScript -->
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
 </head><body onload="loadUser()">
   <div id="target"><h1>Smartcontract documentation for organization</h1>

--- a/docs/organization.html
+++ b/docs/organization.html
@@ -10,38 +10,51 @@
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
-</head><body onload="loadUser()">
+<script>
+$(function() {
+  var reader = new commonmark.Parser();
+  var writer = new commonmark.HtmlRenderer();
+
+  $('#target comment').each(function(i, elem) {
+    var parsed = reader.parse($(this).text()); 
+    var result = writer.render(parsed);
+    $(this).html(result);
+  });
+ });
+</script>
+
+</head><body>
   <div id="target"><h1>Smartcontract documentation for organization</h1>
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li>addcbpoints / <a href="#addcbpoints">addcbpoints</a> - <comment type="action" name="addcbpoints"></comment></li>
-<li>addmember / <a href="#addmember">addmember</a> - <comment type="action" name="addmember"></comment></li>
-<li>addregen / <a href="#addregen">addregen</a> - <comment type="action" name="addregen"></comment></li>
-<li>appuse / <a href="#appuse">appuse</a> - <comment type="action" name="appuse"></comment></li>
-<li>banapp / <a href="#banapp">banapp</a> - <comment type="action" name="banapp"></comment></li>
-<li>changeowner / <a href="#changeowner">changeowner</a> - <comment type="action" name="changeowner"></comment></li>
-<li>changerole / <a href="#changerole">changerole</a> - <comment type="action" name="changerole"></comment></li>
-<li>cleandau / <a href="#cleandau">cleandau</a> - <comment type="action" name="cleandau"></comment></li>
-<li>cleandaus / <a href="#cleandaus">cleandaus</a> - <comment type="action" name="cleandaus"></comment></li>
-<li>create / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
-<li>destroy / <a href="#destroy">destroy</a> - <comment type="action" name="destroy"></comment></li>
-<li>makeregen / <a href="#makeregen">makeregen</a> - <comment type="action" name="makeregen"></comment></li>
-<li>makereptable / <a href="#makereptable">makereptable</a> - <comment type="action" name="makereptable"></comment></li>
-<li>rankcbsorg / <a href="#rankcbsorg">rankcbsorg</a> - <comment type="action" name="rankcbsorg"></comment></li>
-<li>rankcbsorgs / <a href="#rankcbsorgs">rankcbsorgs</a> - <comment type="action" name="rankcbsorgs"></comment></li>
-<li>rankregen / <a href="#rankregen">rankregen</a> - <comment type="action" name="rankregen"></comment></li>
-<li>rankregens / <a href="#rankregens">rankregens</a> - <comment type="action" name="rankregens"></comment></li>
-<li>refund / <a href="#refund">refund</a> - <comment type="action" name="refund"></comment></li>
-<li>registerapp / <a href="#registerapp">registerapp</a> - <comment type="action" name="registerapp"></comment></li>
-<li>removemember / <a href="#removemember">removemember</a> - <comment type="action" name="removemember"></comment></li>
-<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
-<li>scoreorgs / <a href="#scoreorgs">scoreorgs</a> - <comment type="action" name="scoreorgs"></comment></li>
-<li>scoretrxs / <a href="#scoretrxs">scoretrxs</a> - <comment type="action" name="scoretrxs"></comment></li>
-<li>subcbpoints / <a href="#subcbpoints">subcbpoints</a> - <comment type="action" name="subcbpoints"></comment></li>
-<li>subregen / <a href="#subregen">subregen</a> - <comment type="action" name="subregen"></comment></li>
-<li>testregen / <a href="#testregen">testregen</a> - <comment type="action" name="testregen"></comment></li>
-<li>testreptable / <a href="#testreptable">testreptable</a> - <comment type="action" name="testreptable"></comment></li>
+<li><strong>addcbpoints</strong> / <a href="#addcbpoints">addcbpoints</a> - <comment type="action" name="addcbpoints"></comment></li>
+<li><strong>addmember</strong> / <a href="#addmember">addmember</a> - <comment type="action" name="addmember"></comment></li>
+<li><strong>addregen</strong> / <a href="#addregen">addregen</a> - <comment type="action" name="addregen"></comment></li>
+<li><strong>appuse</strong> / <a href="#appuse">appuse</a> - <comment type="action" name="appuse"></comment></li>
+<li><strong>banapp</strong> / <a href="#banapp">banapp</a> - <comment type="action" name="banapp"></comment></li>
+<li><strong>changeowner</strong> / <a href="#changeowner">changeowner</a> - <comment type="action" name="changeowner"></comment></li>
+<li><strong>changerole</strong> / <a href="#changerole">changerole</a> - <comment type="action" name="changerole"></comment></li>
+<li><strong>cleandau</strong> / <a href="#cleandau">cleandau</a> - <comment type="action" name="cleandau"></comment></li>
+<li><strong>cleandaus</strong> / <a href="#cleandaus">cleandaus</a> - <comment type="action" name="cleandaus"></comment></li>
+<li><strong>create</strong> / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
+<li><strong>destroy</strong> / <a href="#destroy">destroy</a> - <comment type="action" name="destroy"></comment></li>
+<li><strong>makeregen</strong> / <a href="#makeregen">makeregen</a> - <comment type="action" name="makeregen"></comment></li>
+<li><strong>makereptable</strong> / <a href="#makereptable">makereptable</a> - <comment type="action" name="makereptable"></comment></li>
+<li><strong>rankcbsorg</strong> / <a href="#rankcbsorg">rankcbsorg</a> - <comment type="action" name="rankcbsorg"></comment></li>
+<li><strong>rankcbsorgs</strong> / <a href="#rankcbsorgs">rankcbsorgs</a> - <comment type="action" name="rankcbsorgs"></comment></li>
+<li><strong>rankregen</strong> / <a href="#rankregen">rankregen</a> - <comment type="action" name="rankregen"></comment></li>
+<li><strong>rankregens</strong> / <a href="#rankregens">rankregens</a> - <comment type="action" name="rankregens"></comment></li>
+<li><strong>refund</strong> / <a href="#refund">refund</a> - <comment type="action" name="refund"></comment></li>
+<li><strong>registerapp</strong> / <a href="#registerapp">registerapp</a> - <comment type="action" name="registerapp"></comment></li>
+<li><strong>removemember</strong> / <a href="#removemember">removemember</a> - <comment type="action" name="removemember"></comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li><strong>scoreorgs</strong> / <a href="#scoreorgs">scoreorgs</a> - <comment type="action" name="scoreorgs"></comment></li>
+<li><strong>scoretrxs</strong> / <a href="#scoretrxs">scoretrxs</a> - <comment type="action" name="scoretrxs"></comment></li>
+<li><strong>subcbpoints</strong> / <a href="#subcbpoints">subcbpoints</a> - <comment type="action" name="subcbpoints"></comment></li>
+<li><strong>subregen</strong> / <a href="#subregen">subregen</a> - <comment type="action" name="subregen"></comment></li>
+<li><strong>testregen</strong> / <a href="#testregen">testregen</a> - <comment type="action" name="testregen"></comment></li>
+<li><strong>testreptable</strong> / <a href="#testreptable">testreptable</a> - <comment type="action" name="testreptable"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
@@ -282,7 +295,7 @@
   <script id="template" type="x-tmpl-handlebars">
 # Smartcontract documentation for {{ file }}
 
-<comment type="main">{{comment}}</comment>
+<comment type="main"></comment>
 
 {{#if types}}
 ## Types
@@ -294,19 +307,19 @@
 ## Actions
 
 {{#each actions}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/organization.html
+++ b/docs/organization.html
@@ -28,51 +28,51 @@ $(function() {
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li><strong>addcbpoints</strong> / <a href="#addcbpoints">addcbpoints</a> - <comment type="action" name="addcbpoints"></comment></li>
-<li><strong>addmember</strong> / <a href="#addmember">addmember</a> - <comment type="action" name="addmember"></comment></li>
-<li><strong>addregen</strong> / <a href="#addregen">addregen</a> - <comment type="action" name="addregen"></comment></li>
-<li><strong>appuse</strong> / <a href="#appuse">appuse</a> - <comment type="action" name="appuse"></comment></li>
-<li><strong>banapp</strong> / <a href="#banapp">banapp</a> - <comment type="action" name="banapp"></comment></li>
-<li><strong>changeowner</strong> / <a href="#changeowner">changeowner</a> - <comment type="action" name="changeowner"></comment></li>
-<li><strong>changerole</strong> / <a href="#changerole">changerole</a> - <comment type="action" name="changerole"></comment></li>
-<li><strong>cleandau</strong> / <a href="#cleandau">cleandau</a> - <comment type="action" name="cleandau"></comment></li>
-<li><strong>cleandaus</strong> / <a href="#cleandaus">cleandaus</a> - <comment type="action" name="cleandaus"></comment></li>
-<li><strong>create</strong> / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
-<li><strong>destroy</strong> / <a href="#destroy">destroy</a> - <comment type="action" name="destroy"></comment></li>
-<li><strong>makeregen</strong> / <a href="#makeregen">makeregen</a> - <comment type="action" name="makeregen"></comment></li>
-<li><strong>makereptable</strong> / <a href="#makereptable">makereptable</a> - <comment type="action" name="makereptable"></comment></li>
-<li><strong>rankcbsorg</strong> / <a href="#rankcbsorg">rankcbsorg</a> - <comment type="action" name="rankcbsorg"></comment></li>
-<li><strong>rankcbsorgs</strong> / <a href="#rankcbsorgs">rankcbsorgs</a> - <comment type="action" name="rankcbsorgs"></comment></li>
-<li><strong>rankregen</strong> / <a href="#rankregen">rankregen</a> - <comment type="action" name="rankregen"></comment></li>
-<li><strong>rankregens</strong> / <a href="#rankregens">rankregens</a> - <comment type="action" name="rankregens"></comment></li>
-<li><strong>refund</strong> / <a href="#refund">refund</a> - <comment type="action" name="refund"></comment></li>
-<li><strong>registerapp</strong> / <a href="#registerapp">registerapp</a> - <comment type="action" name="registerapp"></comment></li>
-<li><strong>removemember</strong> / <a href="#removemember">removemember</a> - <comment type="action" name="removemember"></comment></li>
-<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
-<li><strong>scoreorgs</strong> / <a href="#scoreorgs">scoreorgs</a> - <comment type="action" name="scoreorgs"></comment></li>
-<li><strong>scoretrxs</strong> / <a href="#scoretrxs">scoretrxs</a> - <comment type="action" name="scoretrxs"></comment></li>
-<li><strong>subcbpoints</strong> / <a href="#subcbpoints">subcbpoints</a> - <comment type="action" name="subcbpoints"></comment></li>
-<li><strong>subregen</strong> / <a href="#subregen">subregen</a> - <comment type="action" name="subregen"></comment></li>
-<li><strong>testregen</strong> / <a href="#testregen">testregen</a> - <comment type="action" name="testregen"></comment></li>
-<li><strong>testreptable</strong> / <a href="#testreptable">testreptable</a> - <comment type="action" name="testreptable"></comment></li>
+<li><strong>addcbpoints</strong> / <a href="#addcbpoints">addcbpoints</a> <comment type="action" name="addcbpoints"></comment></li>
+<li><strong>addmember</strong> / <a href="#addmember">addmember</a> <comment type="action" name="addmember"></comment></li>
+<li><strong>addregen</strong> / <a href="#addregen">addregen</a> <comment type="action" name="addregen"></comment></li>
+<li><strong>appuse</strong> / <a href="#appuse">appuse</a> <comment type="action" name="appuse"></comment></li>
+<li><strong>banapp</strong> / <a href="#banapp">banapp</a> <comment type="action" name="banapp"></comment></li>
+<li><strong>changeowner</strong> / <a href="#changeowner">changeowner</a> <comment type="action" name="changeowner"></comment></li>
+<li><strong>changerole</strong> / <a href="#changerole">changerole</a> <comment type="action" name="changerole"></comment></li>
+<li><strong>cleandau</strong> / <a href="#cleandau">cleandau</a> <comment type="action" name="cleandau"></comment></li>
+<li><strong>cleandaus</strong> / <a href="#cleandaus">cleandaus</a> <comment type="action" name="cleandaus"></comment></li>
+<li><strong>create</strong> / <a href="#create">create</a> <comment type="action" name="create"></comment></li>
+<li><strong>destroy</strong> / <a href="#destroy">destroy</a> <comment type="action" name="destroy"></comment></li>
+<li><strong>makeregen</strong> / <a href="#makeregen">makeregen</a> <comment type="action" name="makeregen"></comment></li>
+<li><strong>makereptable</strong> / <a href="#makereptable">makereptable</a> <comment type="action" name="makereptable"></comment></li>
+<li><strong>rankcbsorg</strong> / <a href="#rankcbsorg">rankcbsorg</a> <comment type="action" name="rankcbsorg"></comment></li>
+<li><strong>rankcbsorgs</strong> / <a href="#rankcbsorgs">rankcbsorgs</a> <comment type="action" name="rankcbsorgs"></comment></li>
+<li><strong>rankregen</strong> / <a href="#rankregen">rankregen</a> <comment type="action" name="rankregen"></comment></li>
+<li><strong>rankregens</strong> / <a href="#rankregens">rankregens</a> <comment type="action" name="rankregens"></comment></li>
+<li><strong>refund</strong> / <a href="#refund">refund</a> <comment type="action" name="refund"></comment></li>
+<li><strong>registerapp</strong> / <a href="#registerapp">registerapp</a> <comment type="action" name="registerapp"></comment></li>
+<li><strong>removemember</strong> / <a href="#removemember">removemember</a> <comment type="action" name="removemember"></comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> <comment type="action" name="reset"></comment></li>
+<li><strong>scoreorgs</strong> / <a href="#scoreorgs">scoreorgs</a> <comment type="action" name="scoreorgs"></comment></li>
+<li><strong>scoretrxs</strong> / <a href="#scoretrxs">scoretrxs</a> <comment type="action" name="scoretrxs"></comment></li>
+<li><strong>subcbpoints</strong> / <a href="#subcbpoints">subcbpoints</a> <comment type="action" name="subcbpoints"></comment></li>
+<li><strong>subregen</strong> / <a href="#subregen">subregen</a> <comment type="action" name="subregen"></comment></li>
+<li><strong>testregen</strong> / <a href="#testregen">testregen</a> <comment type="action" name="testregen"></comment></li>
+<li><strong>testreptable</strong> / <a href="#testreptable">testreptable</a> <comment type="action" name="testreptable"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
 <ul>
-<li><strong>apps</strong> / <a href="#app_table">app_table</a> (i64) - <comment type="table" name="apps"></comment></li>
-<li><strong>avgvotes</strong> / <a href="#avg_vote_table">avg_vote_table</a> (i64) - <comment type="table" name="avgvotes"></comment></li>
-<li><strong>cbsorgs</strong> / <a href="#cbs_organization_table">cbs_organization_table</a> (i64) - <comment type="table" name="cbsorgs"></comment></li>
-<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) - <comment type="table" name="config"></comment></li>
-<li><strong>dauhistory</strong> / <a href="#dau_history_table">dau_history_table</a> (i64) - <comment type="table" name="dauhistory"></comment></li>
-<li><strong>daus</strong> / <a href="#dau_table">dau_table</a> (i64) - <comment type="table" name="daus"></comment></li>
-<li><strong>members</strong> / <a href="#members_table">members_table</a> (i64) - <comment type="table" name="members"></comment></li>
-<li><strong>organization</strong> / <a href="#organization_table">organization_table</a> (i64) - <comment type="table" name="organization"></comment></li>
-<li><strong>orgtx</strong> / <a href="#org_tx_table">org_tx_table</a> (i64) - <comment type="table" name="orgtx"></comment></li>
-<li><strong>refs</strong> / <a href="#ref_table">ref_table</a> (i64) - <comment type="table" name="refs"></comment></li>
-<li><strong>regenscores</strong> / <a href="#regen_score_table">regen_score_table</a> (i64) - <comment type="table" name="regenscores"></comment></li>
-<li><strong>sizes</strong> / <a href="#size_table">size_table</a> (i64) - <comment type="table" name="sizes"></comment></li>
-<li><strong>sponsors</strong> / <a href="#sponsors_table">sponsors_table</a> (i64) - <comment type="table" name="sponsors"></comment></li>
-<li><strong>votes</strong> / <a href="#vote_table">vote_table</a> (i64) - <comment type="table" name="votes"></comment></li>
+<li><strong>apps</strong> / <a href="#app_table">app_table</a> (i64) <comment type="table" name="apps"></comment></li>
+<li><strong>avgvotes</strong> / <a href="#avg_vote_table">avg_vote_table</a> (i64) <comment type="table" name="avgvotes"></comment></li>
+<li><strong>cbsorgs</strong> / <a href="#cbs_organization_table">cbs_organization_table</a> (i64) <comment type="table" name="cbsorgs"></comment></li>
+<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) <comment type="table" name="config"></comment></li>
+<li><strong>dauhistory</strong> / <a href="#dau_history_table">dau_history_table</a> (i64) <comment type="table" name="dauhistory"></comment></li>
+<li><strong>daus</strong> / <a href="#dau_table">dau_table</a> (i64) <comment type="table" name="daus"></comment></li>
+<li><strong>members</strong> / <a href="#members_table">members_table</a> (i64) <comment type="table" name="members"></comment></li>
+<li><strong>organization</strong> / <a href="#organization_table">organization_table</a> (i64) <comment type="table" name="organization"></comment></li>
+<li><strong>orgtx</strong> / <a href="#org_tx_table">org_tx_table</a> (i64) <comment type="table" name="orgtx"></comment></li>
+<li><strong>refs</strong> / <a href="#ref_table">ref_table</a> (i64) <comment type="table" name="refs"></comment></li>
+<li><strong>regenscores</strong> / <a href="#regen_score_table">regen_score_table</a> (i64) <comment type="table" name="regenscores"></comment></li>
+<li><strong>sizes</strong> / <a href="#size_table">size_table</a> (i64) <comment type="table" name="sizes"></comment></li>
+<li><strong>sponsors</strong> / <a href="#sponsors_table">sponsors_table</a> (i64) <comment type="table" name="sponsors"></comment></li>
+<li><strong>votes</strong> / <a href="#vote_table">vote_table</a> (i64) <comment type="table" name="votes"></comment></li>
 </ul>
 <h2>ABI Extensions</h2>
 <h2>Structs</h2>
@@ -307,19 +307,19 @@ $(function() {
 ## Actions
 
 {{#each actions}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/policy.html
+++ b/docs/policy.html
@@ -10,15 +10,28 @@
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
-</head><body onload="loadUser()">
+<script>
+$(function() {
+  var reader = new commonmark.Parser();
+  var writer = new commonmark.HtmlRenderer();
+
+  $('#target comment').each(function(i, elem) {
+    var parsed = reader.parse($(this).text()); 
+    var result = writer.render(parsed);
+    $(this).html(result);
+  });
+ });
+</script>
+
+</head><body>
   <div id="target"><h1>Smartcontract documentation for policy</h1>
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li>create / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
-<li>remove / <a href="#remove">remove</a> - <comment type="action" name="remove"></comment></li>
-<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
-<li>update / <a href="#update">update</a> - <comment type="action" name="update"></comment></li>
+<li><strong>create</strong> / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
+<li><strong>remove</strong> / <a href="#remove">remove</a> - <comment type="action" name="remove"></comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li><strong>update</strong> / <a href="#update">update</a> - <comment type="action" name="update"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
@@ -62,7 +75,7 @@
   <script id="template" type="x-tmpl-handlebars">
 # Smartcontract documentation for {{ file }}
 
-<comment type="main">{{comment}}</comment>
+<comment type="main"></comment>
 
 {{#if types}}
 ## Types
@@ -74,19 +87,19 @@
 ## Actions
 
 {{#each actions}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/policy.html
+++ b/docs/policy.html
@@ -28,15 +28,15 @@ $(function() {
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li><strong>create</strong> / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
-<li><strong>remove</strong> / <a href="#remove">remove</a> - <comment type="action" name="remove"></comment></li>
-<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
-<li><strong>update</strong> / <a href="#update">update</a> - <comment type="action" name="update"></comment></li>
+<li><strong>create</strong> / <a href="#create">create</a> <comment type="action" name="create"></comment></li>
+<li><strong>remove</strong> / <a href="#remove">remove</a> <comment type="action" name="remove"></comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> <comment type="action" name="reset"></comment></li>
+<li><strong>update</strong> / <a href="#update">update</a> <comment type="action" name="update"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
 <ul>
-<li><strong>devicepolicy</strong> / <a href="#device_policy_table">device_policy_table</a> (i64) - <comment type="table" name="devicepolicy"></comment></li>
+<li><strong>devicepolicy</strong> / <a href="#device_policy_table">device_policy_table</a> (i64) <comment type="table" name="devicepolicy"></comment></li>
 </ul>
 <h2>ABI Extensions</h2>
 <h2>Structs</h2>
@@ -87,19 +87,19 @@ $(function() {
 ## Actions
 
 {{#each actions}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/policy.html
+++ b/docs/policy.html
@@ -1,0 +1,102 @@
+<html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+
+</head><body onload="loadUser()">
+  <div id="target"><h1>Smartcontract documentation for policy</h1>
+<p><comment type="main"></comment></p>
+<h2>Actions</h2>
+<ul>
+<li>create / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
+<li>remove / <a href="#remove">remove</a> - <comment type="action" name="remove"></comment></li>
+<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li>update / <a href="#update">update</a> - <comment type="action" name="update"></comment></li>
+</ul>
+<h2>Events</h2>
+<h2>Tables</h2>
+<ul>
+<li><strong>devicepolicy</strong> / <a href="#device_policy_table">device_policy_table</a> (i64) - <comment type="table" name="devicepolicy"></comment></li>
+</ul>
+<h2>ABI Extensions</h2>
+<h2>Structs</h2>
+<h3 id="create"> create </h3>
+<ul>
+<li>account / name</li>
+<li>backend_user_id / string</li>
+<li>device_id / string</li>
+<li>signature / string</li>
+<li>policy / string</li>
+</ul>
+<h3 id="device_policy_table"> device_policy_table </h3>
+<ul>
+<li>id / uint64</li>
+<li>account / name</li>
+<li>backend_user_id / string</li>
+<li>device_id / string</li>
+<li>signature / string</li>
+<li>policy / string</li>
+</ul>
+<h3 id="remove"> remove </h3>
+<ul>
+<li>id / uint64</li>
+</ul>
+<h3 id="reset"> reset </h3>
+<h3 id="update"> update </h3>
+<ul>
+<li>id / uint64</li>
+<li>account / name</li>
+<li>backend_user_id / string</li>
+<li>device_id / string</li>
+<li>signature / string</li>
+<li>policy / string</li>
+</ul>
+</div>
+  <script id="template" type="x-tmpl-handlebars">
+# Smartcontract documentation for {{ file }}
+
+<comment type="main">{{comment}}</comment>
+
+{{#if types}}
+## Types
+{{/if}}
+{{#each types}}
+  {{ name }}
+{{/each}}
+
+## Actions
+
+{{#each actions}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Events
+
+{{#each events}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Tables
+
+{{#each tables}}
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## ABI Extensions
+
+{{#each abi_extensions}}
+  - {{ name }}
+{{/each}}
+
+## Structs
+
+{{#each structs}}
+<h3 id={{ name }}> {{ name }} {{#if base}}( {{base}} ){{/if}}</h3>
+  
+  {{#each fields}}
+  - {{ name }} / {{ type }}
+  {{/each}}
+{{/each}}
+
+  </script>
+
+</body></html>

--- a/docs/policy.html
+++ b/docs/policy.html
@@ -1,6 +1,14 @@
 <html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+<!-- Latest compiled and minified CSS -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
+
+<!-- Optional theme -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap-theme.min.css" integrity="sha384-6pzBo3FDv/PJ8r2KRkGHifhEocL+1X2rVCTTkUfGk7/0pbek5mMa1upzvWbrUbOZ" crossorigin="anonymous">
+
+<!-- Latest compiled and minified JavaScript -->
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
 </head><body onload="loadUser()">
   <div id="target"><h1>Smartcontract documentation for policy</h1>

--- a/docs/proposals.html
+++ b/docs/proposals.html
@@ -10,37 +10,50 @@
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
-</head><body onload="loadUser()">
+<script>
+$(function() {
+  var reader = new commonmark.Parser();
+  var writer = new commonmark.HtmlRenderer();
+
+  $('#target comment').each(function(i, elem) {
+    var parsed = reader.parse($(this).text()); 
+    var result = writer.render(parsed);
+    $(this).html(result);
+  });
+ });
+</script>
+
+</head><body>
   <div id="target"><h1>Smartcontract documentation for proposals</h1>
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li>addactive / <a href="#addactive">addactive</a> - <comment type="action" name="addactive"></comment></li>
-<li>addvoice / <a href="#addvoice">addvoice</a> - <comment type="action" name="addvoice"></comment></li>
-<li>against / <a href="#against">against</a> - <comment type="action" name="against"></comment></li>
-<li>cancel / <a href="#cancel">cancel</a> - <comment type="action" name="cancel"></comment></li>
-<li>changetrust / <a href="#changetrust">changetrust</a> - <comment type="action" name="changetrust"></comment></li>
-<li>checkstake / <a href="#checkstake">checkstake</a> - <comment type="action" name="checkstake"></comment></li>
-<li>create / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
-<li>createx / <a href="#createx">createx</a> - <comment type="action" name="createx"></comment></li>
-<li>decayvoice / <a href="#decayvoice">decayvoice</a> - <comment type="action" name="decayvoice"></comment></li>
-<li>decayvoices / <a href="#decayvoices">decayvoices</a> - <comment type="action" name="decayvoices"></comment></li>
-<li>erasepartpts / <a href="#erasepartpts">erasepartpts</a> - <comment type="action" name="erasepartpts"></comment></li>
-<li>favour / <a href="#favour">favour</a> - <comment type="action" name="favour"></comment></li>
-<li>initactives / <a href="#initactives">initactives</a> - <comment type="action" name="initactives"></comment></li>
-<li>initsz / <a href="#initsz">initsz</a> - <comment type="action" name="initsz"></comment></li>
-<li>neutral / <a href="#neutral">neutral</a> - <comment type="action" name="neutral"></comment></li>
-<li>onperiod / <a href="#onperiod">onperiod</a> - <comment type="action" name="onperiod"></comment></li>
-<li>removeactive / <a href="#removeactive">removeactive</a> - <comment type="action" name="removeactive"></comment></li>
-<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
-<li>stake / <a href="#stake">stake</a> - <comment type="action" name="stake"></comment></li>
-<li>testvdecay / <a href="#testvdecay">testvdecay</a> - <comment type="action" name="testvdecay"></comment></li>
-<li>update / <a href="#update">update</a> - <comment type="action" name="update"></comment></li>
-<li>updateactive / <a href="#updateactive">updateactive</a> - <comment type="action" name="updateactive"></comment></li>
-<li>updateactivs / <a href="#updateactivs">updateactivs</a> - <comment type="action" name="updateactivs"></comment></li>
-<li>updatevoice / <a href="#updatevoice">updatevoice</a> - <comment type="action" name="updatevoice"></comment></li>
-<li>updatevoices / <a href="#updatevoices">updatevoices</a> - <comment type="action" name="updatevoices"></comment></li>
-<li>updatex / <a href="#updatex">updatex</a> - <comment type="action" name="updatex"></comment></li>
+<li><strong>addactive</strong> / <a href="#addactive">addactive</a> - <comment type="action" name="addactive"></comment></li>
+<li><strong>addvoice</strong> / <a href="#addvoice">addvoice</a> - <comment type="action" name="addvoice"></comment></li>
+<li><strong>against</strong> / <a href="#against">against</a> - <comment type="action" name="against"></comment></li>
+<li><strong>cancel</strong> / <a href="#cancel">cancel</a> - <comment type="action" name="cancel"></comment></li>
+<li><strong>changetrust</strong> / <a href="#changetrust">changetrust</a> - <comment type="action" name="changetrust"></comment></li>
+<li><strong>checkstake</strong> / <a href="#checkstake">checkstake</a> - <comment type="action" name="checkstake"></comment></li>
+<li><strong>create</strong> / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
+<li><strong>createx</strong> / <a href="#createx">createx</a> - <comment type="action" name="createx"></comment></li>
+<li><strong>decayvoice</strong> / <a href="#decayvoice">decayvoice</a> - <comment type="action" name="decayvoice"></comment></li>
+<li><strong>decayvoices</strong> / <a href="#decayvoices">decayvoices</a> - <comment type="action" name="decayvoices"></comment></li>
+<li><strong>erasepartpts</strong> / <a href="#erasepartpts">erasepartpts</a> - <comment type="action" name="erasepartpts"></comment></li>
+<li><strong>favour</strong> / <a href="#favour">favour</a> - <comment type="action" name="favour"></comment></li>
+<li><strong>initactives</strong> / <a href="#initactives">initactives</a> - <comment type="action" name="initactives"></comment></li>
+<li><strong>initsz</strong> / <a href="#initsz">initsz</a> - <comment type="action" name="initsz"></comment></li>
+<li><strong>neutral</strong> / <a href="#neutral">neutral</a> - <comment type="action" name="neutral"></comment></li>
+<li><strong>onperiod</strong> / <a href="#onperiod">onperiod</a> - <comment type="action" name="onperiod"></comment></li>
+<li><strong>removeactive</strong> / <a href="#removeactive">removeactive</a> - <comment type="action" name="removeactive"></comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li><strong>stake</strong> / <a href="#stake">stake</a> - <comment type="action" name="stake"></comment></li>
+<li><strong>testvdecay</strong> / <a href="#testvdecay">testvdecay</a> - <comment type="action" name="testvdecay"></comment></li>
+<li><strong>update</strong> / <a href="#update">update</a> - <comment type="action" name="update"></comment></li>
+<li><strong>updateactive</strong> / <a href="#updateactive">updateactive</a> - <comment type="action" name="updateactive"></comment></li>
+<li><strong>updateactivs</strong> / <a href="#updateactivs">updateactivs</a> - <comment type="action" name="updateactivs"></comment></li>
+<li><strong>updatevoice</strong> / <a href="#updatevoice">updatevoice</a> - <comment type="action" name="updatevoice"></comment></li>
+<li><strong>updatevoices</strong> / <a href="#updatevoices">updatevoices</a> - <comment type="action" name="updatevoices"></comment></li>
+<li><strong>updatex</strong> / <a href="#updatex">updatex</a> - <comment type="action" name="updatex"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
@@ -268,7 +281,7 @@
   <script id="template" type="x-tmpl-handlebars">
 # Smartcontract documentation for {{ file }}
 
-<comment type="main">{{comment}}</comment>
+<comment type="main"></comment>
 
 {{#if types}}
 ## Types
@@ -280,19 +293,19 @@
 ## Actions
 
 {{#each actions}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/proposals.html
+++ b/docs/proposals.html
@@ -1,0 +1,308 @@
+<html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+
+</head><body onload="loadUser()">
+  <div id="target"><h1>Smartcontract documentation for proposals</h1>
+<p><comment type="main"></comment></p>
+<h2>Actions</h2>
+<ul>
+<li>addactive / <a href="#addactive">addactive</a> - <comment type="action" name="addactive"></comment></li>
+<li>addvoice / <a href="#addvoice">addvoice</a> - <comment type="action" name="addvoice"></comment></li>
+<li>against / <a href="#against">against</a> - <comment type="action" name="against"></comment></li>
+<li>cancel / <a href="#cancel">cancel</a> - <comment type="action" name="cancel"></comment></li>
+<li>changetrust / <a href="#changetrust">changetrust</a> - <comment type="action" name="changetrust"></comment></li>
+<li>checkstake / <a href="#checkstake">checkstake</a> - <comment type="action" name="checkstake"></comment></li>
+<li>create / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
+<li>createx / <a href="#createx">createx</a> - <comment type="action" name="createx"></comment></li>
+<li>decayvoice / <a href="#decayvoice">decayvoice</a> - <comment type="action" name="decayvoice"></comment></li>
+<li>decayvoices / <a href="#decayvoices">decayvoices</a> - <comment type="action" name="decayvoices"></comment></li>
+<li>erasepartpts / <a href="#erasepartpts">erasepartpts</a> - <comment type="action" name="erasepartpts"></comment></li>
+<li>favour / <a href="#favour">favour</a> - <comment type="action" name="favour"></comment></li>
+<li>initactives / <a href="#initactives">initactives</a> - <comment type="action" name="initactives"></comment></li>
+<li>initsz / <a href="#initsz">initsz</a> - <comment type="action" name="initsz"></comment></li>
+<li>neutral / <a href="#neutral">neutral</a> - <comment type="action" name="neutral"></comment></li>
+<li>onperiod / <a href="#onperiod">onperiod</a> - <comment type="action" name="onperiod"></comment></li>
+<li>removeactive / <a href="#removeactive">removeactive</a> - <comment type="action" name="removeactive"></comment></li>
+<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li>stake / <a href="#stake">stake</a> - <comment type="action" name="stake"></comment></li>
+<li>testvdecay / <a href="#testvdecay">testvdecay</a> - <comment type="action" name="testvdecay"></comment></li>
+<li>update / <a href="#update">update</a> - <comment type="action" name="update"></comment></li>
+<li>updateactive / <a href="#updateactive">updateactive</a> - <comment type="action" name="updateactive"></comment></li>
+<li>updateactivs / <a href="#updateactivs">updateactivs</a> - <comment type="action" name="updateactivs"></comment></li>
+<li>updatevoice / <a href="#updatevoice">updatevoice</a> - <comment type="action" name="updatevoice"></comment></li>
+<li>updatevoices / <a href="#updatevoices">updatevoices</a> - <comment type="action" name="updatevoices"></comment></li>
+<li>updatex / <a href="#updatex">updatex</a> - <comment type="action" name="updatex"></comment></li>
+</ul>
+<h2>Events</h2>
+<h2>Tables</h2>
+<ul>
+<li><strong>actives</strong> / <a href="#active_table">active_table</a> (i64) - <comment type="table" name="actives"></comment></li>
+<li><strong>cycle</strong> / <a href="#cycle_table">cycle_table</a> (i64) - <comment type="table" name="cycle"></comment></li>
+<li><strong>lastprops</strong> / <a href="#last_proposal_table">last_proposal_table</a> (i64) - <comment type="table" name="lastprops"></comment></li>
+<li><strong>minstake</strong> / <a href="#min_stake_table">min_stake_table</a> (i64) - <comment type="table" name="minstake"></comment></li>
+<li><strong>participants</strong> / <a href="#participant_table">participant_table</a> (i64) - <comment type="table" name="participants"></comment></li>
+<li><strong>props</strong> / <a href="#proposal_table">proposal_table</a> (i64) - <comment type="table" name="props"></comment></li>
+<li><strong>sizes</strong> / <a href="#size_table">size_table</a> (i64) - <comment type="table" name="sizes"></comment></li>
+<li><strong>users</strong> / <a href="#user_table">user_table</a> (i64) - <comment type="table" name="users"></comment></li>
+<li><strong>voice</strong> / <a href="#voice_table">voice_table</a> (i64) - <comment type="table" name="voice"></comment></li>
+<li><strong>votes</strong> / <a href="#vote_table">vote_table</a> (i64) - <comment type="table" name="votes"></comment></li>
+</ul>
+<h2>ABI Extensions</h2>
+<h2>Structs</h2>
+<h3 id="active_table"> active_table </h3>
+<ul>
+<li>account / name</li>
+<li>timestamp / uint64</li>
+<li>active / bool</li>
+</ul>
+<h3 id="addactive"> addactive </h3>
+<ul>
+<li>account / name</li>
+</ul>
+<h3 id="addvoice"> addvoice </h3>
+<ul>
+<li>user / name</li>
+<li>amount / uint64</li>
+</ul>
+<h3 id="against"> against </h3>
+<ul>
+<li>user / name</li>
+<li>id / uint64</li>
+<li>amount / uint64</li>
+</ul>
+<h3 id="cancel"> cancel </h3>
+<ul>
+<li>id / uint64</li>
+</ul>
+<h3 id="changetrust"> changetrust </h3>
+<ul>
+<li>user / name</li>
+<li>trust / bool</li>
+</ul>
+<h3 id="checkstake"> checkstake </h3>
+<ul>
+<li>prop_id / uint64</li>
+</ul>
+<h3 id="create"> create </h3>
+<ul>
+<li>creator / name</li>
+<li>recipient / name</li>
+<li>quantity / asset</li>
+<li>title / string</li>
+<li>summary / string</li>
+<li>description / string</li>
+<li>image / string</li>
+<li>url / string</li>
+<li>fund / name</li>
+</ul>
+<h3 id="createx"> createx </h3>
+<ul>
+<li>creator / name</li>
+<li>recipient / name</li>
+<li>quantity / asset</li>
+<li>title / string</li>
+<li>summary / string</li>
+<li>description / string</li>
+<li>image / string</li>
+<li>url / string</li>
+<li>fund / name</li>
+<li>pay_percentages / uint64[]</li>
+</ul>
+<h3 id="cycle_table"> cycle_table </h3>
+<ul>
+<li>propcycle / uint64</li>
+<li>t_onperiod / uint64</li>
+<li>t_voicedecay / uint64</li>
+</ul>
+<h3 id="decayvoice"> decayvoice </h3>
+<ul>
+<li>start / uint64</li>
+<li>chunksize / uint64</li>
+</ul>
+<h3 id="decayvoices"> decayvoices </h3>
+<h3 id="erasepartpts"> erasepartpts </h3>
+<ul>
+<li>active_proposals / uint64</li>
+</ul>
+<h3 id="favour"> favour </h3>
+<ul>
+<li>user / name</li>
+<li>id / uint64</li>
+<li>amount / uint64</li>
+</ul>
+<h3 id="initactives"> initactives </h3>
+<h3 id="initsz"> initsz </h3>
+<h3 id="last_proposal_table"> last_proposal_table </h3>
+<ul>
+<li>account / name</li>
+<li>proposal_id / uint64</li>
+</ul>
+<h3 id="min_stake_table"> min_stake_table </h3>
+<ul>
+<li>prop_id / uint64</li>
+<li>min_stake / uint64</li>
+</ul>
+<h3 id="neutral"> neutral </h3>
+<ul>
+<li>user / name</li>
+<li>id / uint64</li>
+</ul>
+<h3 id="onperiod"> onperiod </h3>
+<h3 id="participant_table"> participant_table </h3>
+<ul>
+<li>account / name</li>
+<li>nonneutral / bool</li>
+<li>count / uint64</li>
+</ul>
+<h3 id="proposal_table"> proposal_table </h3>
+<ul>
+<li>id / uint64</li>
+<li>creator / name</li>
+<li>recipient / name</li>
+<li>quantity / asset</li>
+<li>staked / asset</li>
+<li>executed / bool</li>
+<li>total / uint64</li>
+<li>favour / uint64</li>
+<li>against / uint64</li>
+<li>title / string</li>
+<li>summary / string</li>
+<li>description / string</li>
+<li>image / string</li>
+<li>url / string</li>
+<li>status / name</li>
+<li>stage / name</li>
+<li>fund / name</li>
+<li>creation_date / uint64</li>
+<li>pay_percentages / uint64[]</li>
+<li>passed_cycle / uint64</li>
+<li>age / uint32</li>
+<li>current_payout / asset</li>
+</ul>
+<h3 id="removeactive"> removeactive </h3>
+<ul>
+<li>account / name</li>
+</ul>
+<h3 id="reset"> reset </h3>
+<h3 id="size_table"> size_table </h3>
+<ul>
+<li>id / name</li>
+<li>size / uint64</li>
+</ul>
+<h3 id="stake"> stake </h3>
+<ul>
+<li>from / name</li>
+<li>to / name</li>
+<li>quantity / asset</li>
+<li>memo / string</li>
+</ul>
+<h3 id="testvdecay"> testvdecay </h3>
+<ul>
+<li>timestamp / uint64</li>
+</ul>
+<h3 id="update"> update </h3>
+<ul>
+<li>id / uint64</li>
+<li>title / string</li>
+<li>summary / string</li>
+<li>description / string</li>
+<li>image / string</li>
+<li>url / string</li>
+</ul>
+<h3 id="updateactive"> updateactive </h3>
+<ul>
+<li>start / uint64</li>
+</ul>
+<h3 id="updateactivs"> updateactivs </h3>
+<h3 id="updatevoice"> updatevoice </h3>
+<ul>
+<li>start / uint64</li>
+</ul>
+<h3 id="updatevoices"> updatevoices </h3>
+<h3 id="updatex"> updatex </h3>
+<ul>
+<li>id / uint64</li>
+<li>title / string</li>
+<li>summary / string</li>
+<li>description / string</li>
+<li>image / string</li>
+<li>url / string</li>
+<li>pay_percentages / uint64[]</li>
+</ul>
+<h3 id="user_table"> user_table </h3>
+<ul>
+<li>account / name</li>
+<li>status / name</li>
+<li>type / name</li>
+<li>nickname / string</li>
+<li>image / string</li>
+<li>story / string</li>
+<li>roles / string</li>
+<li>skills / string</li>
+<li>interests / string</li>
+<li>reputation / uint64</li>
+<li>timestamp / uint64</li>
+</ul>
+<h3 id="voice_table"> voice_table </h3>
+<ul>
+<li>account / name</li>
+<li>balance / uint64</li>
+</ul>
+<h3 id="vote_table"> vote_table </h3>
+<ul>
+<li>proposal_id / uint64</li>
+<li>account / name</li>
+<li>amount / uint64</li>
+<li>favour / bool</li>
+</ul>
+</div>
+  <script id="template" type="x-tmpl-handlebars">
+# Smartcontract documentation for {{ file }}
+
+<comment type="main">{{comment}}</comment>
+
+{{#if types}}
+## Types
+{{/if}}
+{{#each types}}
+  {{ name }}
+{{/each}}
+
+## Actions
+
+{{#each actions}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Events
+
+{{#each events}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Tables
+
+{{#each tables}}
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## ABI Extensions
+
+{{#each abi_extensions}}
+  - {{ name }}
+{{/each}}
+
+## Structs
+
+{{#each structs}}
+<h3 id={{ name }}> {{ name }} {{#if base}}( {{base}} ){{/if}}</h3>
+  
+  {{#each fields}}
+  - {{ name }} / {{ type }}
+  {{/each}}
+{{/each}}
+
+  </script>
+
+</body></html>

--- a/docs/proposals.html
+++ b/docs/proposals.html
@@ -1,6 +1,14 @@
 <html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+<!-- Latest compiled and minified CSS -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
+
+<!-- Optional theme -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap-theme.min.css" integrity="sha384-6pzBo3FDv/PJ8r2KRkGHifhEocL+1X2rVCTTkUfGk7/0pbek5mMa1upzvWbrUbOZ" crossorigin="anonymous">
+
+<!-- Latest compiled and minified JavaScript -->
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
 </head><body onload="loadUser()">
   <div id="target"><h1>Smartcontract documentation for proposals</h1>

--- a/docs/proposals.html
+++ b/docs/proposals.html
@@ -28,46 +28,46 @@ $(function() {
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li><strong>addactive</strong> / <a href="#addactive">addactive</a> - <comment type="action" name="addactive"></comment></li>
-<li><strong>addvoice</strong> / <a href="#addvoice">addvoice</a> - <comment type="action" name="addvoice"></comment></li>
-<li><strong>against</strong> / <a href="#against">against</a> - <comment type="action" name="against"></comment></li>
-<li><strong>cancel</strong> / <a href="#cancel">cancel</a> - <comment type="action" name="cancel"></comment></li>
-<li><strong>changetrust</strong> / <a href="#changetrust">changetrust</a> - <comment type="action" name="changetrust"></comment></li>
-<li><strong>checkstake</strong> / <a href="#checkstake">checkstake</a> - <comment type="action" name="checkstake"></comment></li>
-<li><strong>create</strong> / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
-<li><strong>createx</strong> / <a href="#createx">createx</a> - <comment type="action" name="createx"></comment></li>
-<li><strong>decayvoice</strong> / <a href="#decayvoice">decayvoice</a> - <comment type="action" name="decayvoice"></comment></li>
-<li><strong>decayvoices</strong> / <a href="#decayvoices">decayvoices</a> - <comment type="action" name="decayvoices"></comment></li>
-<li><strong>erasepartpts</strong> / <a href="#erasepartpts">erasepartpts</a> - <comment type="action" name="erasepartpts"></comment></li>
-<li><strong>favour</strong> / <a href="#favour">favour</a> - <comment type="action" name="favour"></comment></li>
-<li><strong>initactives</strong> / <a href="#initactives">initactives</a> - <comment type="action" name="initactives"></comment></li>
-<li><strong>initsz</strong> / <a href="#initsz">initsz</a> - <comment type="action" name="initsz"></comment></li>
-<li><strong>neutral</strong> / <a href="#neutral">neutral</a> - <comment type="action" name="neutral"></comment></li>
-<li><strong>onperiod</strong> / <a href="#onperiod">onperiod</a> - <comment type="action" name="onperiod"></comment></li>
-<li><strong>removeactive</strong> / <a href="#removeactive">removeactive</a> - <comment type="action" name="removeactive"></comment></li>
-<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
-<li><strong>stake</strong> / <a href="#stake">stake</a> - <comment type="action" name="stake"></comment></li>
-<li><strong>testvdecay</strong> / <a href="#testvdecay">testvdecay</a> - <comment type="action" name="testvdecay"></comment></li>
-<li><strong>update</strong> / <a href="#update">update</a> - <comment type="action" name="update"></comment></li>
-<li><strong>updateactive</strong> / <a href="#updateactive">updateactive</a> - <comment type="action" name="updateactive"></comment></li>
-<li><strong>updateactivs</strong> / <a href="#updateactivs">updateactivs</a> - <comment type="action" name="updateactivs"></comment></li>
-<li><strong>updatevoice</strong> / <a href="#updatevoice">updatevoice</a> - <comment type="action" name="updatevoice"></comment></li>
-<li><strong>updatevoices</strong> / <a href="#updatevoices">updatevoices</a> - <comment type="action" name="updatevoices"></comment></li>
-<li><strong>updatex</strong> / <a href="#updatex">updatex</a> - <comment type="action" name="updatex"></comment></li>
+<li><strong>addactive</strong> / <a href="#addactive">addactive</a> <comment type="action" name="addactive"></comment></li>
+<li><strong>addvoice</strong> / <a href="#addvoice">addvoice</a> <comment type="action" name="addvoice"></comment></li>
+<li><strong>against</strong> / <a href="#against">against</a> <comment type="action" name="against"></comment></li>
+<li><strong>cancel</strong> / <a href="#cancel">cancel</a> <comment type="action" name="cancel"></comment></li>
+<li><strong>changetrust</strong> / <a href="#changetrust">changetrust</a> <comment type="action" name="changetrust"></comment></li>
+<li><strong>checkstake</strong> / <a href="#checkstake">checkstake</a> <comment type="action" name="checkstake"></comment></li>
+<li><strong>create</strong> / <a href="#create">create</a> <comment type="action" name="create"></comment></li>
+<li><strong>createx</strong> / <a href="#createx">createx</a> <comment type="action" name="createx"></comment></li>
+<li><strong>decayvoice</strong> / <a href="#decayvoice">decayvoice</a> <comment type="action" name="decayvoice"></comment></li>
+<li><strong>decayvoices</strong> / <a href="#decayvoices">decayvoices</a> <comment type="action" name="decayvoices"></comment></li>
+<li><strong>erasepartpts</strong> / <a href="#erasepartpts">erasepartpts</a> <comment type="action" name="erasepartpts"></comment></li>
+<li><strong>favour</strong> / <a href="#favour">favour</a> <comment type="action" name="favour"></comment></li>
+<li><strong>initactives</strong> / <a href="#initactives">initactives</a> <comment type="action" name="initactives"></comment></li>
+<li><strong>initsz</strong> / <a href="#initsz">initsz</a> <comment type="action" name="initsz"></comment></li>
+<li><strong>neutral</strong> / <a href="#neutral">neutral</a> <comment type="action" name="neutral"></comment></li>
+<li><strong>onperiod</strong> / <a href="#onperiod">onperiod</a> <comment type="action" name="onperiod"></comment></li>
+<li><strong>removeactive</strong> / <a href="#removeactive">removeactive</a> <comment type="action" name="removeactive"></comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> <comment type="action" name="reset"></comment></li>
+<li><strong>stake</strong> / <a href="#stake">stake</a> <comment type="action" name="stake"></comment></li>
+<li><strong>testvdecay</strong> / <a href="#testvdecay">testvdecay</a> <comment type="action" name="testvdecay"></comment></li>
+<li><strong>update</strong> / <a href="#update">update</a> <comment type="action" name="update"></comment></li>
+<li><strong>updateactive</strong> / <a href="#updateactive">updateactive</a> <comment type="action" name="updateactive"></comment></li>
+<li><strong>updateactivs</strong> / <a href="#updateactivs">updateactivs</a> <comment type="action" name="updateactivs"></comment></li>
+<li><strong>updatevoice</strong> / <a href="#updatevoice">updatevoice</a> <comment type="action" name="updatevoice"></comment></li>
+<li><strong>updatevoices</strong> / <a href="#updatevoices">updatevoices</a> <comment type="action" name="updatevoices"></comment></li>
+<li><strong>updatex</strong> / <a href="#updatex">updatex</a> <comment type="action" name="updatex"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
 <ul>
-<li><strong>actives</strong> / <a href="#active_table">active_table</a> (i64) - <comment type="table" name="actives"></comment></li>
-<li><strong>cycle</strong> / <a href="#cycle_table">cycle_table</a> (i64) - <comment type="table" name="cycle"></comment></li>
-<li><strong>lastprops</strong> / <a href="#last_proposal_table">last_proposal_table</a> (i64) - <comment type="table" name="lastprops"></comment></li>
-<li><strong>minstake</strong> / <a href="#min_stake_table">min_stake_table</a> (i64) - <comment type="table" name="minstake"></comment></li>
-<li><strong>participants</strong> / <a href="#participant_table">participant_table</a> (i64) - <comment type="table" name="participants"></comment></li>
-<li><strong>props</strong> / <a href="#proposal_table">proposal_table</a> (i64) - <comment type="table" name="props"></comment></li>
-<li><strong>sizes</strong> / <a href="#size_table">size_table</a> (i64) - <comment type="table" name="sizes"></comment></li>
-<li><strong>users</strong> / <a href="#user_table">user_table</a> (i64) - <comment type="table" name="users"></comment></li>
-<li><strong>voice</strong> / <a href="#voice_table">voice_table</a> (i64) - <comment type="table" name="voice"></comment></li>
-<li><strong>votes</strong> / <a href="#vote_table">vote_table</a> (i64) - <comment type="table" name="votes"></comment></li>
+<li><strong>actives</strong> / <a href="#active_table">active_table</a> (i64) <comment type="table" name="actives"></comment></li>
+<li><strong>cycle</strong> / <a href="#cycle_table">cycle_table</a> (i64) <comment type="table" name="cycle"></comment></li>
+<li><strong>lastprops</strong> / <a href="#last_proposal_table">last_proposal_table</a> (i64) <comment type="table" name="lastprops"></comment></li>
+<li><strong>minstake</strong> / <a href="#min_stake_table">min_stake_table</a> (i64) <comment type="table" name="minstake"></comment></li>
+<li><strong>participants</strong> / <a href="#participant_table">participant_table</a> (i64) <comment type="table" name="participants"></comment></li>
+<li><strong>props</strong> / <a href="#proposal_table">proposal_table</a> (i64) <comment type="table" name="props"></comment></li>
+<li><strong>sizes</strong> / <a href="#size_table">size_table</a> (i64) <comment type="table" name="sizes"></comment></li>
+<li><strong>users</strong> / <a href="#user_table">user_table</a> (i64) <comment type="table" name="users"></comment></li>
+<li><strong>voice</strong> / <a href="#voice_table">voice_table</a> (i64) <comment type="table" name="voice"></comment></li>
+<li><strong>votes</strong> / <a href="#vote_table">vote_table</a> (i64) <comment type="table" name="votes"></comment></li>
 </ul>
 <h2>ABI Extensions</h2>
 <h2>Structs</h2>
@@ -293,19 +293,19 @@ $(function() {
 ## Actions
 
 {{#each actions}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/referendums.html
+++ b/docs/referendums.html
@@ -1,6 +1,14 @@
 <html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+<!-- Latest compiled and minified CSS -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
+
+<!-- Optional theme -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap-theme.min.css" integrity="sha384-6pzBo3FDv/PJ8r2KRkGHifhEocL+1X2rVCTTkUfGk7/0pbek5mMa1upzvWbrUbOZ" crossorigin="anonymous">
+
+<!-- Latest compiled and minified JavaScript -->
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
 </head><body onload="loadUser()">
   <div id="target"><h1>Smartcontract documentation for referendums</h1>

--- a/docs/referendums.html
+++ b/docs/referendums.html
@@ -28,23 +28,23 @@ $(function() {
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li><strong>addvoice</strong> / <a href="#addvoice">addvoice</a> - <comment type="action" name="addvoice"></comment></li>
-<li><strong>against</strong> / <a href="#against">against</a> - <comment type="action" name="against"></comment></li>
-<li><strong>cancelvote</strong> / <a href="#cancelvote">cancelvote</a> - <comment type="action" name="cancelvote"></comment></li>
-<li><strong>create</strong> / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
-<li><strong>favour</strong> / <a href="#favour">favour</a> - <comment type="action" name="favour"></comment></li>
-<li><strong>onperiod</strong> / <a href="#onperiod">onperiod</a> - <comment type="action" name="onperiod"></comment></li>
-<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
-<li><strong>stake</strong> / <a href="#stake">stake</a> - <comment type="action" name="stake"></comment></li>
-<li><strong>update</strong> / <a href="#update">update</a> - <comment type="action" name="update"></comment></li>
+<li><strong>addvoice</strong> / <a href="#addvoice">addvoice</a> <comment type="action" name="addvoice"></comment></li>
+<li><strong>against</strong> / <a href="#against">against</a> <comment type="action" name="against"></comment></li>
+<li><strong>cancelvote</strong> / <a href="#cancelvote">cancelvote</a> <comment type="action" name="cancelvote"></comment></li>
+<li><strong>create</strong> / <a href="#create">create</a> <comment type="action" name="create"></comment></li>
+<li><strong>favour</strong> / <a href="#favour">favour</a> <comment type="action" name="favour"></comment></li>
+<li><strong>onperiod</strong> / <a href="#onperiod">onperiod</a> <comment type="action" name="onperiod"></comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> <comment type="action" name="reset"></comment></li>
+<li><strong>stake</strong> / <a href="#stake">stake</a> <comment type="action" name="stake"></comment></li>
+<li><strong>update</strong> / <a href="#update">update</a> <comment type="action" name="update"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
 <ul>
-<li><strong>balances</strong> / <a href="#balance_table">balance_table</a> (i64) - <comment type="table" name="balances"></comment></li>
-<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) - <comment type="table" name="config"></comment></li>
-<li><strong>referendums</strong> / <a href="#referendum_table">referendum_table</a> (i64) - <comment type="table" name="referendums"></comment></li>
-<li><strong>voters</strong> / <a href="#voter_table">voter_table</a> (i64) - <comment type="table" name="voters"></comment></li>
+<li><strong>balances</strong> / <a href="#balance_table">balance_table</a> (i64) <comment type="table" name="balances"></comment></li>
+<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) <comment type="table" name="config"></comment></li>
+<li><strong>referendums</strong> / <a href="#referendum_table">referendum_table</a> (i64) <comment type="table" name="referendums"></comment></li>
+<li><strong>voters</strong> / <a href="#voter_table">voter_table</a> (i64) <comment type="table" name="voters"></comment></li>
 </ul>
 <h2>ABI Extensions</h2>
 <h2>Structs</h2>
@@ -154,19 +154,19 @@ $(function() {
 ## Actions
 
 {{#each actions}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/referendums.html
+++ b/docs/referendums.html
@@ -10,20 +10,33 @@
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
-</head><body onload="loadUser()">
+<script>
+$(function() {
+  var reader = new commonmark.Parser();
+  var writer = new commonmark.HtmlRenderer();
+
+  $('#target comment').each(function(i, elem) {
+    var parsed = reader.parse($(this).text()); 
+    var result = writer.render(parsed);
+    $(this).html(result);
+  });
+ });
+</script>
+
+</head><body>
   <div id="target"><h1>Smartcontract documentation for referendums</h1>
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li>addvoice / <a href="#addvoice">addvoice</a> - <comment type="action" name="addvoice"></comment></li>
-<li>against / <a href="#against">against</a> - <comment type="action" name="against"></comment></li>
-<li>cancelvote / <a href="#cancelvote">cancelvote</a> - <comment type="action" name="cancelvote"></comment></li>
-<li>create / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
-<li>favour / <a href="#favour">favour</a> - <comment type="action" name="favour"></comment></li>
-<li>onperiod / <a href="#onperiod">onperiod</a> - <comment type="action" name="onperiod"></comment></li>
-<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
-<li>stake / <a href="#stake">stake</a> - <comment type="action" name="stake"></comment></li>
-<li>update / <a href="#update">update</a> - <comment type="action" name="update"></comment></li>
+<li><strong>addvoice</strong> / <a href="#addvoice">addvoice</a> - <comment type="action" name="addvoice"></comment></li>
+<li><strong>against</strong> / <a href="#against">against</a> - <comment type="action" name="against"></comment></li>
+<li><strong>cancelvote</strong> / <a href="#cancelvote">cancelvote</a> - <comment type="action" name="cancelvote"></comment></li>
+<li><strong>create</strong> / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
+<li><strong>favour</strong> / <a href="#favour">favour</a> - <comment type="action" name="favour"></comment></li>
+<li><strong>onperiod</strong> / <a href="#onperiod">onperiod</a> - <comment type="action" name="onperiod"></comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li><strong>stake</strong> / <a href="#stake">stake</a> - <comment type="action" name="stake"></comment></li>
+<li><strong>update</strong> / <a href="#update">update</a> - <comment type="action" name="update"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
@@ -129,7 +142,7 @@
   <script id="template" type="x-tmpl-handlebars">
 # Smartcontract documentation for {{ file }}
 
-<comment type="main">{{comment}}</comment>
+<comment type="main"></comment>
 
 {{#if types}}
 ## Types
@@ -141,19 +154,19 @@
 ## Actions
 
 {{#each actions}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/referendums.html
+++ b/docs/referendums.html
@@ -1,0 +1,169 @@
+<html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+
+</head><body onload="loadUser()">
+  <div id="target"><h1>Smartcontract documentation for referendums</h1>
+<p><comment type="main"></comment></p>
+<h2>Actions</h2>
+<ul>
+<li>addvoice / <a href="#addvoice">addvoice</a> - <comment type="action" name="addvoice"></comment></li>
+<li>against / <a href="#against">against</a> - <comment type="action" name="against"></comment></li>
+<li>cancelvote / <a href="#cancelvote">cancelvote</a> - <comment type="action" name="cancelvote"></comment></li>
+<li>create / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
+<li>favour / <a href="#favour">favour</a> - <comment type="action" name="favour"></comment></li>
+<li>onperiod / <a href="#onperiod">onperiod</a> - <comment type="action" name="onperiod"></comment></li>
+<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li>stake / <a href="#stake">stake</a> - <comment type="action" name="stake"></comment></li>
+<li>update / <a href="#update">update</a> - <comment type="action" name="update"></comment></li>
+</ul>
+<h2>Events</h2>
+<h2>Tables</h2>
+<ul>
+<li><strong>balances</strong> / <a href="#balance_table">balance_table</a> (i64) - <comment type="table" name="balances"></comment></li>
+<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) - <comment type="table" name="config"></comment></li>
+<li><strong>referendums</strong> / <a href="#referendum_table">referendum_table</a> (i64) - <comment type="table" name="referendums"></comment></li>
+<li><strong>voters</strong> / <a href="#voter_table">voter_table</a> (i64) - <comment type="table" name="voters"></comment></li>
+</ul>
+<h2>ABI Extensions</h2>
+<h2>Structs</h2>
+<h3 id="addvoice"> addvoice </h3>
+<ul>
+<li>account / name</li>
+<li>amount / uint64</li>
+</ul>
+<h3 id="against"> against </h3>
+<ul>
+<li>voter / name</li>
+<li>referendum_id / uint64</li>
+<li>amount / uint64</li>
+</ul>
+<h3 id="balance_table"> balance_table </h3>
+<ul>
+<li>account / name</li>
+<li>stake / asset</li>
+<li>voice / uint64</li>
+</ul>
+<h3 id="cancelvote"> cancelvote </h3>
+<ul>
+<li>voter / name</li>
+<li>referendum_id / uint64</li>
+</ul>
+<h3 id="config_table"> config_table </h3>
+<ul>
+<li>param / name</li>
+<li>value / uint64</li>
+<li>description / string</li>
+<li>impact / name</li>
+</ul>
+<h3 id="create"> create </h3>
+<ul>
+<li>creator / name</li>
+<li>setting_name / name</li>
+<li>setting_value / uint64</li>
+<li>title / string</li>
+<li>summary / string</li>
+<li>description / string</li>
+<li>image / string</li>
+<li>url / string</li>
+</ul>
+<h3 id="favour"> favour </h3>
+<ul>
+<li>voter / name</li>
+<li>referendum_id / uint64</li>
+<li>amount / uint64</li>
+</ul>
+<h3 id="onperiod"> onperiod </h3>
+<h3 id="referendum_table"> referendum_table </h3>
+<ul>
+<li>referendum_id / uint64</li>
+<li>created_at / uint64</li>
+<li>setting_value / uint64</li>
+<li>favour / uint64</li>
+<li>against / uint64</li>
+<li>setting_name / name</li>
+<li>creator / name</li>
+<li>staked / asset</li>
+<li>title / string</li>
+<li>summary / string</li>
+<li>description / string</li>
+<li>image / string</li>
+<li>url / string</li>
+</ul>
+<h3 id="reset"> reset </h3>
+<h3 id="stake"> stake </h3>
+<ul>
+<li>from / name</li>
+<li>to / name</li>
+<li>quantity / asset</li>
+<li>memo / string</li>
+</ul>
+<h3 id="update"> update </h3>
+<ul>
+<li>creator / name</li>
+<li>setting_name / name</li>
+<li>setting_value / uint64</li>
+<li>title / string</li>
+<li>summary / string</li>
+<li>description / string</li>
+<li>image / string</li>
+<li>url / string</li>
+</ul>
+<h3 id="voter_table"> voter_table </h3>
+<ul>
+<li>account / name</li>
+<li>referendum_id / uint64</li>
+<li>amount / uint64</li>
+<li>favoured / bool</li>
+<li>canceled / bool</li>
+</ul>
+</div>
+  <script id="template" type="x-tmpl-handlebars">
+# Smartcontract documentation for {{ file }}
+
+<comment type="main">{{comment}}</comment>
+
+{{#if types}}
+## Types
+{{/if}}
+{{#each types}}
+  {{ name }}
+{{/each}}
+
+## Actions
+
+{{#each actions}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Events
+
+{{#each events}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Tables
+
+{{#each tables}}
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## ABI Extensions
+
+{{#each abi_extensions}}
+  - {{ name }}
+{{/each}}
+
+## Structs
+
+{{#each structs}}
+<h3 id={{ name }}> {{ name }} {{#if base}}( {{base}} ){{/if}}</h3>
+  
+  {{#each fields}}
+  - {{ name }} / {{ type }}
+  {{/each}}
+{{/each}}
+
+  </script>
+
+</body></html>

--- a/docs/scheduler.html
+++ b/docs/scheduler.html
@@ -1,0 +1,132 @@
+<html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+
+</head><body onload="loadUser()">
+  <div id="target"><h1>Smartcontract documentation for scheduler</h1>
+<p><comment type="main"></comment></p>
+<h2>Actions</h2>
+<ul>
+<li>configop / <a href="#configop">configop</a> - <comment type="action" name="configop"></comment></li>
+<li>confirm / <a href="#confirm">confirm</a> - <comment type="action" name="confirm"></comment></li>
+<li>execute / <a href="#execute">execute</a> - <comment type="action" name="execute"></comment></li>
+<li>pauseop / <a href="#pauseop">pauseop</a> - <comment type="action" name="pauseop"></comment></li>
+<li>removeop / <a href="#removeop">removeop</a> - <comment type="action" name="removeop"></comment></li>
+<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li>start / <a href="#start">start</a> - <comment type="action" name="start"></comment></li>
+<li>stop / <a href="#stop">stop</a> - <comment type="action" name="stop"></comment></li>
+<li>test1 / <a href="#test1">test1</a> - <comment type="action" name="test1"></comment></li>
+<li>test2 / <a href="#test2">test2</a> - <comment type="action" name="test2"></comment></li>
+<li>testexec / <a href="#testexec">testexec</a> - <comment type="action" name="testexec"></comment></li>
+</ul>
+<h2>Events</h2>
+<h2>Tables</h2>
+<ul>
+<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) - <comment type="table" name="config"></comment></li>
+<li><strong>operations</strong> / <a href="#operations_table">operations_table</a> (i64) - <comment type="table" name="operations"></comment></li>
+<li><strong>test</strong> / <a href="#test_table">test_table</a> (i64) - <comment type="table" name="test"></comment></li>
+</ul>
+<h2>ABI Extensions</h2>
+<h2>Structs</h2>
+<h3 id="config_table"> config_table </h3>
+<ul>
+<li>param / name</li>
+<li>value / uint64</li>
+<li>description / string</li>
+<li>impact / name</li>
+</ul>
+<h3 id="configop"> configop </h3>
+<ul>
+<li>id / name</li>
+<li>action / name</li>
+<li>contract / name</li>
+<li>period / uint64</li>
+<li>starttime / uint64</li>
+</ul>
+<h3 id="confirm"> confirm </h3>
+<ul>
+<li>operation / name</li>
+</ul>
+<h3 id="execute"> execute </h3>
+<h3 id="operations_table"> operations_table </h3>
+<ul>
+<li>id / name</li>
+<li>operation / name</li>
+<li>contract / name</li>
+<li>pause / uint8</li>
+<li>period / uint64</li>
+<li>timestamp / uint64</li>
+</ul>
+<h3 id="pauseop"> pauseop </h3>
+<ul>
+<li>id / name</li>
+<li>pause / uint8</li>
+</ul>
+<h3 id="removeop"> removeop </h3>
+<ul>
+<li>id / name</li>
+</ul>
+<h3 id="reset"> reset </h3>
+<h3 id="start"> start </h3>
+<h3 id="stop"> stop </h3>
+<h3 id="test1"> test1 </h3>
+<h3 id="test2"> test2 </h3>
+<h3 id="test_table"> test_table </h3>
+<ul>
+<li>param / name</li>
+<li>value / uint64</li>
+</ul>
+<h3 id="testexec"> testexec </h3>
+<ul>
+<li>op / name</li>
+</ul>
+</div>
+  <script id="template" type="x-tmpl-handlebars">
+# Smartcontract documentation for {{ file }}
+
+<comment type="main">{{comment}}</comment>
+
+{{#if types}}
+## Types
+{{/if}}
+{{#each types}}
+  {{ name }}
+{{/each}}
+
+## Actions
+
+{{#each actions}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Events
+
+{{#each events}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Tables
+
+{{#each tables}}
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## ABI Extensions
+
+{{#each abi_extensions}}
+  - {{ name }}
+{{/each}}
+
+## Structs
+
+{{#each structs}}
+<h3 id={{ name }}> {{ name }} {{#if base}}( {{base}} ){{/if}}</h3>
+  
+  {{#each fields}}
+  - {{ name }} / {{ type }}
+  {{/each}}
+{{/each}}
+
+  </script>
+
+</body></html>

--- a/docs/scheduler.html
+++ b/docs/scheduler.html
@@ -28,24 +28,24 @@ $(function() {
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li><strong>configop</strong> / <a href="#configop">configop</a> - <comment type="action" name="configop"></comment></li>
-<li><strong>confirm</strong> / <a href="#confirm">confirm</a> - <comment type="action" name="confirm"></comment></li>
-<li><strong>execute</strong> / <a href="#execute">execute</a> - <comment type="action" name="execute"></comment></li>
-<li><strong>pauseop</strong> / <a href="#pauseop">pauseop</a> - <comment type="action" name="pauseop"></comment></li>
-<li><strong>removeop</strong> / <a href="#removeop">removeop</a> - <comment type="action" name="removeop"></comment></li>
-<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
-<li><strong>start</strong> / <a href="#start">start</a> - <comment type="action" name="start"></comment></li>
-<li><strong>stop</strong> / <a href="#stop">stop</a> - <comment type="action" name="stop"></comment></li>
-<li><strong>test1</strong> / <a href="#test1">test1</a> - <comment type="action" name="test1"></comment></li>
-<li><strong>test2</strong> / <a href="#test2">test2</a> - <comment type="action" name="test2"></comment></li>
-<li><strong>testexec</strong> / <a href="#testexec">testexec</a> - <comment type="action" name="testexec"></comment></li>
+<li><strong>configop</strong> / <a href="#configop">configop</a> <comment type="action" name="configop"></comment></li>
+<li><strong>confirm</strong> / <a href="#confirm">confirm</a> <comment type="action" name="confirm"></comment></li>
+<li><strong>execute</strong> / <a href="#execute">execute</a> <comment type="action" name="execute"></comment></li>
+<li><strong>pauseop</strong> / <a href="#pauseop">pauseop</a> <comment type="action" name="pauseop"></comment></li>
+<li><strong>removeop</strong> / <a href="#removeop">removeop</a> <comment type="action" name="removeop"></comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> <comment type="action" name="reset"></comment></li>
+<li><strong>start</strong> / <a href="#start">start</a> <comment type="action" name="start"></comment></li>
+<li><strong>stop</strong> / <a href="#stop">stop</a> <comment type="action" name="stop"></comment></li>
+<li><strong>test1</strong> / <a href="#test1">test1</a> <comment type="action" name="test1"></comment></li>
+<li><strong>test2</strong> / <a href="#test2">test2</a> <comment type="action" name="test2"></comment></li>
+<li><strong>testexec</strong> / <a href="#testexec">testexec</a> <comment type="action" name="testexec"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
 <ul>
-<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) - <comment type="table" name="config"></comment></li>
-<li><strong>operations</strong> / <a href="#operations_table">operations_table</a> (i64) - <comment type="table" name="operations"></comment></li>
-<li><strong>test</strong> / <a href="#test_table">test_table</a> (i64) - <comment type="table" name="test"></comment></li>
+<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) <comment type="table" name="config"></comment></li>
+<li><strong>operations</strong> / <a href="#operations_table">operations_table</a> (i64) <comment type="table" name="operations"></comment></li>
+<li><strong>test</strong> / <a href="#test_table">test_table</a> (i64) <comment type="table" name="test"></comment></li>
 </ul>
 <h2>ABI Extensions</h2>
 <h2>Structs</h2>
@@ -117,19 +117,19 @@ $(function() {
 ## Actions
 
 {{#each actions}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/scheduler.html
+++ b/docs/scheduler.html
@@ -1,6 +1,14 @@
 <html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+<!-- Latest compiled and minified CSS -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
+
+<!-- Optional theme -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap-theme.min.css" integrity="sha384-6pzBo3FDv/PJ8r2KRkGHifhEocL+1X2rVCTTkUfGk7/0pbek5mMa1upzvWbrUbOZ" crossorigin="anonymous">
+
+<!-- Latest compiled and minified JavaScript -->
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
 </head><body onload="loadUser()">
   <div id="target"><h1>Smartcontract documentation for scheduler</h1>

--- a/docs/scheduler.html
+++ b/docs/scheduler.html
@@ -10,22 +10,35 @@
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
-</head><body onload="loadUser()">
+<script>
+$(function() {
+  var reader = new commonmark.Parser();
+  var writer = new commonmark.HtmlRenderer();
+
+  $('#target comment').each(function(i, elem) {
+    var parsed = reader.parse($(this).text()); 
+    var result = writer.render(parsed);
+    $(this).html(result);
+  });
+ });
+</script>
+
+</head><body>
   <div id="target"><h1>Smartcontract documentation for scheduler</h1>
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li>configop / <a href="#configop">configop</a> - <comment type="action" name="configop"></comment></li>
-<li>confirm / <a href="#confirm">confirm</a> - <comment type="action" name="confirm"></comment></li>
-<li>execute / <a href="#execute">execute</a> - <comment type="action" name="execute"></comment></li>
-<li>pauseop / <a href="#pauseop">pauseop</a> - <comment type="action" name="pauseop"></comment></li>
-<li>removeop / <a href="#removeop">removeop</a> - <comment type="action" name="removeop"></comment></li>
-<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
-<li>start / <a href="#start">start</a> - <comment type="action" name="start"></comment></li>
-<li>stop / <a href="#stop">stop</a> - <comment type="action" name="stop"></comment></li>
-<li>test1 / <a href="#test1">test1</a> - <comment type="action" name="test1"></comment></li>
-<li>test2 / <a href="#test2">test2</a> - <comment type="action" name="test2"></comment></li>
-<li>testexec / <a href="#testexec">testexec</a> - <comment type="action" name="testexec"></comment></li>
+<li><strong>configop</strong> / <a href="#configop">configop</a> - <comment type="action" name="configop"></comment></li>
+<li><strong>confirm</strong> / <a href="#confirm">confirm</a> - <comment type="action" name="confirm"></comment></li>
+<li><strong>execute</strong> / <a href="#execute">execute</a> - <comment type="action" name="execute"></comment></li>
+<li><strong>pauseop</strong> / <a href="#pauseop">pauseop</a> - <comment type="action" name="pauseop"></comment></li>
+<li><strong>removeop</strong> / <a href="#removeop">removeop</a> - <comment type="action" name="removeop"></comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li><strong>start</strong> / <a href="#start">start</a> - <comment type="action" name="start"></comment></li>
+<li><strong>stop</strong> / <a href="#stop">stop</a> - <comment type="action" name="stop"></comment></li>
+<li><strong>test1</strong> / <a href="#test1">test1</a> - <comment type="action" name="test1"></comment></li>
+<li><strong>test2</strong> / <a href="#test2">test2</a> - <comment type="action" name="test2"></comment></li>
+<li><strong>testexec</strong> / <a href="#testexec">testexec</a> - <comment type="action" name="testexec"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
@@ -92,7 +105,7 @@
   <script id="template" type="x-tmpl-handlebars">
 # Smartcontract documentation for {{ file }}
 
-<comment type="main">{{comment}}</comment>
+<comment type="main"></comment>
 
 {{#if types}}
 ## Types
@@ -104,19 +117,19 @@
 ## Actions
 
 {{#each actions}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/settings.html
+++ b/docs/settings.html
@@ -10,15 +10,28 @@
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
-</head><body onload="loadUser()">
+<script>
+$(function() {
+  var reader = new commonmark.Parser();
+  var writer = new commonmark.HtmlRenderer();
+
+  $('#target comment').each(function(i, elem) {
+    var parsed = reader.parse($(this).text()); 
+    var result = writer.render(parsed);
+    $(this).html(result);
+  });
+ });
+</script>
+
+</head><body>
   <div id="target"><h1>Smartcontract documentation for settings</h1>
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li>configure / <a href="#configure">configure</a> - <comment type="action" name="configure"></comment></li>
-<li>confwithdesc / <a href="#confwithdesc">confwithdesc</a> - <comment type="action" name="confwithdesc"></comment></li>
-<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
-<li>setcontract / <a href="#setcontract">setcontract</a> - <comment type="action" name="setcontract"></comment></li>
+<li><strong>configure</strong> / <a href="#configure">configure</a> - <comment type="action" name="configure"></comment></li>
+<li><strong>confwithdesc</strong> / <a href="#confwithdesc">confwithdesc</a> - <comment type="action" name="confwithdesc"></comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li><strong>setcontract</strong> / <a href="#setcontract">setcontract</a> - <comment type="action" name="setcontract"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
@@ -62,7 +75,7 @@
   <script id="template" type="x-tmpl-handlebars">
 # Smartcontract documentation for {{ file }}
 
-<comment type="main">{{comment}}</comment>
+<comment type="main"></comment>
 
 {{#if types}}
 ## Types
@@ -74,19 +87,19 @@
 ## Actions
 
 {{#each actions}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/settings.html
+++ b/docs/settings.html
@@ -1,0 +1,102 @@
+<html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+
+</head><body onload="loadUser()">
+  <div id="target"><h1>Smartcontract documentation for settings</h1>
+<p><comment type="main"></comment></p>
+<h2>Actions</h2>
+<ul>
+<li>configure / <a href="#configure">configure</a> - <comment type="action" name="configure"></comment></li>
+<li>confwithdesc / <a href="#confwithdesc">confwithdesc</a> - <comment type="action" name="confwithdesc"></comment></li>
+<li>reset / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
+<li>setcontract / <a href="#setcontract">setcontract</a> - <comment type="action" name="setcontract"></comment></li>
+</ul>
+<h2>Events</h2>
+<h2>Tables</h2>
+<ul>
+<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) - <comment type="table" name="config"></comment></li>
+<li><strong>contracts</strong> / <a href="#contracts_table">contracts_table</a> (i64) - <comment type="table" name="contracts"></comment></li>
+</ul>
+<h2>ABI Extensions</h2>
+<h2>Structs</h2>
+<h3 id="config_table"> config_table </h3>
+<ul>
+<li>param / name</li>
+<li>value / uint64</li>
+<li>description / string</li>
+<li>impact / name</li>
+</ul>
+<h3 id="configure"> configure </h3>
+<ul>
+<li>param / name</li>
+<li>value / uint64</li>
+</ul>
+<h3 id="confwithdesc"> confwithdesc </h3>
+<ul>
+<li>param / name</li>
+<li>value / uint64</li>
+<li>description / string</li>
+<li>impact / name</li>
+</ul>
+<h3 id="contracts_table"> contracts_table </h3>
+<ul>
+<li>contract / name</li>
+<li>account / name</li>
+</ul>
+<h3 id="reset"> reset </h3>
+<h3 id="setcontract"> setcontract </h3>
+<ul>
+<li>contract / name</li>
+<li>account / name</li>
+</ul>
+</div>
+  <script id="template" type="x-tmpl-handlebars">
+# Smartcontract documentation for {{ file }}
+
+<comment type="main">{{comment}}</comment>
+
+{{#if types}}
+## Types
+{{/if}}
+{{#each types}}
+  {{ name }}
+{{/each}}
+
+## Actions
+
+{{#each actions}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Events
+
+{{#each events}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Tables
+
+{{#each tables}}
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## ABI Extensions
+
+{{#each abi_extensions}}
+  - {{ name }}
+{{/each}}
+
+## Structs
+
+{{#each structs}}
+<h3 id={{ name }}> {{ name }} {{#if base}}( {{base}} ){{/if}}</h3>
+  
+  {{#each fields}}
+  - {{ name }} / {{ type }}
+  {{/each}}
+{{/each}}
+
+  </script>
+
+</body></html>

--- a/docs/settings.html
+++ b/docs/settings.html
@@ -28,16 +28,16 @@ $(function() {
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li><strong>configure</strong> / <a href="#configure">configure</a> - <comment type="action" name="configure"></comment></li>
-<li><strong>confwithdesc</strong> / <a href="#confwithdesc">confwithdesc</a> - <comment type="action" name="confwithdesc"></comment></li>
-<li><strong>reset</strong> / <a href="#reset">reset</a> - <comment type="action" name="reset"></comment></li>
-<li><strong>setcontract</strong> / <a href="#setcontract">setcontract</a> - <comment type="action" name="setcontract"></comment></li>
+<li><strong>configure</strong> / <a href="#configure">configure</a> <comment type="action" name="configure"></comment></li>
+<li><strong>confwithdesc</strong> / <a href="#confwithdesc">confwithdesc</a> <comment type="action" name="confwithdesc"></comment></li>
+<li><strong>reset</strong> / <a href="#reset">reset</a> <comment type="action" name="reset"></comment></li>
+<li><strong>setcontract</strong> / <a href="#setcontract">setcontract</a> <comment type="action" name="setcontract"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
 <ul>
-<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) - <comment type="table" name="config"></comment></li>
-<li><strong>contracts</strong> / <a href="#contracts_table">contracts_table</a> (i64) - <comment type="table" name="contracts"></comment></li>
+<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) <comment type="table" name="config"></comment></li>
+<li><strong>contracts</strong> / <a href="#contracts_table">contracts_table</a> (i64) <comment type="table" name="contracts"></comment></li>
 </ul>
 <h2>ABI Extensions</h2>
 <h2>Structs</h2>
@@ -87,19 +87,19 @@ $(function() {
 ## Actions
 
 {{#each actions}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/settings.html
+++ b/docs/settings.html
@@ -1,6 +1,14 @@
 <html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+<!-- Latest compiled and minified CSS -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
+
+<!-- Optional theme -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap-theme.min.css" integrity="sha384-6pzBo3FDv/PJ8r2KRkGHifhEocL+1X2rVCTTkUfGk7/0pbek5mMa1upzvWbrUbOZ" crossorigin="anonymous">
+
+<!-- Latest compiled and minified JavaScript -->
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
 </head><body onload="loadUser()">
   <div id="target"><h1>Smartcontract documentation for settings</h1>

--- a/docs/token.html
+++ b/docs/token.html
@@ -1,0 +1,157 @@
+<html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+
+</head><body onload="loadUser()">
+  <div id="target"><h1>Smartcontract documentation for token</h1>
+<p><comment type="main"></comment></p>
+<h2>Actions</h2>
+<ul>
+<li>burn / <a href="#burn">burn</a> - <comment type="action" name="burn"></comment></li>
+<li>close / <a href="#close">close</a> - <comment type="action" name="close"></comment></li>
+<li>create / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
+<li>issue / <a href="#issue">issue</a> - <comment type="action" name="issue"></comment></li>
+<li>open / <a href="#open">open</a> - <comment type="action" name="open"></comment></li>
+<li>resetweekly / <a href="#resetweekly">resetweekly</a> - <comment type="action" name="resetweekly"></comment></li>
+<li>resetwhelper / <a href="#resetwhelper">resetwhelper</a> - <comment type="action" name="resetwhelper"></comment></li>
+<li>retire / <a href="#retire">retire</a> - <comment type="action" name="retire"></comment></li>
+<li>transfer / <a href="#transfer">transfer</a> - <comment type="action" name="transfer"></comment></li>
+<li>updatecirc / <a href="#updatecirc">updatecirc</a> - <comment type="action" name="updatecirc"></comment></li>
+</ul>
+<h2>Events</h2>
+<h2>Tables</h2>
+<ul>
+<li><strong>accounts</strong> / <a href="#account">account</a> (i64) - <comment type="table" name="accounts"></comment></li>
+<li><strong>circulating</strong> / <a href="#circulating_supply_table">circulating_supply_table</a> (i64) - <comment type="table" name="circulating"></comment></li>
+<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) - <comment type="table" name="config"></comment></li>
+<li><strong>stat</strong> / <a href="#currency_stats">currency_stats</a> (i64) - <comment type="table" name="stat"></comment></li>
+<li><strong>trxstat</strong> / <a href="#transaction_stats">transaction_stats</a> (i64) - <comment type="table" name="trxstat"></comment></li>
+</ul>
+<h2>ABI Extensions</h2>
+<h2>Structs</h2>
+<h3 id="account"> account </h3>
+<ul>
+<li>balance / asset</li>
+</ul>
+<h3 id="burn"> burn </h3>
+<ul>
+<li>from / name</li>
+<li>quantity / asset</li>
+</ul>
+<h3 id="circulating_supply_table"> circulating_supply_table </h3>
+<ul>
+<li>id / uint64</li>
+<li>total / uint64</li>
+<li>circulating / uint64</li>
+</ul>
+<h3 id="close"> close </h3>
+<ul>
+<li>owner / name</li>
+<li>symbol / symbol</li>
+</ul>
+<h3 id="config_table"> config_table </h3>
+<ul>
+<li>param / name</li>
+<li>value / uint64</li>
+<li>description / string</li>
+<li>impact / name</li>
+</ul>
+<h3 id="create"> create </h3>
+<ul>
+<li>issuer / name</li>
+<li>initial_supply / asset</li>
+</ul>
+<h3 id="currency_stats"> currency_stats </h3>
+<ul>
+<li>supply / asset</li>
+<li>initial_supply / asset</li>
+<li>issuer / name</li>
+</ul>
+<h3 id="issue"> issue </h3>
+<ul>
+<li>to / name</li>
+<li>quantity / asset</li>
+<li>memo / string</li>
+</ul>
+<h3 id="open"> open </h3>
+<ul>
+<li>owner / name</li>
+<li>symbol / symbol</li>
+<li>ram_payer / name</li>
+</ul>
+<h3 id="resetweekly"> resetweekly </h3>
+<h3 id="resetwhelper"> resetwhelper </h3>
+<ul>
+<li>begin / uint64</li>
+</ul>
+<h3 id="retire"> retire </h3>
+<ul>
+<li>quantity / asset</li>
+<li>memo / string</li>
+</ul>
+<h3 id="transaction_stats"> transaction_stats </h3>
+<ul>
+<li>account / name</li>
+<li>transactions_volume / asset</li>
+<li>total_transactions / uint64</li>
+<li>incoming_transactions / uint64</li>
+<li>outgoing_transactions / uint64</li>
+</ul>
+<h3 id="transfer"> transfer </h3>
+<ul>
+<li>from / name</li>
+<li>to / name</li>
+<li>quantity / asset</li>
+<li>memo / string</li>
+</ul>
+<h3 id="updatecirc"> updatecirc </h3>
+</div>
+  <script id="template" type="x-tmpl-handlebars">
+# Smartcontract documentation for {{ file }}
+
+<comment type="main">{{comment}}</comment>
+
+{{#if types}}
+## Types
+{{/if}}
+{{#each types}}
+  {{ name }}
+{{/each}}
+
+## Actions
+
+{{#each actions}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Events
+
+{{#each events}}
+  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## Tables
+
+{{#each tables}}
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+{{/each}}
+
+## ABI Extensions
+
+{{#each abi_extensions}}
+  - {{ name }}
+{{/each}}
+
+## Structs
+
+{{#each structs}}
+<h3 id={{ name }}> {{ name }} {{#if base}}( {{base}} ){{/if}}</h3>
+  
+  {{#each fields}}
+  - {{ name }} / {{ type }}
+  {{/each}}
+{{/each}}
+
+  </script>
+
+</body></html>

--- a/docs/token.html
+++ b/docs/token.html
@@ -10,21 +10,34 @@
 <!-- Latest compiled and minified JavaScript -->
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
-</head><body onload="loadUser()">
+<script>
+$(function() {
+  var reader = new commonmark.Parser();
+  var writer = new commonmark.HtmlRenderer();
+
+  $('#target comment').each(function(i, elem) {
+    var parsed = reader.parse($(this).text()); 
+    var result = writer.render(parsed);
+    $(this).html(result);
+  });
+ });
+</script>
+
+</head><body>
   <div id="target"><h1>Smartcontract documentation for token</h1>
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li>burn / <a href="#burn">burn</a> - <comment type="action" name="burn"></comment></li>
-<li>close / <a href="#close">close</a> - <comment type="action" name="close"></comment></li>
-<li>create / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
-<li>issue / <a href="#issue">issue</a> - <comment type="action" name="issue"></comment></li>
-<li>open / <a href="#open">open</a> - <comment type="action" name="open"></comment></li>
-<li>resetweekly / <a href="#resetweekly">resetweekly</a> - <comment type="action" name="resetweekly"></comment></li>
-<li>resetwhelper / <a href="#resetwhelper">resetwhelper</a> - <comment type="action" name="resetwhelper"></comment></li>
-<li>retire / <a href="#retire">retire</a> - <comment type="action" name="retire"></comment></li>
-<li>transfer / <a href="#transfer">transfer</a> - <comment type="action" name="transfer"></comment></li>
-<li>updatecirc / <a href="#updatecirc">updatecirc</a> - <comment type="action" name="updatecirc"></comment></li>
+<li><strong>burn</strong> / <a href="#burn">burn</a> - <comment type="action" name="burn"></comment></li>
+<li><strong>close</strong> / <a href="#close">close</a> - <comment type="action" name="close"></comment></li>
+<li><strong>create</strong> / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
+<li><strong>issue</strong> / <a href="#issue">issue</a> - <comment type="action" name="issue"></comment></li>
+<li><strong>open</strong> / <a href="#open">open</a> - <comment type="action" name="open"></comment></li>
+<li><strong>resetweekly</strong> / <a href="#resetweekly">resetweekly</a> - <comment type="action" name="resetweekly"></comment></li>
+<li><strong>resetwhelper</strong> / <a href="#resetwhelper">resetwhelper</a> - <comment type="action" name="resetwhelper"></comment></li>
+<li><strong>retire</strong> / <a href="#retire">retire</a> - <comment type="action" name="retire"></comment></li>
+<li><strong>transfer</strong> / <a href="#transfer">transfer</a> - <comment type="action" name="transfer"></comment></li>
+<li><strong>updatecirc</strong> / <a href="#updatecirc">updatecirc</a> - <comment type="action" name="updatecirc"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
@@ -117,7 +130,7 @@
   <script id="template" type="x-tmpl-handlebars">
 # Smartcontract documentation for {{ file }}
 
-<comment type="main">{{comment}}</comment>
+<comment type="main"></comment>
 
 {{#if types}}
 ## Types
@@ -129,19 +142,19 @@
 ## Actions
 
 {{#each actions}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - {{ name }} / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}">{{comment}}</comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/token.html
+++ b/docs/token.html
@@ -28,25 +28,25 @@ $(function() {
 <p><comment type="main"></comment></p>
 <h2>Actions</h2>
 <ul>
-<li><strong>burn</strong> / <a href="#burn">burn</a> - <comment type="action" name="burn"></comment></li>
-<li><strong>close</strong> / <a href="#close">close</a> - <comment type="action" name="close"></comment></li>
-<li><strong>create</strong> / <a href="#create">create</a> - <comment type="action" name="create"></comment></li>
-<li><strong>issue</strong> / <a href="#issue">issue</a> - <comment type="action" name="issue"></comment></li>
-<li><strong>open</strong> / <a href="#open">open</a> - <comment type="action" name="open"></comment></li>
-<li><strong>resetweekly</strong> / <a href="#resetweekly">resetweekly</a> - <comment type="action" name="resetweekly"></comment></li>
-<li><strong>resetwhelper</strong> / <a href="#resetwhelper">resetwhelper</a> - <comment type="action" name="resetwhelper"></comment></li>
-<li><strong>retire</strong> / <a href="#retire">retire</a> - <comment type="action" name="retire"></comment></li>
-<li><strong>transfer</strong> / <a href="#transfer">transfer</a> - <comment type="action" name="transfer"></comment></li>
-<li><strong>updatecirc</strong> / <a href="#updatecirc">updatecirc</a> - <comment type="action" name="updatecirc"></comment></li>
+<li><strong>burn</strong> / <a href="#burn">burn</a> <comment type="action" name="burn"></comment></li>
+<li><strong>close</strong> / <a href="#close">close</a> <comment type="action" name="close"></comment></li>
+<li><strong>create</strong> / <a href="#create">create</a> <comment type="action" name="create"></comment></li>
+<li><strong>issue</strong> / <a href="#issue">issue</a> <comment type="action" name="issue"></comment></li>
+<li><strong>open</strong> / <a href="#open">open</a> <comment type="action" name="open"></comment></li>
+<li><strong>resetweekly</strong> / <a href="#resetweekly">resetweekly</a> <comment type="action" name="resetweekly"></comment></li>
+<li><strong>resetwhelper</strong> / <a href="#resetwhelper">resetwhelper</a> <comment type="action" name="resetwhelper"></comment></li>
+<li><strong>retire</strong> / <a href="#retire">retire</a> <comment type="action" name="retire"></comment></li>
+<li><strong>transfer</strong> / <a href="#transfer">transfer</a> <comment type="action" name="transfer"></comment></li>
+<li><strong>updatecirc</strong> / <a href="#updatecirc">updatecirc</a> <comment type="action" name="updatecirc"></comment></li>
 </ul>
 <h2>Events</h2>
 <h2>Tables</h2>
 <ul>
-<li><strong>accounts</strong> / <a href="#account">account</a> (i64) - <comment type="table" name="accounts"></comment></li>
-<li><strong>circulating</strong> / <a href="#circulating_supply_table">circulating_supply_table</a> (i64) - <comment type="table" name="circulating"></comment></li>
-<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) - <comment type="table" name="config"></comment></li>
-<li><strong>stat</strong> / <a href="#currency_stats">currency_stats</a> (i64) - <comment type="table" name="stat"></comment></li>
-<li><strong>trxstat</strong> / <a href="#transaction_stats">transaction_stats</a> (i64) - <comment type="table" name="trxstat"></comment></li>
+<li><strong>accounts</strong> / <a href="#account">account</a> (i64) <comment type="table" name="accounts"></comment></li>
+<li><strong>circulating</strong> / <a href="#circulating_supply_table">circulating_supply_table</a> (i64) <comment type="table" name="circulating"></comment></li>
+<li><strong>config</strong> / <a href="#config_table">config_table</a> (i64) <comment type="table" name="config"></comment></li>
+<li><strong>stat</strong> / <a href="#currency_stats">currency_stats</a> (i64) <comment type="table" name="stat"></comment></li>
+<li><strong>trxstat</strong> / <a href="#transaction_stats">transaction_stats</a> (i64) <comment type="table" name="trxstat"></comment></li>
 </ul>
 <h2>ABI Extensions</h2>
 <h2>Structs</h2>
@@ -142,19 +142,19 @@ $(function() {
 ## Actions
 
 {{#each actions}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="action" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="action" name="{{name}}"></comment>
 {{/each}}
 
 ## Events
 
 {{#each events}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) - <comment type="event" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) <comment type="event" name="{{name}}"></comment>
 {{/each}}
 
 ## Tables
 
 {{#each tables}}
-  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) - <comment type="table" name="{{name}}"></comment>
+  - **{{ name }}** / [{{ type }}](#{{ type }}) ({{ index_type }}) <comment type="table" name="{{name}}"></comment>
 {{/each}}
 
 ## ABI Extensions

--- a/docs/token.html
+++ b/docs/token.html
@@ -1,6 +1,14 @@
 <html><head><script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.7.6/handlebars.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/commonmark/0.28.1/commonmark.min.js"></script>
+<!-- Latest compiled and minified CSS -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
+
+<!-- Optional theme -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap-theme.min.css" integrity="sha384-6pzBo3FDv/PJ8r2KRkGHifhEocL+1X2rVCTTkUfGk7/0pbek5mMa1upzvWbrUbOZ" crossorigin="anonymous">
+
+<!-- Latest compiled and minified JavaScript -->
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
 </head><body onload="loadUser()">
   <div id="target"><h1>Smartcontract documentation for token</h1>

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
     "dotenv": "^8.1.0",
     "eosjs": "^16.0.9",
     "eosjs-ecc": "^4.0.7",
+    "handlebars": "^4.7.6",
     "json": "^9.0.6",
     "mocha": "^6.1.4",
     "moment": "^2.24.0",
-    "mustache": "^4.0.1",
     "ramda": "^0.26.1",
     "riteway": "^6.0.3",
     "tap-nirvana": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -16,13 +16,16 @@
   "dependencies": {
     "bignumber.js": "^8.1.1",
     "chai": "^4.2.0",
+    "cheerio": "^1.0.0-rc.3",
     "commander": "^3.0.2",
+    "commonmark": "^0.29.2",
     "dotenv": "^8.1.0",
     "eosjs": "^16.0.9",
     "eosjs-ecc": "^4.0.7",
     "json": "^9.0.6",
     "mocha": "^6.1.4",
     "moment": "^2.24.0",
+    "mustache": "^4.0.1",
     "ramda": "^0.26.1",
     "riteway": "^6.0.3",
     "tap-nirvana": "^1.1.0"

--- a/scripts/docsgen.js
+++ b/scripts/docsgen.js
@@ -56,6 +56,24 @@ const docsgen = async (contract) => {
         var result = writer.render(parsed);
         $('#target').html(result);
 
+        $('#target comment').each(function(i, elem) {
+            if ($(this).attr("type") == "main") {
+                $(this).text(abiContents["comment"]);
+            } else {
+                const desired_type = $(this).attr("type")+"s"; 
+                const desired_name = $(this).attr("name");
+                if ($(this).attr("type") == "action") {
+                    var old = abiContents[desired_type].find(function (e) { 
+                        return e["name"]==desired_name;
+                    });
+                    if (old) {
+                        var pos = abiContents[desired_type].indexOf(old)
+                        $(this).text(abiContents[desired_type][pos]["comment"]);    
+                    }
+                }
+            }
+        });
+
         fs.writeFile(outputPath, $.html(), function (err) {
             if (err) throw err;
             console.log('Saved!');

--- a/scripts/docsgen.js
+++ b/scripts/docsgen.js
@@ -1,0 +1,47 @@
+require('dotenv').config()
+const fs = require(`fs`)
+const path = require(`path`)
+const Mustache = require('mustache')
+const cheerio = require('cheerio')
+const commonmark = require('commonmark')
+const { Serialize, api } = require(`eosjs`)
+
+const { exec } = require('child_process')
+const { promisify } = require('util')
+
+const { source } = require('./deploy')
+
+const existsAsync = promisify(fs.exists)
+const mkdirAsync = promisify(fs.mkdir)
+const unlinkAsync = promisify(fs.unlink)
+const readFileAsync = promisify(fs.readFile)
+const execAsync = promisify(exec)
+
+const docsgen = async (contract) => {
+    try {
+        const abiPath = path.join(__dirname, '../artifacts', contract.concat('.abi'))
+        const outputPath = path.join(__dirname, '../docs', contract.concat('.html'))
+        const templatePath = path.join(__dirname, '../docs/docstemplate.html')
+        var abiFile = await readFileAsync(abiPath, "utf8")
+        var templateFile = await readFileAsync(templatePath, "utf8")
+        console.log(`generating docs for: ${contract}`)
+        const $ = cheerio.load(templateFile)
+        var template = $('#template').html();
+        var rendered = Mustache.render(template, JSON.parse(abiFile));
+        $('#target').html(rendered);
+        var reader = new commonmark.Parser();
+        var writer = new commonmark.HtmlRenderer();
+        var parsed = reader.parse($('#target').html());
+        var result = writer.render(parsed);
+        $('#target').html(result);
+
+        fs.writeFile(outputPath, $.html(), function (err) {
+            if (err) throw err;
+            console.log('Saved!');
+          });
+    } catch (err) {
+        console.log("doc generation failed for " + contract + " error: " + err)
+    }
+}
+
+module.exports = docsgen

--- a/scripts/docsgen.js
+++ b/scripts/docsgen.js
@@ -25,8 +25,10 @@ const docsgen = async (contract) => {
             //remove unwanted from the list
             files.splice(files.indexOf("index.html"), 1);
             files.splice(files.indexOf("docstemplate.html"), 1);
-            abiContents = {"contracts": files.map(function(contract) {
-                return {"name":contract.substring(0, contract.length-5), "file": contract};
+            abiContents = {"contracts": files.map(function(file) {
+                return {"contract": "seeds."+file.substring(0, file.length-5),
+                        "name": file.substring(0, file.length-5),
+                        "file": file};
             })};
             templatePath = path.join(__dirname, '../docs/index.html')
         } else {
@@ -55,8 +57,7 @@ const docsgen = async (contract) => {
                     if (old) {
                         var pos = abiContents[desired_type].indexOf(old)
                         abiContents[desired_type][pos]["comment"] = $(this).text();    
-                    }
-        
+                    }        
                 }
             });
         }
@@ -79,14 +80,12 @@ const docsgen = async (contract) => {
             } else {
                 const desired_type = $(this).attr("type")+"s"; 
                 const desired_name = $(this).attr("name");
-                if ($(this).attr("type") == "action") {
-                    var old = abiContents[desired_type].find(function (e) { 
-                        return e["name"]==desired_name;
-                    });
-                    if (old) {
-                        var pos = abiContents[desired_type].indexOf(old)
-                        $(this).text(abiContents[desired_type][pos]["comment"]);    
-                    }
+                var old = abiContents[desired_type].find(function (e) { 
+                    return e["name"]==desired_name;
+                });
+                if (old) {
+                    var pos = abiContents[desired_type].indexOf(old)
+                    $(this).text(abiContents[desired_type][pos]["comment"]);    
                 }
             }
         });

--- a/scripts/docsgen.js
+++ b/scripts/docsgen.js
@@ -1,7 +1,7 @@
 require('dotenv').config()
 const fs = require(`fs`)
 const path = require(`path`)
-const Mustache = require('mustache')
+const Handlebars = require("handlebars");
 const cheerio = require('cheerio')
 const commonmark = require('commonmark')
 const { Serialize, api } = require(`eosjs`)
@@ -11,11 +11,7 @@ const { promisify } = require('util')
 
 const { source } = require('./deploy')
 
-const existsAsync = promisify(fs.exists)
-const mkdirAsync = promisify(fs.mkdir)
-const unlinkAsync = promisify(fs.unlink)
 const readFileAsync = promisify(fs.readFile)
-const execAsync = promisify(exec)
 
 const docsgen = async (contract) => {
     try {
@@ -23,11 +19,36 @@ const docsgen = async (contract) => {
         const outputPath = path.join(__dirname, '../docs', contract.concat('.html'))
         const templatePath = path.join(__dirname, '../docs/docstemplate.html')
         var abiFile = await readFileAsync(abiPath, "utf8")
+        var abiContents = JSON.parse(abiFile);
+        abiContents["file"] = contract;
+
+        // Imports comments from previous genrated page
+        if (fs.existsSync(outputPath)) {
+            var outFile = await readFileAsync(outputPath, "utf8")
+            const $ = cheerio.load(outFile)
+            $('#target comment').each(function(i, elem) {
+                if ($(this).attr("type") == "main") {
+                    abiContents["comment"] = $(this).text();
+                } else {
+                    const desired_type = $(this).attr("type")+"s"; 
+                    const desired_name = $(this).attr("name");
+                    var old = abiContents[desired_type].find(function (e) { 
+                        return e["name"]==desired_name;
+                    });
+                    if (old) {
+                        var pos = abiContents[desired_type].indexOf(old)
+                        abiContents[desired_type][pos]["comment"] = $(this).text();    
+                    }
+        
+                }
+            });
+        }
         var templateFile = await readFileAsync(templatePath, "utf8")
         console.log(`generating docs for: ${contract}`)
         const $ = cheerio.load(templateFile)
-        var template = $('#template').html();
-        var rendered = Mustache.render(template, JSON.parse(abiFile));
+        var templateCode = $('#template').html();
+        const template = Handlebars.compile(templateCode);
+        var rendered = template(abiContents);
         $('#target').html(rendered);
         var reader = new commonmark.Parser();
         var writer = new commonmark.HtmlRenderer();

--- a/scripts/seeds.js
+++ b/scripts/seeds.js
@@ -4,6 +4,7 @@ const test = require('./test')
 const program = require('commander')
 const compile = require('./compile')
 const { isLocal, names, allContracts, allContractNames, allBankAccountNames } = require('./helper')
+const docsgen = require('./docsgen')
 const { harvest } = names
 
 const deploy = require('./deploy.command')
@@ -137,35 +138,35 @@ program
     await batchCallFunc(contract, moreContracts, runAction)
   })
 
-  program
+program
   .command('test <contract> [moreContracts...]')
   .description('Run unit tests for deployed contract')
   .action(async function(contract, moreContracts) {
     await batchCallFunc(contract, moreContracts, test)
   })
 
-  program
+program
   .command('reset <contract> [moreContracts...]')
   .description('Reset deployed contract')
   .action(async function(contract, moreContracts) {
     await batchCallFunc(contract, moreContracts, resetAction)
   })
 
-  program
+program
   .command('init')
   .description('Initial creation of all accounts and contracts contract')
   .action(async function(contract) {
     await initAction()
   })
 
-  program
+program
   .command('updatePermissions')
   .description('Update all permissions of all contracts')
   .action(async function(contract) {
     await updatePermissionAction()
   })
 
-  program
+program
   .command('list')
   .description('List all contracts / accounts')
   .action(async function() {
@@ -175,7 +176,7 @@ program
     allContractNames.forEach(item=>console.print(item))
   })
 
-  program
+program
   .command('changekey <contract> <key>')
   .description('Change owner and active key')
   .action(async function(contract, key) {
@@ -183,7 +184,7 @@ program
     await changeOwnerAndActivePermission(contract, key)
   })
 
-  program
+program
   .command('change_key_permission <contract> <role> <parentrole> <key>')
   .description('Change owner and active key')
   .action(async function(contract, role, parentrole, key) {
@@ -191,6 +192,12 @@ program
     await changeExistingKeyPermission(contract, role, parentrole, key)
   })
 
+program
+  .command('docsgen <contract> [moreContracts...]')
+  .description('Exports SDK docs for contract')
+  .action(async function(contract, moreContracts) {
+    await batchCallFunc(contract, moreContracts, docsgen)
+  })
 
 program.parse(process.argv)
 


### PR DESCRIPTION
Added a command to script.js to enable automatic ABI docs generation.

1. Remember to do `npm install` again to load new deps
2. Run `./scripts/seeds.js docsgen all`
3. Check the "docs" folder, it should have html files for all the contracts

If you change the contents of the `<comment>` tags inside the HTML files, they will be untouched by new executions of the docsgen command, even if new tables or actions are created. 