### PR TITLE
Unified QEV Calculation #167

### DIFF
--- a/include/seeds.accounts.hpp
+++ b/include/seeds.accounts.hpp
@@ -28,7 +28,8 @@ CONTRACT accounts : public contract {
           balances(contracts::harvest, contracts::harvest.value),
           config(contracts::settings, contracts::settings.value),
           accts(contracts::token, contracts::token.value),
-          actives(contracts::proposals, contracts::proposals.value)
+          actives(contracts::proposals, contracts::proposals.value),
+          totals(contracts::history, contracts::history.value)
           {}
 
       ACTION reset();
@@ -224,23 +225,17 @@ CONTRACT accounts : public contract {
     price_history_tables pricehistory;
 
     // From history contract
-    TABLE transaction_table {
-       uint64_t id;
-       name to;
-       asset quantity;
-       uint64_t timestamp;
+    TABLE totals_table {
+      name account;
+      uint64_t total_volume;
+      uint64_t total_number_of_transactions;
+      uint64_t total_incoming_from_rep_orgs;
+      uint64_t total_outgoing_to_rep_orgs;
 
-       uint64_t primary_key() const { return id; }
-       uint64_t by_timestamp() const { return timestamp; }
-       uint64_t by_to() const { return to.value; }
-       uint64_t by_quantity() const { return quantity.amount; }
+      uint64_t primary_key() const { return account.value; }
     };
-
-    typedef eosio::multi_index<"transactions"_n, transaction_table,
-      indexed_by<"bytimestamp"_n,const_mem_fun<transaction_table, uint64_t, &transaction_table::by_timestamp>>,
-      indexed_by<"byquantity"_n,const_mem_fun<transaction_table, uint64_t, &transaction_table::by_quantity>>,
-      indexed_by<"byto"_n,const_mem_fun<transaction_table, uint64_t, &transaction_table::by_to>>
-    > transaction_tables;
+    typedef eosio::multi_index<"totals"_n, totals_table> totals_tables;
+    totals_tables totals;
 
     // From proposals contract
     TABLE active_table {
@@ -252,6 +247,7 @@ CONTRACT accounts : public contract {
     };
     typedef eosio::multi_index<"actives"_n, active_table> active_tables;
     active_tables actives;
+
 };
 
 EOSIO_DISPATCH(accounts, (reset)(adduser)(canresident)(makeresident)(cancitizen)(makecitizen)(update)(addref)(invitevouch)(addrep)(changesize)

--- a/include/seeds.accounts.hpp
+++ b/include/seeds.accounts.hpp
@@ -27,7 +27,7 @@ CONTRACT accounts : public contract {
           config(contracts::settings, contracts::settings.value),
           accts(contracts::token, contracts::token.value),
           actives(contracts::proposals, contracts::proposals.value),
-          totals(contracts::history, contracts::history.value)
+          totals(contracts::history, contracts::history.value),
           residents(contracts::history, contracts::history.value),
           citizens(contracts::history, contracts::history.value),
           history_sizes(contracts::history, contracts::history.value)

--- a/include/seeds.harvest.hpp
+++ b/include/seeds.harvest.hpp
@@ -202,18 +202,6 @@ CONTRACT harvest : public contract {
     typedef singleton<"total"_n, total_table> total_tables;
     typedef eosio::multi_index<"total"_n, total_table> dump_for_total;
 
-    TABLE transaction_table { // from History contract - scoped by 'from'
-       uint64_t id;
-       name to;
-       asset quantity;
-       uint64_t timestamp;
-
-       uint64_t primary_key() const { return id; }
-       uint64_t by_timestamp() const { return timestamp; }
-       uint64_t by_to() const { return to.value; }
-       uint64_t by_quantity() const { return quantity.amount; }
-    };
-
     typedef eosio::multi_index<"refunds"_n, refund_table> refund_tables;
 
     typedef eosio::multi_index<"balances"_n, balance_table,
@@ -221,11 +209,56 @@ CONTRACT harvest : public contract {
         const_mem_fun<balance_table, uint64_t, &balance_table::by_planted>>
     > balance_tables;
 
-    typedef eosio::multi_index<"transactions"_n, transaction_table,
-      indexed_by<"bytimestamp"_n,const_mem_fun<transaction_table, uint64_t, &transaction_table::by_timestamp>>,
-      indexed_by<"byquantity"_n,const_mem_fun<transaction_table, uint64_t, &transaction_table::by_quantity>>,
-      indexed_by<"byto"_n,const_mem_fun<transaction_table, uint64_t, &transaction_table::by_to>>
-    > transaction_tables;
+
+    // new tables ------------------------------
+
+    TABLE transaction_points_table { // scoped by account
+      uint64_t timestamp;
+      uint64_t points;
+
+      uint64_t primary_key() const { return timestamp; }
+      uint64_t by_points() const { return points; }
+    };
+
+    TABLE qev_table { // scoped by account
+      uint64_t timestamp;
+      uint64_t qualifying_volume;
+
+      uint64_t primary_key() const { return timestamp; }
+      uint64_t by_volume() const { return qualifying_volume; }
+    };
+
+    typedef eosio::multi_index<"trxpoints"_n, transaction_points_table,
+      indexed_by<"bypoints"_n,
+      const_mem_fun<transaction_points_table, uint64_t, &transaction_points_table::by_points>>
+    > transaction_points_tables;
+
+    typedef eosio::multi_index<"qevs"_n, qev_table,
+      indexed_by<"byvolume"_n,
+      const_mem_fun<qev_table, uint64_t, &qev_table::by_volume>>
+    > qev_tables;
+
+    // -----------------------------------------
+
+
+
+    // TABLE transaction_table { // from History contract - scoped by 'from'
+    //    uint64_t id;
+    //    name to;
+    //    asset quantity;
+    //    uint64_t timestamp;
+
+    //    uint64_t primary_key() const { return id; }
+    //    uint64_t by_timestamp() const { return timestamp; }
+    //    uint64_t by_to() const { return to.value; }
+    //    uint64_t by_quantity() const { return quantity.amount; }
+    // };
+
+    // typedef eosio::multi_index<"transactions"_n, transaction_table,
+    //   indexed_by<"bytimestamp"_n,const_mem_fun<transaction_table, uint64_t, &transaction_table::by_timestamp>>,
+    //   indexed_by<"byquantity"_n,const_mem_fun<transaction_table, uint64_t, &transaction_table::by_quantity>>,
+    //   indexed_by<"byto"_n,const_mem_fun<transaction_table, uint64_t, &transaction_table::by_to>>
+    // > transaction_tables;
 
     // Contract Tables
     balance_tables balances;

--- a/include/seeds.harvest.hpp
+++ b/include/seeds.harvest.hpp
@@ -37,7 +37,8 @@ CONTRACT harvest : public contract {
         config(contracts::settings, contracts::settings.value),
         users(contracts::accounts, contracts::accounts.value),
         rep(contracts::accounts, contracts::accounts.value),
-        cbs(contracts::accounts, contracts::accounts.value)
+        cbs(contracts::accounts, contracts::accounts.value),
+        circulating(contracts::token, contracts::token.value)
         {}
         
     ACTION reset();
@@ -236,9 +237,18 @@ CONTRACT harvest : public contract {
     TABLE monthly_qev_table {
       uint64_t timestamp;
       uint64_t qualifying_volume;
+      uint64_t circulating_supply;
 
       uint64_t primary_key() const { return timestamp; }
       uint64_t by_volume() const { return qualifying_volume; }
+    };
+
+    // From token contract
+    TABLE circulating_supply_table {
+      uint64_t id;
+      uint64_t total;
+      uint64_t circulating;
+      uint64_t primary_key()const { return id; }
     };
 
     typedef eosio::multi_index<"trxpoints"_n, transaction_points_table,
@@ -255,6 +265,9 @@ CONTRACT harvest : public contract {
       indexed_by<"byvolume"_n,
       const_mem_fun<monthly_qev_table, uint64_t, &monthly_qev_table::by_volume>>
     > monthly_qev_tables;
+
+    typedef singleton<"circulating"_n, circulating_supply_table> circulating_supply_tables;
+    typedef eosio::multi_index<"circulating"_n, circulating_supply_table> dump_for_circulating;
 
     // -----------------------------------------
 
@@ -277,6 +290,7 @@ CONTRACT harvest : public contract {
     cbs_tables cbs;
     rep_tables rep;
     total_tables total;
+    circulating_supply_tables circulating;
 
 };
 

--- a/include/seeds.history.hpp
+++ b/include/seeds.history.hpp
@@ -7,6 +7,8 @@
 #include <contracts.hpp>
 #include <tables/user_table.hpp>
 
+#include <cmath>
+
 using namespace eosio;
 using std::string;
 
@@ -20,7 +22,8 @@ CONTRACT history : public contract {
           residents(receiver, receiver.value),
           citizens(receiver, receiver.value),
           reputables(receiver, receiver.value),
-          regens(receiver, receiver.value)
+          regens(receiver, receiver.value),
+          totals(receiver, receiver.value)
         {}
 
         ACTION reset(name account);
@@ -33,15 +36,20 @@ CONTRACT history : public contract {
         
         ACTION addresident(name account);
 
-        ACTION numtrx(name account);
+//        ACTION numtrx(name account);
 
         ACTION addreputable(name organization);
 
         ACTION addregen(name organization);
 
-        ACTION orgtxpoints(name organization);
+//        ACTION orgtxpoints(name organization);
 
-        ACTION orgtxpt(name organization, uint128_t start_val, uint64_t chunksize, uint64_t running_total);
+//        ACTION orgtxpt(name organization, uint128_t start_val, uint64_t chunksize, uint64_t running_total);
+
+
+        ACTION deldailytrx (uint64_t day);
+
+        ACTION savepoints(uint64_t id, uint64_t timestamp);
 
 
     private:
@@ -98,42 +106,85 @@ CONTRACT history : public contract {
         uint64_t primary_key()const { return history_id; }
       };
       
-      TABLE transaction_table {
+      // TABLE transaction_table {
+      //   uint64_t id;
+      //   name to;
+      //   asset quantity;
+      //   uint64_t timestamp;
+
+      //   uint64_t primary_key() const { return id; }
+      //   uint64_t by_timestamp() const { return timestamp; }
+      //   uint64_t by_to() const { return to.value; }
+      //   uint64_t by_quantity() const { return quantity.amount; }
+      // };
+
+      // TABLE org_tx_table {
+      //   uint64_t id;
+      //   name other;
+      //   bool in;
+      //   asset quantity;
+      //   uint64_t timestamp;
+
+      //   uint64_t primary_key() const { return id; }
+      //   uint64_t by_timestamp() const { return timestamp; }
+      //   uint64_t by_quantity() const { return quantity.amount; }
+      //   uint128_t by_other() const { return (uint128_t(other.value) << 64) + id; }
+      // };
+
+      // typedef eosio::multi_index<"orgtx"_n, org_tx_table,
+      //   indexed_by<"bytimestamp"_n,const_mem_fun<org_tx_table, uint64_t, &org_tx_table::by_timestamp>>,
+      //   indexed_by<"byquantity"_n,const_mem_fun<org_tx_table, uint64_t, &org_tx_table::by_quantity>>,
+      //   indexed_by<"byother"_n,const_mem_fun<org_tx_table, uint128_t, &org_tx_table::by_other>>
+      // > org_tx_tables;
+
+      // typedef eosio::multi_index<"transactions"_n, transaction_table,
+      //   indexed_by<"bytimestamp"_n,const_mem_fun<transaction_table, uint64_t, &transaction_table::by_timestamp>>,
+      //   indexed_by<"byquantity"_n,const_mem_fun<transaction_table, uint64_t, &transaction_table::by_quantity>>,
+      //   indexed_by<"byto"_n,const_mem_fun<transaction_table, uint64_t, &transaction_table::by_to>>
+      // > transaction_tables;
+
+      TABLE daily_transactions_table { // scoped by beginning_of_day_in_seconds
         uint64_t id;
+        name from;
         name to;
-        asset quantity;
+        uint64_t volume;
+        uint64_t qualifying_volume;
+        uint64_t from_points;
+        uint64_t to_points;
         uint64_t timestamp;
 
         uint64_t primary_key() const { return id; }
-        uint64_t by_timestamp() const { return timestamp; }
+        uint64_t by_from() const { return from.value; }
         uint64_t by_to() const { return to.value; }
-        uint64_t by_quantity() const { return quantity.amount; }
-      };
-
-      TABLE org_tx_table {
-        uint64_t id;
-        name other;
-        bool in;
-        asset quantity;
-        uint64_t timestamp;
-
-        uint64_t primary_key() const { return id; }
         uint64_t by_timestamp() const { return timestamp; }
-        uint64_t by_quantity() const { return quantity.amount; }
-        uint128_t by_other() const { return (uint128_t(other.value) << 64) + id; }
+        uint128_t by_from_to() const { return (uint128_t(from.value) << 64) + to.value; }
       };
 
-      typedef eosio::multi_index<"orgtx"_n, org_tx_table,
-        indexed_by<"bytimestamp"_n,const_mem_fun<org_tx_table, uint64_t, &org_tx_table::by_timestamp>>,
-        indexed_by<"byquantity"_n,const_mem_fun<org_tx_table, uint64_t, &org_tx_table::by_quantity>>,
-        indexed_by<"byother"_n,const_mem_fun<org_tx_table, uint128_t, &org_tx_table::by_other>>
-      > org_tx_tables;
+      TABLE transaction_points_table { // scoped by account
+        uint64_t timestamp;
+        uint64_t points;
 
-      typedef eosio::multi_index<"transactions"_n, transaction_table,
-        indexed_by<"bytimestamp"_n,const_mem_fun<transaction_table, uint64_t, &transaction_table::by_timestamp>>,
-        indexed_by<"byquantity"_n,const_mem_fun<transaction_table, uint64_t, &transaction_table::by_quantity>>,
-        indexed_by<"byto"_n,const_mem_fun<transaction_table, uint64_t, &transaction_table::by_to>>
-      > transaction_tables;
+        uint64_t primary_key() const { return timestamp; }
+        uint64_t by_points() const { return points; }
+      };
+
+      TABLE qev_table { // scoped by account
+        uint64_t timestamp;
+        uint64_t qualifying_volume;
+
+        uint64_t primary_key() const { return timestamp; }
+        uint64_t by_volume() const { return qualifying_volume; }
+      };
+
+      TABLE totals_table {
+        name account;
+        uint64_t total_volume;
+        uint64_t total_number_of_transactions;
+        uint64_t total_incoming_from_rep_orgs;
+        uint64_t total_outgoing_to_rep_orgs;
+
+        uint64_t primary_key() const { return account.value; }
+      };
 
       typedef eosio::multi_index<"citizens"_n, citizen_table,
         indexed_by<"byaccount"_n,
@@ -156,6 +207,29 @@ CONTRACT history : public contract {
         indexed_by<"byorg"_n,
         const_mem_fun<regenerative_table, uint64_t, &regenerative_table::by_org>>
       > regenerative_tables;
+
+      typedef eosio::multi_index<"dailytrxs"_n, daily_transactions_table,
+        indexed_by<"byfrom"_n,
+        const_mem_fun<daily_transactions_table, uint64_t, &daily_transactions_table::by_from>>,
+        indexed_by<"byto"_n,
+        const_mem_fun<daily_transactions_table, uint64_t, &daily_transactions_table::by_to>>,
+        indexed_by<"bytimestamp"_n,
+        const_mem_fun<daily_transactions_table, uint64_t, &daily_transactions_table::by_timestamp>>,
+        indexed_by<"byfromto"_n,
+        const_mem_fun<daily_transactions_table, uint128_t, &daily_transactions_table::by_from_to>>
+      > daily_transactions_tables;
+
+      typedef eosio::multi_index<"trxpoints"_n, transaction_points_table,
+        indexed_by<"bypoints"_n,
+        const_mem_fun<transaction_points_table, uint64_t, &transaction_points_table::by_points>>
+      > transaction_points_tables;
+
+      typedef eosio::multi_index<"qevs"_n, qev_table,
+        indexed_by<"byvolume"_n,
+        const_mem_fun<qev_table, uint64_t, &qev_table::by_volume>>
+      > qev_tables;
+
+      typedef eosio::multi_index<"totals"_n, totals_table> totals_tables;
       
       DEFINE_USER_TABLE
       
@@ -166,6 +240,7 @@ CONTRACT history : public contract {
       citizen_tables citizens;
       reputable_tables reputables;
       regenerative_tables regens;
+      totals_tables totals;
 };
 
 EOSIO_DISPATCH(history, 
@@ -173,6 +248,5 @@ EOSIO_DISPATCH(history,
   (historyentry)(trxentry)
   (addcitizen)(addresident)
   (addreputable)(addregen)
-  (numtrx)
-  (orgtxpoints)(orgtxpt)
+  (deldailytrx)(savepoints)
   );

--- a/include/seeds.history.hpp
+++ b/include/seeds.history.hpp
@@ -267,6 +267,5 @@ EOSIO_DISPATCH(history,
   (numtrx)
   (deldailytrx)(savepoints)
   (testtotalqev)
-  (orgtxpoints)(orgtxpt)
   (migrate)
   );

--- a/include/seeds.organization.hpp
+++ b/include/seeds.organization.hpp
@@ -26,7 +26,8 @@ CONTRACT organization : public contract {
               refs(contracts::accounts, contracts::accounts.value),
               users(contracts::accounts, contracts::accounts.value),
               balances(contracts::harvest, contracts::harvest.value),
-              config(contracts::settings, contracts::settings.value)
+              config(contracts::settings, contracts::settings.value),
+              totals(contracts::history, contracts::history.value)
               {}
         
         
@@ -203,6 +204,19 @@ CONTRACT organization : public contract {
         DEFINE_SIZE_TABLE_MULTI_INDEX
 
 
+        TABLE totals_table {
+            name account;
+            uint64_t total_volume;
+            uint64_t total_number_of_transactions;
+            uint64_t total_incoming_from_rep_orgs;
+            uint64_t total_outgoing_to_rep_orgs;
+
+            uint64_t primary_key() const { return account.value; }
+        };
+
+        typedef eosio::multi_index<"totals"_n, totals_table> totals_tables;
+
+
         TABLE app_table {
             name app_name;
             name org_name;
@@ -295,6 +309,7 @@ CONTRACT organization : public contract {
         balance_tables balances;
         ref_tables refs;
         avg_vote_tables avgvotes;
+        totals_tables totals;
 
         const name min_planted = "org.minplant"_n;
         const name regen_score_size = "rs.sz"_n;
@@ -326,7 +341,7 @@ CONTRACT organization : public contract {
         uint64_t get_regen_score(name organization);
         void history_add_regenerative(name organization);
         void history_add_reputable(name organization);
-        uint64_t count_transactions(name organization, uint64_t limit);
+        uint64_t count_transactions(name organization);
 };
 
 

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -1,5 +1,6 @@
 #include <eosio/eosio.hpp>
 #include <eosio/asset.hpp>
+#include <eosio/system.hpp>
 #include <tables/rep_table.hpp>
 #include <tables/size_table.hpp>
 
@@ -88,6 +89,12 @@ namespace utils {
 
     return size.get("users.sz"_n.value, "users size unknown").size;
 
+  }
+
+  uint64_t get_beginning_of_day_in_seconds() {
+    auto sec = eosio::current_time_point().sec_since_epoch();
+    auto date = eosio::time_point_sec(sec / 86400 * 86400);
+    return date.utc_seconds;
   }
 
 }

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -580,6 +580,12 @@ var permissions = [{
 }, {
   target: `${accounts.forum.account}@execute`,
   action: 'givereps'
+}, {
+  target: `${accounts.harvest.account}@execute`,
+  action: 'calcmqevs'
+}, {
+  target: `${accounts.harvest.account}@active`,
+  actor: `${accounts.organization.account}@active`
 }]
 
 const isTestnet = chainId == networks.telosTestnet

--- a/src/seeds.accounts.cpp
+++ b/src/seeds.accounts.cpp
@@ -1,3 +1,4 @@
+ 
 #include <seeds.accounts.hpp>
 #include <eosio/system.hpp>
 #include <eosio/symbol.hpp>
@@ -659,14 +660,13 @@ void accounts::testcitizen(name user)
 
 // return number of transactions outgoing, until a limit
 uint32_t accounts::num_transactions(name account, uint32_t limit) {
-  transaction_tables transactions(contracts::history, account.value);
-  auto titr = transactions.begin();
-  uint32_t count = 0;
-  while(titr != transactions.end() && count < limit) {
-    titr++;
-    count++;
+  auto titr = totals.find(account.value);
+  
+  if (titr == totals.end()) {
+    return 0;
   }
-  return count;
+
+  return titr -> total_number_of_transactions;
 }
 
 void accounts::rankreps() {
@@ -968,4 +968,3 @@ uint64_t accounts::rep_score(name user)
 
     return ritr->rank;
 }
-

--- a/src/seeds.harvest.cpp
+++ b/src/seeds.harvest.cpp
@@ -882,16 +882,20 @@ void harvest::calcmqevs () {
     qitr++;
   }
 
+  circulating_supply_table c = circulating.get();
+
   auto mqitr = monthlyqevs.find(day);
   
   if (mqitr != monthlyqevs.end()) {
     monthlyqevs.modify(mqitr, _self, [&](auto & item){
       item.qualifying_volume = total_volume;
+      item.circulating_supply = c.circulating;
     });
   } else {
     monthlyqevs.emplace(_self, [&](auto & item){
       item.timestamp = day;
       item.qualifying_volume = total_volume;
+      item.circulating_supply = c.circulating;
     });
   }
 }

--- a/src/seeds.history.cpp
+++ b/src/seeds.history.cpp
@@ -10,21 +10,27 @@ void history::reset(name account) {
   auto hitr = history.begin();
   
   while(hitr != history.end()) {
-      hitr = history.erase(hitr);
+    hitr = history.erase(hitr);
   }
   
-  transaction_tables transactions(get_self(), account.value);
-  auto titr = transactions.begin();  
+  // org_tx_tables orgtx(get_self(), account.value);
+  // auto oitr = orgtx.begin();
+  // while (oitr != orgtx.end()) {
+  //   oitr = orgtx.erase(oitr);
+  // }
+
+  transaction_points_tables transactions(get_self(), account.value);
+  auto titr = transactions.begin();
   while (titr != transactions.end()) {
     titr = transactions.erase(titr);
   }
-  
-  org_tx_tables orgtx(get_self(), account.value);
-  auto oitr = orgtx.begin();
-  while (oitr != orgtx.end()) {
-    oitr = orgtx.erase(oitr);
+
+  qev_tables qevs(get_self(), account.value);
+  auto qitr = qevs.begin();
+  while (qitr != qevs.end()) {
+    qitr = qevs.erase(qitr);
   }
-  
+
   auto citr = citizens.begin();
   while (citr != citizens.end()) {
     citr = citizens.erase(citr);
@@ -33,6 +39,19 @@ void history::reset(name account) {
   auto ritr = residents.begin();
   while (ritr != residents.end()) {
     ritr = residents.erase(ritr);
+  }
+
+  auto toitr = totals.begin();
+  while (toitr != totals.end()) {
+    toitr = totals.erase(toitr);
+  }
+}
+
+void history::deldailytrx (uint64_t day) {
+  daily_transactions_tables transactions(get_self(), day);
+  auto titr = transactions.begin();
+  while (titr != transactions.end()) {
+    titr = transactions.erase(titr);
   }
 }
 
@@ -113,40 +132,179 @@ void history::trxentry(name from, name to, asset quantity) {
     return;
   }
 
-  bool from_is_organization = from_user->type == "organisation"_n;
+  uint64_t day = utils::get_beginning_of_day_in_seconds();
+  daily_transactions_tables transactions(get_self(), day);
+
+  uint64_t transaction_id = transactions.available_primary_key();
+  uint64_t timestamp = eosio::current_time_point().sec_since_epoch();
+
+  int64_t transactions_cap = int64_t(config_get("qev.trx.cap"_n));
+  int64_t max_transaction_points = int64_t(config_get("i.trx.max"_n));
+
+  double trx_multiplier = std::min(max_transaction_points, quantity.amount) / 10000.0;
+
+  print("MIRA: to = ", to, ", multiplier = ", utils::get_rep_multiplier(to), ", volume = ", trx_multiplier, "\n");
   
-  if (from_is_organization) {
-    org_tx_tables orgtx(get_self(), from.value);
-    orgtx.emplace(_self, [&](auto& item) {
-      item.id = orgtx.available_primary_key();
-      item.other = to;
-      item.in = false;
-      item.quantity = quantity;
-      item.timestamp = eosio::current_time_point().sec_since_epoch();
+  transactions.emplace(_self, [&](auto & transaction){
+    transaction.id = transaction_id;
+    transaction.from = from;
+    transaction.to = to;
+    transaction.volume = quantity.amount;
+    transaction.qualifying_volume = std::min(transactions_cap, quantity.amount);
+    transaction.from_points = uint64_t(ceil(trx_multiplier * utils::get_rep_multiplier(to)));
+    transaction.to_points = uint64_t(ceil(trx_multiplier * utils::get_rep_multiplier(from)));
+    transaction.timestamp = timestamp;
+  });
+
+  auto from_totals_itr = totals.find(from.value);
+  bool from_is_organization = from_user -> type == "organisation"_n;
+  bool to_is_organization = to_user -> type == "organisation"_n;
+
+  if (from_totals_itr != totals.end()) {
+    totals.modify(from_totals_itr, _self, [&](auto & item){
+      item.total_volume += quantity.amount;
+      item.total_number_of_transactions += 1;
+      item.total_outgoing_to_rep_orgs += ( to_is_organization ? 1 : 0 );
     });
   } else {
-    transaction_tables transactions(get_self(), from.value);
-    transactions.emplace(_self, [&](auto& item) {
-      item.id = transactions.available_primary_key();
-      item.to = to;
-      item.quantity = quantity;
-      item.timestamp = eosio::current_time_point().sec_since_epoch();
+    totals.emplace(_self, [&](auto & item){
+      item.account = from;
+      item.total_volume += quantity.amount;
+      item.total_number_of_transactions = 1;
+      item.total_incoming_from_rep_orgs = 0;
+      item.total_outgoing_to_rep_orgs = ( to_is_organization ? 1 : 0 );
     });
   }
 
-  // Orgs get entry for "to"
-  if (to_user->type == "organisation"_n) {
-      org_tx_tables orgtx(get_self(), to.value);
-      orgtx.emplace(_self, [&](auto& item) {
-        item.id = orgtx.available_primary_key();
-        item.other = from;
-        item.in = true;
-        item.quantity = quantity;
-        item.timestamp = eosio::current_time_point().sec_since_epoch();
+  if (from_is_organization) {
+    auto to_totals_itr = totals.find(to.value);
+    if (to_totals_itr != totals.end()) {
+      totals.modify(to_totals_itr, _self, [&](auto & item){
+        item.total_incoming_from_rep_orgs += 1;
       });
+    } else {
+      totals.emplace(_self, [&](auto & item){
+        item.account = to;
+        item.total_volume = 0;
+        item.total_number_of_transactions = 0;
+        item.total_incoming_from_rep_orgs = 1;
+        item.total_outgoing_to_rep_orgs = 0;
+      });
+    }
   }
 
-  if (!from_is_organization) {
+  cancel_deferred(from.value);
+
+  action a(
+    permission_level{contracts::history, "active"_n},
+    get_self(),
+    "savepoints"_n,
+    std::make_tuple(transaction_id, timestamp)
+  );
+
+  transaction tx;
+  tx.actions.emplace_back(a);
+  tx.delay_sec = 1;
+  tx.send(from.value, _self);
+}
+
+
+void history::savepoints(uint64_t id, uint64_t timestamp) {
+  require_auth(get_self());
+
+  auto date = eosio::time_point_sec(timestamp / 86400 * 86400);
+  uint64_t day = date.utc_seconds;
+
+  daily_transactions_tables transactions(get_self(), day);
+  auto transactions_by_from_to = transactions.get_index<"byfromto"_n>();
+
+  auto titr = transactions.find(id);
+  check(titr != transactions.end(), "transaction not found");
+  name from = titr -> from;
+  name to = titr -> to;
+
+  auto uitr_from = users.find(from.value);
+  auto uitr_to = users.find(to.value);
+
+  uint64_t max_number_transactions = config_get("htry.trx.max"_n);
+
+  uint128_t from_to_id = (uint128_t(titr -> from.value) << 64) + titr -> to.value;
+  uint64_t count = 0;
+
+  auto ft_itr = transactions_by_from_to.find(from_to_id);
+  auto current_itr = ft_itr;
+
+  while (ft_itr != transactions_by_from_to.end() && 
+      count <= max_number_transactions && 
+      ft_itr -> from == from && ft_itr -> to == to) {
+
+    if (ft_itr -> volume < current_itr -> volume) {
+      current_itr = ft_itr;
+    }
+
+    print("count = ", count, ", volume = ", ft_itr -> volume, "\n");
+
+    ft_itr++;
+    count++;
+  }
+
+  int64_t from_points = int64_t(titr -> from_points);
+  int64_t to_points = int64_t(titr -> to_points);
+  int64_t qualifying_volume = int64_t(titr -> qualifying_volume);
+
+  if (count > max_number_transactions) {
+    from_points -= current_itr -> from_points;
+    to_points -= current_itr -> to_points;
+    qualifying_volume -= current_itr -> qualifying_volume;
+
+    transactions_by_from_to.erase(current_itr);
+  }
+
+  transaction_points_tables trx_points_from(get_self(), from.value);
+  qev_tables qevs(get_self(), from.value);
+
+  auto trx_itr = trx_points_from.find(day);
+  auto qev_itr = qevs.find(day);
+
+  if (trx_itr != trx_points_from.end()) {
+    trx_points_from.modify(trx_itr, _self, [&](auto & item){
+      item.points += from_points;
+    });
+  } else {
+    trx_points_from.emplace(_self, [&](auto & item){
+      item.timestamp = day;
+      item.points = from_points;
+    });
+  }
+
+  if (qev_itr != qevs.end()) {
+    qevs.modify(qev_itr, _self, [&](auto & item){
+      item.qualifying_volume += qualifying_volume;
+    });
+  } else {
+    qevs.emplace(_self, [&](auto & item){
+      item.timestamp = day;
+      item.qualifying_volume = qualifying_volume;
+    });
+  }
+
+  if (uitr_to -> type == name("organisation")) {
+    transaction_points_tables trx_points_to(get_self(), to.value);
+    auto trx_itr_to = trx_points_to.find(day);
+
+    if (trx_itr_to != trx_points_to.end()) {
+      trx_points_to.modify(trx_itr_to, _self, [&](auto & item){
+        item.points += to_points;
+      });
+    } else {
+      trx_points_to.emplace(_self, [&](auto & item){
+        item.timestamp = day;
+        item.points = to_points;
+      });
+    }
+  }
+
+  if (uitr_from -> type != name("organisation")) {
     // delayed update
     cancel_deferred(from.value);
 
@@ -165,149 +323,162 @@ void history::trxentry(name from, name to, asset quantity) {
     tx.delay_sec = 1; 
     tx.send(from.value, _self);
   }
-
 }
 
-// return true if anything was cleaned up, false otherwise
-bool history::clean_old_tx(name org, uint64_t chunksize) {
+
+// // return true if anything was cleaned up, false otherwise
+// bool history::clean_old_tx(name org, uint64_t chunksize) {
   
-  auto now = eosio::current_time_point().sec_since_epoch();
-  auto cutoffdate = now - utils::moon_cycle * 3;
+//   auto now = eosio::current_time_point().sec_since_epoch();
+//   auto cutoffdate = now - utils::moon_cycle * 3;
 
-  org_tx_tables orgtx(get_self(), org.value);
-  uint64_t count = 0;
-  auto transactions_by_time = orgtx.get_index<"bytimestamp"_n>();
-  auto tx_time_itr = transactions_by_time.begin();
-  bool result = false;
-  while(tx_time_itr != transactions_by_time.end() && tx_time_itr->timestamp < cutoffdate && count < chunksize) {
-    tx_time_itr = transactions_by_time.erase(tx_time_itr);
-    result = true;
-    count++;
-  }  
-  return result;
+//   org_tx_tables orgtx(get_self(), org.value);
+//   uint64_t count = 0;
+//   auto transactions_by_time = orgtx.get_index<"bytimestamp"_n>();
+//   auto tx_time_itr = transactions_by_time.begin();
+//   bool result = false;
+//   while(tx_time_itr != transactions_by_time.end() && tx_time_itr->timestamp < cutoffdate && count < chunksize) {
+//     tx_time_itr = transactions_by_time.erase(tx_time_itr);
+//     result = true;
+//     count++;
+//   }  
+//   return result;
   
-}
+// }
 
-void history::orgtxpoints(name org) {
-  require_auth(get_self());
-  orgtxpt(org, 0, 200, 0);
-}
+// void history::orgtxpoints(name org) {
+//   require_auth(get_self());
+//   orgtxpt(org, 0, 200, 0);
+// }
 
-void history::orgtxpt(name org, uint128_t start_val, uint64_t chunksize, uint64_t running_total) {
-  require_auth(get_self());
+// void history::orgtxpt(name org, uint128_t start_val, uint64_t chunksize, uint64_t running_total) {
+//   require_auth(get_self());
 
-  org_tx_tables orgtx(get_self(), org.value);
-  uint64_t count = 0;
 
-  if (start_val == 0 && clean_old_tx(org, chunksize)) {    // Step 0 - remove all old transactions
-    fire_orgtx_calc(org, 0, chunksize, running_total);
-    return;
-  }
 
-  // Step 1 - add up values
-  uint64_t max_quantity = config_get("org.trx.max"_n);
-  uint64_t max_number_of_transactions = config_get("org.trx.div"_n);;
+// }
 
-  auto transactions_by_other = orgtx.get_index<"byother"_n>();
-  auto tx_other_itr = start_val == 0 ? transactions_by_other.begin() : transactions_by_other.lower_bound(start_val);
+// void history::orgtxpt(name org, uint128_t start_val, uint64_t chunksize, uint64_t running_total) {
+//   require_auth(get_self());
 
-  name      current_other = name("");
-  uint64_t  current_num = 0;
-  double    current_rep_multiplier = 0.0;
+//   org_tx_tables orgtx(get_self(), org.value);
+//   uint64_t count = 0;
 
-  //print("orgtxpt for "+org.to_string());
+//   if (start_val == 0 && clean_old_tx(org, chunksize)) {    // Step 0 - remove all old transactions
+//     fire_orgtx_calc(org, 0, chunksize, running_total);
+//     return;
+//   }
 
-  while(tx_other_itr != transactions_by_other.end() && count < chunksize) {
+//   // Step 1 - add up values
+//   uint64_t max_quantity = config_get("org.trx.max"_n);
+//   uint64_t max_number_of_transactions = config_get("org.trx.div"_n);;
 
-    if (current_other != tx_other_itr->other) {
-      current_other = tx_other_itr->other;
-      current_num = 0;
-      current_rep_multiplier = utils::get_rep_multiplier(current_other);
-      //print("new other "+current_other.to_string());
-      //print("rep mul "+std::to_string(current_rep_multiplier));
-    } else {
-      //print("same iter other "+current_other.to_string());
-      current_num++;
-    }
+//   auto transactions_by_other = orgtx.get_index<"byother"_n>();
+//   auto tx_other_itr = start_val == 0 ? transactions_by_other.begin() : transactions_by_other.lower_bound(start_val);
 
-    if (current_num < max_number_of_transactions) {
-      uint64_t volume = tx_other_itr->quantity.amount;
+//   name      current_other = name("");
+//   uint64_t  current_num = 0;
+//   double    current_rep_multiplier = 0.0;
+
+//   //print("orgtxpt for "+org.to_string());
+
+//   while(tx_other_itr != transactions_by_other.end() && count < chunksize) {
+
+//     if (current_other != tx_other_itr->other) {
+//       current_other = tx_other_itr->other;
+//       current_num = 0;
+//       current_rep_multiplier = utils::get_rep_multiplier(current_other);
+//       //print("new other "+current_other.to_string());
+//       //print("rep mul "+std::to_string(current_rep_multiplier));
+//     } else {
+//       //print("same iter other "+current_other.to_string());
+//       current_num++;
+//     }
+
+//     if (current_num < max_number_of_transactions) {
+//       uint64_t volume = tx_other_itr->quantity.amount;
       
-      //print("; vol: "+std::to_string(volume));
+//       //print("; vol: "+std::to_string(volume));
 
-      // limit max volume
-      if (volume > max_quantity) {
-        volume = max_quantity;
-        //print("; vol exceed max - limited to: "+std::to_string(volume));
-      }
+//       // limit max volume
+//       if (volume > max_quantity) {
+//         volume = max_quantity;
+//         //print("; vol exceed max - limited to: "+std::to_string(volume));
+//       }
 
-      // multiply by receiver reputation
-      double points = (double(volume) / 10000.0) * current_rep_multiplier;
-      //print("; rep mul "+std::to_string(current_rep_multiplier));
-      //print("; points "+std::to_string(points));
+//       // multiply by receiver reputation
+//       double points = (double(volume) / 10000.0) * current_rep_multiplier;
+//       //print("; rep mul "+std::to_string(current_rep_multiplier));
+//       //print("; points "+std::to_string(points));
 
-      running_total += points;
+//       running_total += points;
       
-      //print("; total "+std::to_string(running_total));
-      tx_other_itr++;
-    } else {
-      tx_other_itr++;
-      // TODO skip ahead to next account!
-      // rather than increasing account by 1, increase name by 1 and look for a new 
-      // iterator starting with that name as lower limit
-      // name next_name = name(tx_other_itr->other.value + 1);
-      // uunt128_t next_val = uunt128_t(next_name.value) << 64;
-      // tx_other_itr = transactions_by_other.lower_bound(next_val);
-      // print("; skip to "+std::to_string(next_val));
+//       //print("; total "+std::to_string(running_total));
+//       tx_other_itr++;
+//     } else {
+//       tx_other_itr++;
+//       // TODO skip ahead to next account!
+//       // rather than increasing account by 1, increase name by 1 and look for a new 
+//       // iterator starting with that name as lower limit
+//       // name next_name = name(tx_other_itr->other.value + 1);
+//       // uunt128_t next_val = uunt128_t(next_name.value) << 64;
+//       // tx_other_itr = transactions_by_other.lower_bound(next_val);
+//       // print("; skip to "+std::to_string(next_val));
 
-    }
+//     }
   
-    count++;
-  }
-  if (tx_other_itr == transactions_by_other.end()) {
-    action(
-      permission_level{contracts::harvest, "active"_n},
-      contracts::harvest, "setorgtxpt"_n,
-      std::make_tuple(org, running_total)
-    ).send();
-  } else {
-    uint128_t next_value = tx_other_itr->by_other();
-    fire_orgtx_calc(org, next_value, chunksize, running_total);
-  }
+//     count++;
+//   }
+//   if (tx_other_itr == transactions_by_other.end()) {
+//     action(
+//       permission_level{contracts::harvest, "active"_n},
+//       contracts::harvest, "setorgtxpt"_n,
+//       std::make_tuple(org, running_total)
+//     ).send();
+//   } else {
+//     uint128_t next_value = tx_other_itr->by_other();
+//     fire_orgtx_calc(org, next_value, chunksize, running_total);
+//   }
 
   
 
-}
+// }
 
-void history::fire_orgtx_calc(name org, uint128_t next_value, uint64_t chunksize, uint64_t running_total) {
-  action next_execution(
-      permission_level{get_self(), "active"_n},
-      get_self(),
-      "orgtxpt"_n,
-      std::make_tuple(org, next_value, chunksize, running_total)
-  );
-  transaction tx;
-  tx.actions.emplace_back(next_execution);
-  tx.delay_sec = 1;
-  tx.send(next_value + 1, _self);
-}
+// void history::fire_orgtx_calc(name org, uint128_t next_value, uint64_t chunksize, uint64_t running_total) {
+//   action next_execution(
+//       permission_level{get_self(), "active"_n},
+//       get_self(),
+//       "orgtxpt"_n,
+//       std::make_tuple(org, next_value, chunksize, running_total)
+//   );
+//   transaction tx;
+//   tx.actions.emplace_back(next_execution);
+//   tx.delay_sec = 1;
+//   tx.send(next_value + 1, _self);
+// }
 
-void history::numtrx(name account) {
-  uint32_t num = num_transactions(account, 200);
-  check(false, "{ numtrx: " + std::to_string(num) + " }");
-}
 
-// return number of transactions outgoing, until a limit
-uint32_t history::num_transactions(name account, uint32_t limit) {
-  transaction_tables transactions(contracts::history, account.value);
-  auto titr = transactions.begin();
-  uint32_t count = 0;
-  while(titr != transactions.end() && count < limit) {
-    titr++;
-    count++;
-  }
-  return count;
-}
+
+
+// void history::numtrx(name account) {
+//   uint32_t num = num_transactions(account, 200);
+//   check(false, "{ numtrx: " + std::to_string(num) + " }");
+// }
+
+// // return number of transactions outgoing, until a limit
+// uint32_t history::num_transactions(name account, uint32_t limit) {
+//   transaction_tables transactions(contracts::history, account.value);
+//   auto titr = transactions.begin();
+//   uint32_t count = 0;
+//   while(titr != transactions.end() && count < limit) {
+//     titr++;
+//     count++;
+//   }
+//   return count;
+// }
+
+
+
 
 void history::check_user(name account)
 {

--- a/src/seeds.history.cpp
+++ b/src/seeds.history.cpp
@@ -148,13 +148,13 @@ void history::trxentry(name from, name to, asset quantity) {
   int64_t max_transaction_points_individuals = int64_t(config_get("i.trx.max"_n));
   int64_t max_transaction_points_organizations = int64_t(config_get("org.trx.max"_n));
 
-  double from_trx_multiplier = (
+  double from_capped_amount = (
     from_is_organization ? 
     std::min(max_transaction_points_organizations, quantity.amount) : 
     std::min(max_transaction_points_individuals, quantity.amount)
   ) / 10000.0;
   
-  double to_trx_multiplier = std::min(max_transaction_points_organizations, quantity.amount) / 10000.0;
+  double to_capped_amount = std::min(max_transaction_points_organizations, quantity.amount) / 10000.0;
 
   transactions.emplace(_self, [&](auto & transaction){
     transaction.id = transaction_id;
@@ -162,8 +162,8 @@ void history::trxentry(name from, name to, asset quantity) {
     transaction.to = to;
     transaction.volume = quantity.amount;
     transaction.qualifying_volume = std::min(transactions_cap, quantity.amount);
-    transaction.from_points = uint64_t(ceil(from_trx_multiplier * utils::get_rep_multiplier(to)));
-    transaction.to_points = uint64_t(ceil(to_trx_multiplier * utils::get_rep_multiplier(from)));
+    transaction.from_points = uint64_t(ceil(from_capped_amount * utils::get_rep_multiplier(to)));
+    transaction.to_points = to_is_organization ? uint64_t(ceil(to_capped_amount * utils::get_rep_multiplier(from))) : 0;
     transaction.timestamp = timestamp;
   });
 

--- a/src/seeds.organization.cpp
+++ b/src/seeds.organization.cpp
@@ -859,25 +859,32 @@ ACTION organization::scoretrxs() {
 ACTION organization::scoreorgs(name next) {
     require_auth(get_self());
 
-    auto itr = next == ""_n ? organizations.begin() : organizations.lower_bound(next.value);
-    if(itr != organizations.end()) {
-        action(
-            permission_level{contracts::history, "active"_n},
-            contracts::history, "orgtxpoints"_n,
-            std::make_tuple(itr -> org_name)
-        ).send();
-        itr++;
-        if (itr != organizations.end()) {
-            action next_execution(
-                permission_level{get_self(), "active"_n},
-                get_self(),
-                "scoreorgs"_n,
-                std::make_tuple(itr->org_name)
-            );
-            transaction tx;
-            tx.actions.emplace_back(next_execution);
-            tx.delay_sec = 1; // change this to 1 to test
-            tx.send(next.value+2, _self);
-        }
-    }
+    action(
+        permission_level{contracts::harvest, "active"_n},
+        contracts::harvest,
+        "calctrxpts"_n,
+        std::make_tuple()
+    ).send();
+
+    // auto itr = next == ""_n ? organizations.begin() : organizations.lower_bound(next.value);
+    // if(itr != organizations.end()) {
+    //     action(
+    //         permission_level{contracts::history, "active"_n},
+    //         contracts::history, "orgtxpoints"_n,
+    //         std::make_tuple(itr -> org_name)
+    //     ).send();
+    //     itr++;
+    //     if (itr != organizations.end()) {
+    //         action next_execution(
+    //             permission_level{get_self(), "active"_n},
+    //             get_self(),
+    //             "scoreorgs"_n,
+    //             std::make_tuple(itr->org_name)
+    //         );
+    //         transaction tx;
+    //         tx.actions.emplace_back(next_execution);
+    //         tx.delay_sec = 1; // change this to 1 to test
+    //         tx.send(next.value+2, _self);
+    //     }
+    // }
 }

--- a/src/seeds.organization.cpp
+++ b/src/seeds.organization.cpp
@@ -592,29 +592,14 @@ uint64_t organization::count_refs(name organization, uint32_t check_num_resident
     }
 }
 
-uint64_t organization::count_transactions(name organization, uint64_t limit) {
-    org_tx_tables transactions(contracts::history, organization.value);
-    auto transactions_by_date = transactions.get_index<"bytimestamp"_n>();
-    auto titr = transactions_by_date.rbegin();
-    uint64_t count = 0;
-    uint64_t t_number = 0;
+uint64_t organization::count_transactions(name organization) {
+    auto totals_itr = totals.find(organization.value);
 
-    while (titr != transactions_by_date.rend() && count < limit) {
-        auto other = titr -> other;
-        auto uitr = users.find(other.value);
-        if (uitr -> status == name("citizen")) {
-            t_number += 1;
-        } else if (uitr -> type == name("organisation")) {
-            auto oitr = organizations.find(other.value);
-            if (oitr -> status == reputable_org || oitr -> status == regenerative_org) {
-                t_number += 1;
-            }
-        }
-        count++;
-        titr++;
+    if (totals_itr == totals.end()) {
+        return 0;
     }
 
-    return t_number;
+    return totals_itr -> total_number_of_transactions;
 }
 
 void organization::check_can_make_reputable(name organization) {
@@ -632,7 +617,7 @@ void organization::check_can_make_reputable(name organization) {
 
     uint64_t invited_users_number = count_refs(organization, min_residents_invited);
     uint64_t regen_score = get_regen_score(organization);
-    uint64_t valid_trxs = count_transactions(organization, 300);
+    uint64_t valid_trxs = count_transactions(organization);
 
     check(bitr -> planted.amount >= planted_min, "organization has less than the required amount of seeds planted");
     check(regen_score >= regen_min_rank, "organization has less than the required regenerative score");
@@ -657,7 +642,7 @@ void organization::check_can_make_regen(name organization) {
 
     uint64_t invited_users_number = count_refs(organization, min_residents_invited);
     uint64_t regen_score = get_regen_score(organization);
-    uint64_t valid_trxs = count_transactions(organization, 300);
+    uint64_t valid_trxs = count_transactions(organization);
 
     check(bitr -> planted.amount >= planted_min, "organization has less than the required amount of seeds planted");
     check(regen_score >= regen_min_rank, "organization has less than the required regenerative score");

--- a/src/seeds.scheduler.cpp
+++ b/src/seeds.scheduler.cpp
@@ -70,7 +70,6 @@ ACTION scheduler::reset() {
         name("org.clndaus"),
         name("org.rankregn"),
         name("org.rankcbs"),
-        name("org.scortrxs"),
 
         name("hrvst.orgtxs"),
 
@@ -78,6 +77,8 @@ ACTION scheduler::reset() {
 
         name("forum.rank"),
         name("forum.giverp"),
+
+        name("hrvst.qevs"),
     };
     
     std::vector<name> operations_v = {
@@ -97,7 +98,6 @@ ACTION scheduler::reset() {
         name("cleandaus"),
         name("rankregens"),
         name("rankcbsorgs"),
-        name("scoretrxs"),
 
         name("rankorgtxs"),
 
@@ -105,6 +105,8 @@ ACTION scheduler::reset() {
 
         name("rankforums"),
         name("givereps"),
+
+        name("calcmqevs"),
     };
 
     std::vector<name> contracts_v = {
@@ -124,7 +126,6 @@ ACTION scheduler::reset() {
         contracts::organization,
         contracts::organization,
         contracts::organization,
-        contracts::organization,
 
         contracts::harvest,
 
@@ -132,6 +133,8 @@ ACTION scheduler::reset() {
 
         contracts::forum,
         contracts::forum,
+
+        contracts::harvest,
     };
 
     std::vector<uint64_t> delay_v = {
@@ -151,7 +154,6 @@ ACTION scheduler::reset() {
         utils::seconds_per_day / 2,
         utils::seconds_per_day,
         utils::seconds_per_day,
-        utils::seconds_per_day,
 
         utils::seconds_per_day,
 
@@ -159,6 +161,8 @@ ACTION scheduler::reset() {
         
         utils::moon_cycle / 4,
         utils::moon_cycle / 4,
+
+        utils::seconds_per_day,
     };
 
     uint64_t now = current_time_point().sec_since_epoch();
@@ -180,7 +184,6 @@ ACTION scheduler::reset() {
         now,
         now,
         now,
-        now,
 
         now,
 
@@ -188,6 +191,8 @@ ACTION scheduler::reset() {
 
         now,
         now - utils::seconds_per_hour,
+
+        now,
     };
 
     int i = 0;

--- a/src/seeds.settings.cpp
+++ b/src/seeds.settings.cpp
@@ -56,6 +56,9 @@ void settings::reset() {
 
   confwithdesc(name("txlimit.min"), 7, "Minimum number of transactions per user", high_impact);
 
+  confwithdesc(name("htry.trx.max"), 2, "Maximum number of transactions to take into account for transaction score between to users per day", high_impact);
+  confwithdesc(name("qev.trx.cap"), uint64_t(1777) * uint64_t(10000), "Maximum number of seeds to take into account as qualifying volume", high_impact);
+
   // Organizations
   confwithdesc(name("org.minplant"), 200 * 10000, "Minimum amount to create an organization (in Seeds)", high_impact);
   confwithdesc(name("org.rgen.min"), 1000, "Minimum regen points an organization must have to be ranked", high_impact);

--- a/test/accounts.test.js
+++ b/test/accounts.test.js
@@ -799,13 +799,6 @@ describe('make resident', async assert => {
     await contracts.token.transfer(firstuser, seconduser, '1.0000 SEEDS', 'memo'+i, { authorization: `${firstuser}@active` })
   }
 
-  const hist = await eos.getTableRows({
-    code: history,
-    scope: history,
-    table: 'transactions',
-    json: true,
-  })
-
   console.log('add referral')
   await contracts.accounts.addref(firstuser, seconduser, { authorization: `${accounts}@api` })
   console.log('update reputation')

--- a/test/harvest.test.js
+++ b/test/harvest.test.js
@@ -799,6 +799,9 @@ describe('Monthly QEV', async assert => {
   console.log('reset harvest')
   await contracts.harvest.reset({ authorization: `${harvest}@active` })
 
+  console.log('update circulaing supply')
+  await contracts.token.updatecirc({ authorization: `${token}@active` })
+
   console.log('calculate total monthly qev')
   
   await contracts.history.testtotalqev(120, 100 * 10000, { authorization: `${history}@active` })
@@ -811,6 +814,8 @@ describe('Monthly QEV', async assert => {
     table: 'monthlyqevs',
     json: true,
   })
+
+  delete totalQev.rows[0].circulating_supply
 
   assert({
     given: 'monthly qev calculated',

--- a/test/harvest.test.js
+++ b/test/harvest.test.js
@@ -13,442 +13,451 @@ function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-// describe("Harvest General", async assert => {
+describe("Harvest General", async assert => {
 
-//   if (!isLocal()) {
-//     console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
-//     return
-//   }
+  if (!isLocal()) {
+    console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
+    return
+  }
 
-//   const contracts = await initContracts({ accounts, token, harvest, settings, history })
+  const contracts = await initContracts({ accounts, token, harvest, settings, history })
 
-//   console.log('harvest reset')
-//   await contracts.harvest.reset({ authorization: `${harvest}@active` })
+  console.log('harvest reset')
+  await contracts.harvest.reset({ authorization: `${harvest}@active` })
 
-//   console.log('accounts reset')
-//   await contracts.accounts.reset({ authorization: `${accounts}@active` })
+  console.log('accounts reset')
+  await contracts.accounts.reset({ authorization: `${accounts}@active` })
 
-//   console.log('reset token stats')
-//   await contracts.token.resetweekly({ authorization: `${token}@active` })
+  console.log('reset token stats')
+  await contracts.token.resetweekly({ authorization: `${token}@active` })
 
-//   console.log('configure')
-//   await contracts.settings.configure("hrvstreward", 10000 * 100, { authorization: `${settings}@active` })
+  console.log('configure')
+  await contracts.settings.configure("hrvstreward", 10000 * 100, { authorization: `${settings}@active` })
 
-//   console.log('join users')
-//   await contracts.accounts.adduser(firstuser, 'first user', 'individual', { authorization: `${accounts}@active` })
-//   await contracts.accounts.adduser(seconduser, 'second user', 'individual', { authorization: `${accounts}@active` })
+  console.log('join users')
+  await contracts.accounts.adduser(firstuser, 'first user', 'individual', { authorization: `${accounts}@active` })
+  await contracts.accounts.adduser(seconduser, 'second user', 'individual', { authorization: `${accounts}@active` })
 
-//   console.log('reset history')
-//   let users = [firstuser, seconduser]
-//   users.forEach( async (user, index) => await contracts.history.reset(user, { authorization: `${history}@active` }))
+  console.log('reset history')
+  let users = [firstuser, seconduser]
+  users.forEach( async (user, index) => await contracts.history.reset(user, { authorization: `${history}@active` }))
 
+  const day = getBeginningOfDayInSeconds()
 
-//   const txpoints1 = await eos.getTableRows({
-//     code: harvest,
-//     scope: harvest,
-//     table: 'txpoints',
-//     json: true,
-//     limit: 100
-//   })
+  await contracts.history.deldailytrx(day, { authorization: `${history}@active` })
+  await sleep(100)
 
-//   console.log(" tx points 1 "+JSON.stringify(txpoints1, null, 2))
+  const txpoints1 = await eos.getTableRows({
+    code: harvest,
+    scope: harvest,
+    table: 'txpoints',
+    json: true,
+    limit: 100
+  })
+
+  console.log(" tx points 1 "+JSON.stringify(txpoints1, null, 2))
 
   
-//   console.log('plant seeds x')
-//   await contracts.token.transfer(firstuser, harvest, '500.0000 SEEDS', '', { authorization: `${firstuser}@active` })
+  console.log('plant seeds x')
+  await contracts.token.transfer(firstuser, harvest, '500.0000 SEEDS', '', { authorization: `${firstuser}@active` })
 
-//   await contracts.token.transfer(seconduser, harvest, '200.0000 SEEDS', '', { authorization: `${seconduser}@active` })
-//   // await sleep(5000)
+  await contracts.token.transfer(seconduser, harvest, '200.0000 SEEDS', '', { authorization: `${seconduser}@active` })
+  // await sleep(5000)
 
-//   // console.log('transfer seeds')
-//   await contracts.token.transfer(firstuser, seconduser, '1.0000 SEEDS', '', { authorization: `${firstuser}@active` })
+  // console.log('transfer seeds')
+  await contracts.token.transfer(firstuser, seconduser, '1.0000 SEEDS', '', { authorization: `${firstuser}@active` })
   
-//   // await sleep(5000)
-//   await contracts.token.transfer(seconduser, firstuser, '0.1000 SEEDS', '', { authorization: `${seconduser}@active` })
-
-//   const balanceBeforeUnplanted = await getBalanceFloat(seconduser)
-
-//   const checkTotal = async (check) => {
-//     const total = await eos.getTableRows({
-//       code: harvest,
-//       scope: harvest,
-//       table: 'total',
-//       json: true,
-//     })
-//     // const planted = await eos.getTableRows({
-//     //   code: harvest,
-//     //   scope: harvest,
-//     //   table: 'planted',
-//     //   json: true,
-//     // })
-//     // console.log("planted "+JSON.stringify(planted, null, 2))
-//     // console.log("total "+JSON.stringify(total, null, 2))
-
-//     assert({
-//       given: 'checking total '+check,
-//       should: 'be able the same',
-//       actual: total.rows[0].total_planted,
-//       expected: check + ".0000 SEEDS"
-//     })
-//   }
-
-//   await checkTotal(700);
-
-//   let num_seeds_unplanted = 100
-//   await contracts.harvest.unplant(seconduser, num_seeds_unplanted + '.0000 SEEDS', { authorization: `${seconduser}@active` })
-
-//   await checkTotal(600);
-
-//   var unplantedOverdrawCheck = true
-//   try {
-//     await contracts.harvest.unplant(seconduser, '100000000.0000 SEEDS', { authorization: `${seconduser}@active` })
-//     unplantedOverdrawCheck = false
-//   } catch (err) {
-//     console.log("overdraw protection works")
-//   }
-
-//   const refundsAfterUnplanted = await getTableRows({
-//     code: harvest,
-//     scope: seconduser,
-//     table: 'refunds',
-//     json: true,
-//     limit: 100
-//   })
-
-//   console.log("call first signer pays action")
-//   await contracts.harvest.payforcpu(
-//     seconduser, 
-//     { 
-//       authorization: [ 
-//         {
-//           actor: harvest,
-//           permission: 'payforcpu'
-//         },   
-//         {
-//           actor: seconduser,
-//           permission: 'active'
-//         }
-//       ]
-//     }
-//   )
-
-//   var payforcpuSeedsUserOnly = true
-//   try {
-//     await contracts.harvest.payforcpu(
-//       thirduser, 
-//       { 
-//         authorization: [ 
-//           {
-//             actor: harvest,
-//             permission: 'payforcpu'
-//           },   
-//           {
-//             actor: thirduser,
-//             permission: 'active'
-//           }
-//         ]
-//       }
-//     )  
-//     payforcpuSeedsUserOnly = false
-//   } catch (err) {
-//     console.log("require seeds user for pay for cpu test")
-//   }
-
-//   var payforCPURequireAuth = true
-//   try {
-//     await contracts.harvest.payforcpu(
-//       thirduser, 
-//       { 
-//         authorization: [    
-//           {
-//             actor: thirduser,
-//             permission: 'active'
-//           }
-//         ]
-//       }
-//     )  
-//     payforCPURequireAuth = false
-//   } catch (err) {
-//     console.log("require payforcup perm test")
-//   }
-
-//   var payforCPURequireUserAuth = true
-//   try {
-//     await contracts.harvest.payforcpu(
-//       thirduser, 
-//       { 
-//         authorization: [ 
-//           {
-//             actor: harvest,
-//             permission: 'payforcpu'
-//           },   
-//         ]
-//       }
-//     )  
-//     payforCPURequireUserAuth = false
-//   } catch (err) {
-//     console.log("require user auth test")
-//   }
-
-
-//   //console.log("results after unplanted" + JSON.stringify(refundsAfterUnplanted, null, 2))
-
-//   const balanceAfterUnplanted = await getBalanceFloat(seconduser)
-
-//   const assetIt = (string) => {
-//     let a = string.split(" ")
-//     return {
-//       amount: Number(a[0]) * 10000,
-//       symbol: a[1]
-//     }
-//   }
-
-//   const totalUnplanted = refundsAfterUnplanted.rows.reduce( (a, b) => a + assetIt(b.amount).amount, 0) / 10000
-
-//   console.log('claim refund\n')
-//   const balanceBeforeClaimed = await getBalanceFloat(seconduser)
-
-//   // rewind 16 days
-//   let day_seconds = 60 * 60 * 24
-//   let num_days_expired = 16
-//   let weeks_expired = parseInt(num_days_expired/7)
-//   await contracts.harvest.testclaim(seconduser, 1, day_seconds * num_days_expired, { authorization: `${harvest}@active` })
-
-//   const transactionRefund = await contracts.harvest.claimrefund(seconduser, 1, { authorization: `${seconduser}@active` })
-
-//   const refundsAfterClaimed = await getTableRows({
-//     code: harvest,
-//     scope: seconduser,
-//     table: 'refunds',
-//     json: true,
-//     limit: 100
-//   })
-
-//   const balanceAfterClaimed = await getBalanceFloat(seconduser)
-
-//   //console.log(weeks_expired + " balance before claim "+balanceBeforeClaimed)
-//   //console.log("balance after claim  "+balanceAfterClaimed)
-
-//   let difference = balanceAfterClaimed - balanceBeforeClaimed
-//   let expectedDifference = num_seeds_unplanted * weeks_expired / 12
-
-//   assert({
-//     given: 'claim refund after '+num_days_expired+' days',
-//     should: 'be able to claim '+weeks_expired+'/12 of total unplanted',
-//     actual: Math.floor(difference * 1000)/1000,
-//     expected: Math.floor(expectedDifference * 1000)/1000
-//   })
-
-//   console.log('cancel refund')
-//   const transactionCancelRefund = await contracts.harvest.cancelrefund(seconduser, 1, { authorization: `${seconduser}@active` })
-
-//   const refundsAfterCanceled = await getTableRows({
-//     code: harvest,
-//     scope: seconduser,
-//     table: 'refunds',
-//     json: true,
-//     limit: 100
-//   })
-
-//   console.log('sow seeds')
-//   await contracts.harvest.sow(seconduser, firstuser, '10.0000 SEEDS', { authorization: `${seconduser}@active` })
-
-//   var sowBalanceExceeded = false
-//   try {
-//     await contracts.harvest.sow(seconduser, firstuser, '100000000000.0000 SEEDS', { authorization: `${seconduser}@active` })
-//     sowBalanceExceeded = true
-//   } catch (err) {
-//     console.log("trying to sow more than user has planted throws error")
-//   }
-
-//   console.log('calculate planted score')
-//   await contracts.harvest.rankplanteds({ authorization: `${harvest}@active` })
-//   const planted = await getTableRows({
-//     code: harvest,
-//     scope: harvest,
-//     table: 'planted',
-//     json: true
-//   })
-//   const sizes = await getTableRows({
-//     code: harvest,
-//     scope: harvest,
-//     table: 'sizes',
-//     json: true
-//   })
-//   console.log("plantedXX  "+JSON.stringify(planted, null, 2))
-//   console.log("sizesxx  "+JSON.stringify(sizes, null, 2))
-
-
-//   console.log('calculate reputation multiplier')
-//   await contracts.accounts.addrep(firstuser, 1, { authorization: `${accounts}@active` })
-//   await contracts.accounts.addrep(seconduser, 2, { authorization: `${accounts}@active` })
-//   await contracts.accounts.rankreps({ authorization: `${accounts}@active` })
-
-//   console.log('calculate transactions score')
-//   await contracts.harvest.calctrxpts({ authorization: `${harvest}@active` })
-//   await contracts.harvest.ranktxs({ authorization: `${harvest}@active` })
-
-//   const txpoints = await getTableRows({
-//     code: harvest,
-//     scope: harvest,
-//     table: 'txpoints',
-//     json: true
-//   })
-
-
-
-//   let transactionAsString = JSON.stringify(transactionRefund.processed)
-
-//   console.log("includes history "+transactionAsString.includes(history))
-//   console.log("includes history "+transactionAsString.includes("trxentry"))
-
-//   assert({
-//     given: 'sow more than planted',
-//     should: 'throw exception',
-//     actual: sowBalanceExceeded,
-//     expected: false
-//   })
-
-//   assert({
-//     given: 'claim refund transaction',
-//     should: 'call inline action to history',
-//     actual: transactionAsString.includes(history) && transactionAsString.includes("trxentry") ,
-//     expected: true
-//   })
-
-//   assert({
-//     given: 'unplant more than planted',
-//     should: 'fail',
-//     actual: unplantedOverdrawCheck,
-//     expected: true
-//   })
+  // await sleep(5000)
+  await contracts.token.transfer(seconduser, firstuser, '0.1000 SEEDS', '', { authorization: `${seconduser}@active` })
   
-//   assert({
-//     given: 'cancel refund transaction',
-//     should: 'call inline action to history',
-//     actual: transactionCancelRefund.processed.action_traces[0].inline_traces[0].act.account,
-//     expected: history
-//   })
+  const balanceBeforeUnplanted = await getBalanceFloat(seconduser)
 
-//   assert({
-//     given: 'after unplanting 100 seeds',
-//     should: 'refund rows add up to 100',
-//     actual: totalUnplanted,
-//     expected: 100
-//   })
+  const checkTotal = async (check) => {
+    const total = await eos.getTableRows({
+      code: harvest,
+      scope: harvest,
+      table: 'total',
+      json: true,
+    })
+    // const planted = await eos.getTableRows({
+    //   code: harvest,
+    //   scope: harvest,
+    //   table: 'planted',
+    //   json: true,
+    // })
+    // console.log("planted "+JSON.stringify(planted, null, 2))
+    // console.log("total "+JSON.stringify(total, null, 2))
 
-//   assert({
-//     given: 'unplant called',
-//     should: 'create refunds rows',
-//     actual: refundsAfterUnplanted.rows.length,
-//     expected: 12
-//   })
+    assert({
+      given: 'checking total '+check,
+      should: 'be able the same',
+      actual: total.rows[0].total_planted,
+      expected: check + ".0000 SEEDS"
+    })
+  }
 
-//   assert({
-//     given: 'claimed refund',
-//     should: 'keep refunds rows',
-//     actual: refundsAfterClaimed.rows.length,
-//     expected: 10
-//   })
+  await checkTotal(700);
 
-//   assert({
-//     given: 'canceled refund',
-//     should: 'withdraw refunds to user',
-//     actual: refundsAfterCanceled.rows.length,
-//     expected: 0
-//   })
+  let num_seeds_unplanted = 100
+  await contracts.harvest.unplant(seconduser, num_seeds_unplanted + '.0000 SEEDS', { authorization: `${seconduser}@active` })
 
-//   assert({
-//     given: 'unplanting process',
-//     should: 'not change user balance before timeout',
-//     actual: balanceAfterUnplanted,
-//     expected: balanceBeforeUnplanted
-//   })
+  await checkTotal(600);
 
-//   assert({
-//     given: 'planted calculation',
-//     should: 'assign planted score to each user',
-//     actual: planted.rows.map(row => ({
-//       account: row.account,
-//       score: row.rank
-//     })),
-//     expected: [{
-//       account: firstuser,
-//       score: 50
-//     }, {
-//       account: seconduser,
-//       score: 0
-//     }]
-//   })
+  var unplantedOverdrawCheck = true
+  try {
+    await contracts.harvest.unplant(seconduser, '100000000.0000 SEEDS', { authorization: `${seconduser}@active` })
+    unplantedOverdrawCheck = false
+  } catch (err) {
+    console.log("overdraw protection works")
+  }
 
-//   console.log("txpoints 77: "+JSON.stringify(txpoints, null, 2))
+  const refundsAfterUnplanted = await getTableRows({
+    code: harvest,
+    scope: seconduser,
+    table: 'refunds',
+    json: true,
+    limit: 100
+  })
+
+  console.log("call first signer pays action")
+  await contracts.harvest.payforcpu(
+    seconduser, 
+    { 
+      authorization: [ 
+        {
+          actor: harvest,
+          permission: 'payforcpu'
+        },   
+        {
+          actor: seconduser,
+          permission: 'active'
+        }
+      ]
+    }
+  )
+
+  var payforcpuSeedsUserOnly = true
+  try {
+    await contracts.harvest.payforcpu(
+      thirduser, 
+      { 
+        authorization: [ 
+          {
+            actor: harvest,
+            permission: 'payforcpu'
+          },   
+          {
+            actor: thirduser,
+            permission: 'active'
+          }
+        ]
+      }
+    )  
+    payforcpuSeedsUserOnly = false
+  } catch (err) {
+    console.log("require seeds user for pay for cpu test")
+  }
+
+  var payforCPURequireAuth = true
+  try {
+    await contracts.harvest.payforcpu(
+      thirduser, 
+      { 
+        authorization: [    
+          {
+            actor: thirduser,
+            permission: 'active'
+          }
+        ]
+      }
+    )  
+    payforCPURequireAuth = false
+  } catch (err) {
+    console.log("require payforcup perm test")
+  }
+
+  var payforCPURequireUserAuth = true
+  try {
+    await contracts.harvest.payforcpu(
+      thirduser, 
+      { 
+        authorization: [ 
+          {
+            actor: harvest,
+            permission: 'payforcpu'
+          },   
+        ]
+      }
+    )  
+    payforCPURequireUserAuth = false
+  } catch (err) {
+    console.log("require user auth test")
+  }
+
+
+  //console.log("results after unplanted" + JSON.stringify(refundsAfterUnplanted, null, 2))
+
+  const balanceAfterUnplanted = await getBalanceFloat(seconduser)
+
+  const assetIt = (string) => {
+    let a = string.split(" ")
+    return {
+      amount: Number(a[0]) * 10000,
+      symbol: a[1]
+    }
+  }
+
+  const totalUnplanted = refundsAfterUnplanted.rows.reduce( (a, b) => a + assetIt(b.amount).amount, 0) / 10000
+
+  console.log('claim refund\n')
+  const balanceBeforeClaimed = await getBalanceFloat(seconduser)
+
+  // rewind 16 days
+  let day_seconds = 60 * 60 * 24
+  let num_days_expired = 16
+  let weeks_expired = parseInt(num_days_expired/7)
+  await contracts.harvest.testclaim(seconduser, 1, day_seconds * num_days_expired, { authorization: `${harvest}@active` })
+
+  const transactionRefund = await contracts.harvest.claimrefund(seconduser, 1, { authorization: `${seconduser}@active` })
+
+  const refundsAfterClaimed = await getTableRows({
+    code: harvest,
+    scope: seconduser,
+    table: 'refunds',
+    json: true,
+    limit: 100
+  })
+
+  const balanceAfterClaimed = await getBalanceFloat(seconduser)
+
+  //console.log(weeks_expired + " balance before claim "+balanceBeforeClaimed)
+  //console.log("balance after claim  "+balanceAfterClaimed)
+
+  let difference = balanceAfterClaimed - balanceBeforeClaimed
+  let expectedDifference = num_seeds_unplanted * weeks_expired / 12
+
+  assert({
+    given: 'claim refund after '+num_days_expired+' days',
+    should: 'be able to claim '+weeks_expired+'/12 of total unplanted',
+    actual: Math.floor(difference * 1000)/1000,
+    expected: Math.floor(expectedDifference * 1000)/1000
+  })
+
+  console.log('cancel refund')
+  const transactionCancelRefund = await contracts.harvest.cancelrefund(seconduser, 1, { authorization: `${seconduser}@active` })
+
+  const refundsAfterCanceled = await getTableRows({
+    code: harvest,
+    scope: seconduser,
+    table: 'refunds',
+    json: true,
+    limit: 100
+  })
+
+  console.log('sow seeds')
+  await contracts.harvest.sow(seconduser, firstuser, '10.0000 SEEDS', { authorization: `${seconduser}@active` })
+
+  var sowBalanceExceeded = false
+  try {
+    await contracts.harvest.sow(seconduser, firstuser, '100000000000.0000 SEEDS', { authorization: `${seconduser}@active` })
+    sowBalanceExceeded = true
+  } catch (err) {
+    console.log("trying to sow more than user has planted throws error")
+  }
+
+  console.log('calculate planted score')
+  await contracts.harvest.rankplanteds({ authorization: `${harvest}@active` })
+  const planted = await getTableRows({
+    code: harvest,
+    scope: harvest,
+    table: 'planted',
+    json: true
+  })
+  const sizes = await getTableRows({
+    code: harvest,
+    scope: harvest,
+    table: 'sizes',
+    json: true
+  })
+  console.log("plantedXX  "+JSON.stringify(planted, null, 2))
+  console.log("sizesxx  "+JSON.stringify(sizes, null, 2))
+
+
+  console.log('calculate reputation multiplier')
+  await contracts.accounts.addrep(firstuser, 1, { authorization: `${accounts}@active` })
+  await contracts.accounts.addrep(seconduser, 2, { authorization: `${accounts}@active` })
+  await contracts.accounts.rankreps({ authorization: `${accounts}@active` })
+
+  await contracts.token.transfer(firstuser, seconduser, '1.0000 SEEDS', '', { authorization: `${firstuser}@active` })
+  await sleep(2000)
   
-//   assert({
-//     given: 'transactions calculation',
-//     should: 'assign transactions score to each user',
-//     actual: txpoints.rows.map(({ rank }) => rank).sort((a, b) => b - a),
-//     expected: [0]
-//   })
+  await contracts.token.transfer(seconduser, firstuser, '0.1000 SEEDS', '', { authorization: `${seconduser}@active` })
+  await sleep(2000)
 
-//   assert({
-//     given: 'payforcpu called',
-//     should: 'work only when both authorizations are provided and user is seeds user',
-//     actual: [payforCPURequireAuth, payforCPURequireUserAuth, payforcpuSeedsUserOnly],
-//     expected: [true, true, true]
-//   })
+  console.log('calculate transactions score')
+  await contracts.harvest.calctrxpts({ authorization: `${harvest}@active` })
+  await contracts.harvest.ranktxs({ authorization: `${harvest}@active` })
 
-// })
-
-// describe("harvest planted score", async assert => {
-
-//   if (!isLocal()) {
-//     console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
-//     return
-//   }
-
-//   const contracts = await initContracts({ accounts, token, harvest, settings })
+  const txpoints = await getTableRows({
+    code: harvest,
+    scope: harvest,
+    table: 'txpoints',
+    json: true
+  })
 
 
-//   console.log('harvest reset')
-//   await contracts.harvest.reset({ authorization: `${harvest}@active` })
+  let transactionAsString = JSON.stringify(transactionRefund.processed)
 
-//   console.log('accounts reset')
-//   await contracts.accounts.reset({ authorization: `${accounts}@active` })
+  console.log("includes history "+transactionAsString.includes(history))
+  console.log("includes history "+transactionAsString.includes("trxentry"))
 
-//   console.log('reset token stats')
-//   await contracts.token.resetweekly({ authorization: `${token}@active` })
+  assert({
+    given: 'sow more than planted',
+    should: 'throw exception',
+    actual: sowBalanceExceeded,
+    expected: false
+  })
 
-//   console.log('join users')
-//   await contracts.accounts.adduser(firstuser, 'first user', 'individual', { authorization: `${accounts}@active` })
-//   await contracts.accounts.adduser(seconduser, 'second user', 'individual', { authorization: `${accounts}@active` })
+  assert({
+    given: 'claim refund transaction',
+    should: 'call inline action to history',
+    actual: transactionAsString.includes(history) && transactionAsString.includes("trxentry") ,
+    expected: true
+  })
 
-//   console.log('plant seeds')
-//   await contracts.token.transfer(firstuser, harvest, '500.0000 SEEDS', '', { authorization: `${firstuser}@active` })
-//   await contracts.token.transfer(seconduser, harvest, '200.0000 SEEDS', '', { authorization: `${seconduser}@active` })
+  assert({
+    given: 'unplant more than planted',
+    should: 'fail',
+    actual: unplantedOverdrawCheck,
+    expected: true
+  })
+  
+  assert({
+    given: 'cancel refund transaction',
+    should: 'call inline action to history',
+    actual: transactionCancelRefund.processed.action_traces[0].inline_traces[0].act.account,
+    expected: history
+  })
 
-//   await contracts.harvest.rankplanteds({ authorization: `${harvest}@active` })
-//   await contracts.accounts.rankreps({ authorization: `${accounts}@active` })
-//   await contracts.harvest.calctrxpts({ authorization: `${harvest}@active` })
-//   await contracts.harvest.ranktxs({ authorization: `${harvest}@active` })
+  assert({
+    given: 'after unplanting 100 seeds',
+    should: 'refund rows add up to 100',
+    actual: totalUnplanted,
+    expected: 100
+  })
 
-//   const planted = await eos.getTableRows({
-//     code: harvest,
-//     scope: harvest,
-//     table: 'planted',
-//     json: true,
-//     limit: 100
-//   })
+  assert({
+    given: 'unplant called',
+    should: 'create refunds rows',
+    actual: refundsAfterUnplanted.rows.length,
+    expected: 12
+  })
 
-//   console.log('planted '+JSON.stringify(planted, null, 2))
+  assert({
+    given: 'claimed refund',
+    should: 'keep refunds rows',
+    actual: refundsAfterClaimed.rows.length,
+    expected: 10
+  })
 
-//   assert({
-//     given: 'planted calculation',
-//     should: 'have valies',
-//     actual: planted.rows.map(({ rank }) => rank),
-//     expected: [50, 0]
-//   })
+  assert({
+    given: 'canceled refund',
+    should: 'withdraw refunds to user',
+    actual: refundsAfterCanceled.rows.length,
+    expected: 0
+  })
 
-// })
+  assert({
+    given: 'unplanting process',
+    should: 'not change user balance before timeout',
+    actual: balanceAfterUnplanted,
+    expected: balanceBeforeUnplanted
+  })
+
+  assert({
+    given: 'planted calculation',
+    should: 'assign planted score to each user',
+    actual: planted.rows.map(row => ({
+      account: row.account,
+      score: row.rank
+    })),
+    expected: [{
+      account: firstuser,
+      score: 50
+    }, {
+      account: seconduser,
+      score: 0
+    }]
+  })
+
+  console.log("txpoints 77: "+JSON.stringify(txpoints, null, 2))
+  
+  assert({
+    given: 'transactions calculation',
+    should: 'assign transactions score to each user',
+    actual: txpoints.rows.map(({ rank }) => rank).sort((a, b) => b - a),
+    expected: [0]
+  })
+
+  assert({
+    given: 'payforcpu called',
+    should: 'work only when both authorizations are provided and user is seeds user',
+    actual: [payforCPURequireAuth, payforCPURequireUserAuth, payforcpuSeedsUserOnly],
+    expected: [true, true, true]
+  })
+
+})
+
+describe("harvest planted score", async assert => {
+
+  if (!isLocal()) {
+    console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
+    return
+  }
+
+  const contracts = await initContracts({ accounts, token, harvest, settings })
+
+
+  console.log('harvest reset')
+  await contracts.harvest.reset({ authorization: `${harvest}@active` })
+
+  console.log('accounts reset')
+  await contracts.accounts.reset({ authorization: `${accounts}@active` })
+
+  console.log('reset token stats')
+  await contracts.token.resetweekly({ authorization: `${token}@active` })
+
+  console.log('join users')
+  await contracts.accounts.adduser(firstuser, 'first user', 'individual', { authorization: `${accounts}@active` })
+  await contracts.accounts.adduser(seconduser, 'second user', 'individual', { authorization: `${accounts}@active` })
+
+  console.log('plant seeds')
+  await contracts.token.transfer(firstuser, harvest, '500.0000 SEEDS', '', { authorization: `${firstuser}@active` })
+  await contracts.token.transfer(seconduser, harvest, '200.0000 SEEDS', '', { authorization: `${seconduser}@active` })
+
+  await contracts.harvest.rankplanteds({ authorization: `${harvest}@active` })
+  await contracts.accounts.rankreps({ authorization: `${accounts}@active` })
+  await contracts.harvest.calctrxpts({ authorization: `${harvest}@active` })
+  await contracts.harvest.ranktxs({ authorization: `${harvest}@active` })
+
+  const planted = await eos.getTableRows({
+    code: harvest,
+    scope: harvest,
+    table: 'planted',
+    json: true,
+    limit: 100
+  })
+
+  console.log('planted '+JSON.stringify(planted, null, 2))
+
+  assert({
+    given: 'planted calculation',
+    should: 'have valies',
+    actual: planted.rows.map(({ rank }) => rank),
+    expected: [50, 0]
+  })
+
+})
 
 describe("harvest transaction score", async assert => {
 
@@ -596,169 +605,222 @@ describe("harvest transaction score", async assert => {
     given: 'contribution score',
     should: 'have contribution score score',
     actual: cspoints.rows.map(({ rank }) => rank), 
-    expected: [89]
+    expected: [0]
   })
 
 })
 
 
-// describe("harvest community building score", async assert => {
+describe("harvest community building score", async assert => {
 
-//   if (!isLocal()) {
-//     console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
-//     return
-//   }
+  if (!isLocal()) {
+    console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
+    return
+  }
 
-//   const contracts = await initContracts({ accounts, harvest, settings, history })
+  const contracts = await initContracts({ accounts, harvest, settings, history })
 
-//   console.log('harvest reset')
-//   await contracts.harvest.reset({ authorization: `${harvest}@active` })
+  console.log('harvest reset')
+  await contracts.harvest.reset({ authorization: `${harvest}@active` })
 
-//   console.log('accounts reset')
-//   await contracts.accounts.reset({ authorization: `${accounts}@active` })
+  console.log('accounts reset')
+  await contracts.accounts.reset({ authorization: `${accounts}@active` })
 
-//   console.log('join users')
-//   let users = [firstuser, seconduser, thirduser, fourthuser]
+  console.log('join users')
+  let users = [firstuser, seconduser, thirduser, fourthuser]
 
-//   for (let i = 0; i < users.length; i++) {
-//     await contracts.accounts.adduser(users[i], i+' user', 'individual', { authorization: `${accounts}@active` })
-//     await sleep(400)
-//   }
+  for (let i = 0; i < users.length; i++) {
+    await contracts.accounts.adduser(users[i], i+' user', 'individual', { authorization: `${accounts}@active` })
+    await sleep(400)
+  }
 
-//   const checkScores = async (points, scores, given, should) => {
+  const checkScores = async (points, scores, given, should) => {
 
-//     console.log("checking points "+points + " scores: "+scores)
-//     await sleep(300)
-//     await contracts.accounts.rankcbss({ authorization: `${accounts}@active` })
+    console.log("checking points "+points + " scores: "+scores)
+    await sleep(300)
+    await contracts.accounts.rankcbss({ authorization: `${accounts}@active` })
     
-//     const cbs = await eos.getTableRows({
-//       code: accounts,
-//       scope: accounts,
-//       table: 'cbs',
-//       json: true,
-//       limit: 100
-//     })
+    const cbs = await eos.getTableRows({
+      code: accounts,
+      scope: accounts,
+      table: 'cbs',
+      json: true,
+      limit: 100
+    })
 
-//     //console.log(given + " cba points "+JSON.stringify(cbs, null, 2))
+    //console.log(given + " cba points "+JSON.stringify(cbs, null, 2))
   
-//     assert({
-//       given: 'cbs points '+given,
-//       should: 'have expected values '+should,
-//       actual: cbs.rows.map(({ community_building_score }) => community_building_score),
-//       expected: points
-//     })
+    assert({
+      given: 'cbs points '+given,
+      should: 'have expected values '+should,
+      actual: cbs.rows.map(({ community_building_score }) => community_building_score),
+      expected: points
+    })
 
-//     assert({
-//       given: 'cbs scores '+given,
-//       should: 'have expected values '+should,
-//       actual: cbs.rows.map(({ rank }) => rank),
-//       expected: scores
-//     })
+    assert({
+      given: 'cbs scores '+given,
+      should: 'have expected values '+should,
+      actual: cbs.rows.map(({ rank }) => rank),
+      expected: scores
+    })
 
-//   }
+  }
 
-//   console.log('add cbs')
-//   //await contracts.accounts.rankcbss({ authorization: `${accounts}@active` })
+  console.log('add cbs')
+  //await contracts.accounts.rankcbss({ authorization: `${accounts}@active` })
 
-//   //await checkScores([], [], "no cbs", "be empty")
+  //await checkScores([], [], "no cbs", "be empty")
 
-//   console.log('calculate cbs scores')
-//   await contracts.accounts.testsetcbs(firstuser, 1, { authorization: `${accounts}@active` })
-//   await sleep(200)
-//   await checkScores([1], [0], "1 cbs", "0 score")
+  console.log('calculate cbs scores')
+  await contracts.accounts.testsetcbs(firstuser, 1, { authorization: `${accounts}@active` })
+  await sleep(200)
+  await checkScores([1], [0], "1 cbs", "0 score")
 
-//   await contracts.accounts.testsetcbs(seconduser, 2, { authorization: `${accounts}@active` })
-//   await sleep(200)
-//   await contracts.accounts.testsetcbs(thirduser, 3, { authorization: `${accounts}@active` })
-//   await sleep(200)
-//   await contracts.accounts.testsetcbs(fourthuser, 0, { authorization: `${accounts}@active` })
+  await contracts.accounts.testsetcbs(seconduser, 2, { authorization: `${accounts}@active` })
+  await sleep(200)
+  await contracts.accounts.testsetcbs(thirduser, 3, { authorization: `${accounts}@active` })
+  await sleep(200)
+  await contracts.accounts.testsetcbs(fourthuser, 0, { authorization: `${accounts}@active` })
 
-//   await contracts.accounts.rankcbss({ authorization: `${accounts}@active` })
-//   await checkScores([1, 2, 3, 0], [25, 50, 75, 0], "cbs distribution", "correct")
-// })
+  await contracts.accounts.rankcbss({ authorization: `${accounts}@active` })
+  await checkScores([1, 2, 3, 0], [25, 50, 75, 0], "cbs distribution", "correct")
+})
 
-// describe("plant for other user", async assert => {
+describe("plant for other user", async assert => {
 
-//   if (!isLocal()) {
-//     console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
-//     return
-//   }
+  if (!isLocal()) {
+    console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
+    return
+  }
 
-//   const contracts = await Promise.all([
-//     eos.contract(token),
-//     eos.contract(accounts),
-//     eos.contract(harvest),
-//     eos.contract(settings),
-//   ]).then(([token, accounts, harvest, settings]) => ({
-//     token, accounts, harvest, settings
-//   }))
+  const contracts = await Promise.all([
+    eos.contract(token),
+    eos.contract(accounts),
+    eos.contract(harvest),
+    eos.contract(settings),
+  ]).then(([token, accounts, harvest, settings]) => ({
+    token, accounts, harvest, settings
+  }))
 
-//   console.log('harvest reset')
-//   await contracts.harvest.reset({ authorization: `${harvest}@active` })
+  console.log('harvest reset')
+  await contracts.harvest.reset({ authorization: `${harvest}@active` })
 
-//   console.log('accounts reset')
-//   await contracts.accounts.reset({ authorization: `${accounts}@active` })
+  console.log('accounts reset')
+  await contracts.accounts.reset({ authorization: `${accounts}@active` })
 
-//   console.log('reset token stats')
-//   await contracts.token.resetweekly({ authorization: `${token}@active` })
+  console.log('reset token stats')
+  await contracts.token.resetweekly({ authorization: `${token}@active` })
 
-//   console.log('join users')
-//   await contracts.accounts.adduser(firstuser, 'first user', 'individual', { authorization: `${accounts}@active` })
-//   await contracts.accounts.adduser(seconduser, 'second user', 'individual', { authorization: `${accounts}@active` })
+  console.log('join users')
+  await contracts.accounts.adduser(firstuser, 'first user', 'individual', { authorization: `${accounts}@active` })
+  await contracts.accounts.adduser(seconduser, 'second user', 'individual', { authorization: `${accounts}@active` })
 
-//   let memo = "sow "+seconduser
+  let memo = "sow "+seconduser
 
-//   console.log('plant seeds with memo: ' + memo)
+  console.log('plant seeds with memo: ' + memo)
 
-//   await contracts.token.transfer(firstuser, harvest, '77.0000 SEEDS', memo, { authorization: `${firstuser}@active` })
+  await contracts.token.transfer(firstuser, harvest, '77.0000 SEEDS', memo, { authorization: `${firstuser}@active` })
 
-//   const plantedBalances = await getTableRows({
-//     code: harvest,
-//     scope: harvest,
-//     table: 'balances',
-//     upper_bound: seconduser,
-//     lower_bound: seconduser,
-//     json: true,
-//   })
+  const plantedBalances = await getTableRows({
+    code: harvest,
+    scope: harvest,
+    table: 'balances',
+    upper_bound: seconduser,
+    lower_bound: seconduser,
+    json: true,
+  })
 
-//   let badMemos = false
-//   const badMemo = async (badmemo) => {
-//     try {
-//       await contracts.token.transfer(firstuser, harvest, '77.0000 SEEDS', badmemo, { authorization: `${firstuser}@active` })
-//       badMemos = true
-//     } catch (error) {
-//       //console.log("error as expected "+ badmemo)
-//       //console.log(error)
-//     }  
-//   }
-//   //console.log('planted: ' + JSON.stringify(plantedBalances, null, 2))
+  let badMemos = false
+  const badMemo = async (badmemo) => {
+    try {
+      await contracts.token.transfer(firstuser, harvest, '77.0000 SEEDS', badmemo, { authorization: `${firstuser}@active` })
+      badMemos = true
+    } catch (error) {
+      //console.log("error as expected "+ badmemo)
+      //console.log(error)
+    }  
+  }
+  //console.log('planted: ' + JSON.stringify(plantedBalances, null, 2))
 
-//   await badMemo("foobar");
-//   await badMemo("ASDASDSDASDSADSDSDSDASDSDSDSSDSDSDSADSDSADSD");
-//   await badMemo("sow X");
-//   await badMemo("sow somethingspecial");
-//   await badMemo("sow seedsuserfoo");
-//   await badMemo("sow seedsuseraaa foo");
+  await badMemo("foobar");
+  await badMemo("ASDASDSDASDSADSDSDSDASDSDSDSSDSDSDSADSDSADSD");
+  await badMemo("sow X");
+  await badMemo("sow somethingspecial");
+  await badMemo("sow seedsuserfoo");
+  await badMemo("sow seedsuseraaa foo");
 
-//   await badMemo("sow .");
-//   await badMemo("sow \u03A9\u0122\u9099\u6660");
-//   await badMemo("sow sadsadsakd;skdjlksajdlaskjd;lkaslaksdj;lkasjdals;kdjsal;kdj;aslKDJ;alskdj;alskdj;alskdj;alskdj;alskdjas;lKDJas;lkdj;alsKDJ;aslkdja;sLKDJas;lkdj");
+  await badMemo("sow .");
+  await badMemo("sow \u03A9\u0122\u9099\u6660");
+  await badMemo("sow sadsadsakd;skdjlksajdlaskjd;lkaslaksdj;lkasjdals;kdjsal;kdj;aslKDJ;alskdj;alskdj;alskdj;alskdj;alskdjas;lKDJas;lkdj;alsKDJ;aslkdja;sLKDJas;lkdj");
 
-//   assert({
-//     given: 'user '+firstuser + 'planted for '+seconduser,
-//     should: 'second user should have planted balance',
-//     actual: plantedBalances.rows[0],
-//     expected: {
-//       "account": seconduser,
-//       "planted": "77.0000 SEEDS",
-//       "reward": "0.0000 SEEDS"
-//     }
-//   })
-//   assert({
-//     given: 'bad memo',
-//     should: 'cause exception',
-//     actual: badMemos,
-//     expected: false
-//   })
+  assert({
+    given: 'user '+firstuser + 'planted for '+seconduser,
+    should: 'second user should have planted balance',
+    actual: plantedBalances.rows[0],
+    expected: {
+      "account": seconduser,
+      "planted": "77.0000 SEEDS",
+      "reward": "0.0000 SEEDS"
+    }
+  })
+  assert({
+    given: 'bad memo',
+    should: 'cause exception',
+    actual: badMemos,
+    expected: false
+  })
 
-// })
+})
+
+
+describe('Monthly QEV', async assert => {
+
+  if (!isLocal()) {
+    console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
+    return
+  }
+
+  const contracts = await Promise.all([
+    eos.contract(token),
+    eos.contract(accounts),
+    eos.contract(harvest),
+    eos.contract(settings),
+    eos.contract(history)
+  ]).then(([token, accounts, harvest, settings, history]) => ({
+    token, accounts, harvest, settings, history
+  }))
+
+  const day = getBeginningOfDayInSeconds()
+
+  console.log('reset history')
+  await contracts.history.reset(history, { authorization: `${history}@active` })
+  await contracts.history.deldailytrx(day, { authorization: `${history}@active` })
+  
+  console.log('reset harvest')
+  await contracts.harvest.reset({ authorization: `${harvest}@active` })
+
+  console.log('calculate total monthly qev')
+  
+  await contracts.history.testtotalqev(120, 100 * 10000, { authorization: `${history}@active` })
+  await sleep(100)
+  await contracts.harvest.calcmqevs({ authorization: `${harvest}@active` })
+
+  const totalQev = await getTableRows({
+    code: harvest,
+    scope: harvest,
+    table: 'monthlyqevs',
+    json: true,
+  })
+
+  assert({
+    given: 'monthly qev calculated',
+    should: 'have the correct monthlyqevs entries',
+    actual: totalQev.rows,
+    expected: [
+      { timestamp: day, qualifying_volume: 30000000 }
+    ]
+  })
+
+})
+
+

--- a/test/harvest.test.js
+++ b/test/harvest.test.js
@@ -548,7 +548,7 @@ describe("harvest transaction score", async assert => {
 
   let expectedScore = 15 + 25 * (1 * 1.5) // 52.5
   console.log("More than 26 transactions. Expected tx points: "+ expectedScore)
-  for(let i = 0; i < 1; i++) {
+  for(let i = 0; i < 40; i++) {
     // 40 transactions
     // rep multiplier 2nd user: 1.5
     // vulume: 1

--- a/test/harvest.test.js
+++ b/test/harvest.test.js
@@ -4,446 +4,451 @@ const { equals } = require("ramda")
 
 const { accounts, harvest, token, firstuser, seconduser, thirduser, bank, settings, history, fourthuser } = names
 
+function getBeginningOfDayInSeconds () {
+  const now = new Date()
+  return now.setUTCHours(0, 0, 0, 0) / 1000
+}
+
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-describe("Harvest General", async assert => {
+// describe("Harvest General", async assert => {
 
-  if (!isLocal()) {
-    console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
-    return
-  }
+//   if (!isLocal()) {
+//     console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
+//     return
+//   }
 
-  const contracts = await initContracts({ accounts, token, harvest, settings, history })
+//   const contracts = await initContracts({ accounts, token, harvest, settings, history })
 
-  console.log('harvest reset')
-  await contracts.harvest.reset({ authorization: `${harvest}@active` })
+//   console.log('harvest reset')
+//   await contracts.harvest.reset({ authorization: `${harvest}@active` })
 
-  console.log('accounts reset')
-  await contracts.accounts.reset({ authorization: `${accounts}@active` })
+//   console.log('accounts reset')
+//   await contracts.accounts.reset({ authorization: `${accounts}@active` })
 
-  console.log('reset token stats')
-  await contracts.token.resetweekly({ authorization: `${token}@active` })
+//   console.log('reset token stats')
+//   await contracts.token.resetweekly({ authorization: `${token}@active` })
 
-  console.log('configure')
-  await contracts.settings.configure("hrvstreward", 10000 * 100, { authorization: `${settings}@active` })
+//   console.log('configure')
+//   await contracts.settings.configure("hrvstreward", 10000 * 100, { authorization: `${settings}@active` })
 
-  console.log('join users')
-  await contracts.accounts.adduser(firstuser, 'first user', 'individual', { authorization: `${accounts}@active` })
-  await contracts.accounts.adduser(seconduser, 'second user', 'individual', { authorization: `${accounts}@active` })
+//   console.log('join users')
+//   await contracts.accounts.adduser(firstuser, 'first user', 'individual', { authorization: `${accounts}@active` })
+//   await contracts.accounts.adduser(seconduser, 'second user', 'individual', { authorization: `${accounts}@active` })
 
-  console.log('reset history')
-  let users = [firstuser, seconduser]
-  users.forEach( async (user, index) => await contracts.history.reset(user, { authorization: `${history}@active` }))
+//   console.log('reset history')
+//   let users = [firstuser, seconduser]
+//   users.forEach( async (user, index) => await contracts.history.reset(user, { authorization: `${history}@active` }))
 
 
-  const txpoints1 = await eos.getTableRows({
-    code: harvest,
-    scope: harvest,
-    table: 'txpoints',
-    json: true,
-    limit: 100
-  })
+//   const txpoints1 = await eos.getTableRows({
+//     code: harvest,
+//     scope: harvest,
+//     table: 'txpoints',
+//     json: true,
+//     limit: 100
+//   })
 
-  console.log(" tx points 1 "+JSON.stringify(txpoints1, null, 2))
+//   console.log(" tx points 1 "+JSON.stringify(txpoints1, null, 2))
 
   
-  console.log('plant seeds x')
-  await contracts.token.transfer(firstuser, harvest, '500.0000 SEEDS', '', { authorization: `${firstuser}@active` })
+//   console.log('plant seeds x')
+//   await contracts.token.transfer(firstuser, harvest, '500.0000 SEEDS', '', { authorization: `${firstuser}@active` })
 
-  await contracts.token.transfer(seconduser, harvest, '200.0000 SEEDS', '', { authorization: `${seconduser}@active` })
-  // await sleep(5000)
+//   await contracts.token.transfer(seconduser, harvest, '200.0000 SEEDS', '', { authorization: `${seconduser}@active` })
+//   // await sleep(5000)
 
-  // console.log('transfer seeds')
-  await contracts.token.transfer(firstuser, seconduser, '1.0000 SEEDS', '', { authorization: `${firstuser}@active` })
+//   // console.log('transfer seeds')
+//   await contracts.token.transfer(firstuser, seconduser, '1.0000 SEEDS', '', { authorization: `${firstuser}@active` })
   
-  // await sleep(5000)
-  await contracts.token.transfer(seconduser, firstuser, '0.1000 SEEDS', '', { authorization: `${seconduser}@active` })
+//   // await sleep(5000)
+//   await contracts.token.transfer(seconduser, firstuser, '0.1000 SEEDS', '', { authorization: `${seconduser}@active` })
 
-  const balanceBeforeUnplanted = await getBalanceFloat(seconduser)
+//   const balanceBeforeUnplanted = await getBalanceFloat(seconduser)
 
-  const checkTotal = async (check) => {
-    const total = await eos.getTableRows({
-      code: harvest,
-      scope: harvest,
-      table: 'total',
-      json: true,
-    })
-    // const planted = await eos.getTableRows({
-    //   code: harvest,
-    //   scope: harvest,
-    //   table: 'planted',
-    //   json: true,
-    // })
-    // console.log("planted "+JSON.stringify(planted, null, 2))
-    // console.log("total "+JSON.stringify(total, null, 2))
+//   const checkTotal = async (check) => {
+//     const total = await eos.getTableRows({
+//       code: harvest,
+//       scope: harvest,
+//       table: 'total',
+//       json: true,
+//     })
+//     // const planted = await eos.getTableRows({
+//     //   code: harvest,
+//     //   scope: harvest,
+//     //   table: 'planted',
+//     //   json: true,
+//     // })
+//     // console.log("planted "+JSON.stringify(planted, null, 2))
+//     // console.log("total "+JSON.stringify(total, null, 2))
 
-    assert({
-      given: 'checking total '+check,
-      should: 'be able the same',
-      actual: total.rows[0].total_planted,
-      expected: check + ".0000 SEEDS"
-    })
-  }
+//     assert({
+//       given: 'checking total '+check,
+//       should: 'be able the same',
+//       actual: total.rows[0].total_planted,
+//       expected: check + ".0000 SEEDS"
+//     })
+//   }
 
-  await checkTotal(700);
+//   await checkTotal(700);
 
-  let num_seeds_unplanted = 100
-  await contracts.harvest.unplant(seconduser, num_seeds_unplanted + '.0000 SEEDS', { authorization: `${seconduser}@active` })
+//   let num_seeds_unplanted = 100
+//   await contracts.harvest.unplant(seconduser, num_seeds_unplanted + '.0000 SEEDS', { authorization: `${seconduser}@active` })
 
-  await checkTotal(600);
+//   await checkTotal(600);
 
-  var unplantedOverdrawCheck = true
-  try {
-    await contracts.harvest.unplant(seconduser, '100000000.0000 SEEDS', { authorization: `${seconduser}@active` })
-    unplantedOverdrawCheck = false
-  } catch (err) {
-    console.log("overdraw protection works")
-  }
+//   var unplantedOverdrawCheck = true
+//   try {
+//     await contracts.harvest.unplant(seconduser, '100000000.0000 SEEDS', { authorization: `${seconduser}@active` })
+//     unplantedOverdrawCheck = false
+//   } catch (err) {
+//     console.log("overdraw protection works")
+//   }
 
-  const refundsAfterUnplanted = await getTableRows({
-    code: harvest,
-    scope: seconduser,
-    table: 'refunds',
-    json: true,
-    limit: 100
-  })
+//   const refundsAfterUnplanted = await getTableRows({
+//     code: harvest,
+//     scope: seconduser,
+//     table: 'refunds',
+//     json: true,
+//     limit: 100
+//   })
 
-  console.log("call first signer pays action")
-  await contracts.harvest.payforcpu(
-    seconduser, 
-    { 
-      authorization: [ 
-        {
-          actor: harvest,
-          permission: 'payforcpu'
-        },   
-        {
-          actor: seconduser,
-          permission: 'active'
-        }
-      ]
-    }
-  )
+//   console.log("call first signer pays action")
+//   await contracts.harvest.payforcpu(
+//     seconduser, 
+//     { 
+//       authorization: [ 
+//         {
+//           actor: harvest,
+//           permission: 'payforcpu'
+//         },   
+//         {
+//           actor: seconduser,
+//           permission: 'active'
+//         }
+//       ]
+//     }
+//   )
 
-  var payforcpuSeedsUserOnly = true
-  try {
-    await contracts.harvest.payforcpu(
-      thirduser, 
-      { 
-        authorization: [ 
-          {
-            actor: harvest,
-            permission: 'payforcpu'
-          },   
-          {
-            actor: thirduser,
-            permission: 'active'
-          }
-        ]
-      }
-    )  
-    payforcpuSeedsUserOnly = false
-  } catch (err) {
-    console.log("require seeds user for pay for cpu test")
-  }
+//   var payforcpuSeedsUserOnly = true
+//   try {
+//     await contracts.harvest.payforcpu(
+//       thirduser, 
+//       { 
+//         authorization: [ 
+//           {
+//             actor: harvest,
+//             permission: 'payforcpu'
+//           },   
+//           {
+//             actor: thirduser,
+//             permission: 'active'
+//           }
+//         ]
+//       }
+//     )  
+//     payforcpuSeedsUserOnly = false
+//   } catch (err) {
+//     console.log("require seeds user for pay for cpu test")
+//   }
 
-  var payforCPURequireAuth = true
-  try {
-    await contracts.harvest.payforcpu(
-      thirduser, 
-      { 
-        authorization: [    
-          {
-            actor: thirduser,
-            permission: 'active'
-          }
-        ]
-      }
-    )  
-    payforCPURequireAuth = false
-  } catch (err) {
-    console.log("require payforcup perm test")
-  }
+//   var payforCPURequireAuth = true
+//   try {
+//     await contracts.harvest.payforcpu(
+//       thirduser, 
+//       { 
+//         authorization: [    
+//           {
+//             actor: thirduser,
+//             permission: 'active'
+//           }
+//         ]
+//       }
+//     )  
+//     payforCPURequireAuth = false
+//   } catch (err) {
+//     console.log("require payforcup perm test")
+//   }
 
-  var payforCPURequireUserAuth = true
-  try {
-    await contracts.harvest.payforcpu(
-      thirduser, 
-      { 
-        authorization: [ 
-          {
-            actor: harvest,
-            permission: 'payforcpu'
-          },   
-        ]
-      }
-    )  
-    payforCPURequireUserAuth = false
-  } catch (err) {
-    console.log("require user auth test")
-  }
-
-
-  //console.log("results after unplanted" + JSON.stringify(refundsAfterUnplanted, null, 2))
-
-  const balanceAfterUnplanted = await getBalanceFloat(seconduser)
-
-  const assetIt = (string) => {
-    let a = string.split(" ")
-    return {
-      amount: Number(a[0]) * 10000,
-      symbol: a[1]
-    }
-  }
-
-  const totalUnplanted = refundsAfterUnplanted.rows.reduce( (a, b) => a + assetIt(b.amount).amount, 0) / 10000
-
-  console.log('claim refund\n')
-  const balanceBeforeClaimed = await getBalanceFloat(seconduser)
-
-  // rewind 16 days
-  let day_seconds = 60 * 60 * 24
-  let num_days_expired = 16
-  let weeks_expired = parseInt(num_days_expired/7)
-  await contracts.harvest.testclaim(seconduser, 1, day_seconds * num_days_expired, { authorization: `${harvest}@active` })
-
-  const transactionRefund = await contracts.harvest.claimrefund(seconduser, 1, { authorization: `${seconduser}@active` })
-
-  const refundsAfterClaimed = await getTableRows({
-    code: harvest,
-    scope: seconduser,
-    table: 'refunds',
-    json: true,
-    limit: 100
-  })
-
-  const balanceAfterClaimed = await getBalanceFloat(seconduser)
-
-  //console.log(weeks_expired + " balance before claim "+balanceBeforeClaimed)
-  //console.log("balance after claim  "+balanceAfterClaimed)
-
-  let difference = balanceAfterClaimed - balanceBeforeClaimed
-  let expectedDifference = num_seeds_unplanted * weeks_expired / 12
-
-  assert({
-    given: 'claim refund after '+num_days_expired+' days',
-    should: 'be able to claim '+weeks_expired+'/12 of total unplanted',
-    actual: Math.floor(difference * 1000)/1000,
-    expected: Math.floor(expectedDifference * 1000)/1000
-  })
-
-  console.log('cancel refund')
-  const transactionCancelRefund = await contracts.harvest.cancelrefund(seconduser, 1, { authorization: `${seconduser}@active` })
-
-  const refundsAfterCanceled = await getTableRows({
-    code: harvest,
-    scope: seconduser,
-    table: 'refunds',
-    json: true,
-    limit: 100
-  })
-
-  console.log('sow seeds')
-  await contracts.harvest.sow(seconduser, firstuser, '10.0000 SEEDS', { authorization: `${seconduser}@active` })
-
-  var sowBalanceExceeded = false
-  try {
-    await contracts.harvest.sow(seconduser, firstuser, '100000000000.0000 SEEDS', { authorization: `${seconduser}@active` })
-    sowBalanceExceeded = true
-  } catch (err) {
-    console.log("trying to sow more than user has planted throws error")
-  }
-
-  console.log('calculate planted score')
-  await contracts.harvest.rankplanteds({ authorization: `${harvest}@active` })
-  const planted = await getTableRows({
-    code: harvest,
-    scope: harvest,
-    table: 'planted',
-    json: true
-  })
-  const sizes = await getTableRows({
-    code: harvest,
-    scope: harvest,
-    table: 'sizes',
-    json: true
-  })
-  console.log("plantedXX  "+JSON.stringify(planted, null, 2))
-  console.log("sizesxx  "+JSON.stringify(sizes, null, 2))
+//   var payforCPURequireUserAuth = true
+//   try {
+//     await contracts.harvest.payforcpu(
+//       thirduser, 
+//       { 
+//         authorization: [ 
+//           {
+//             actor: harvest,
+//             permission: 'payforcpu'
+//           },   
+//         ]
+//       }
+//     )  
+//     payforCPURequireUserAuth = false
+//   } catch (err) {
+//     console.log("require user auth test")
+//   }
 
 
-  console.log('calculate reputation multiplier')
-  await contracts.accounts.addrep(firstuser, 1, { authorization: `${accounts}@active` })
-  await contracts.accounts.addrep(seconduser, 2, { authorization: `${accounts}@active` })
-  await contracts.accounts.rankreps({ authorization: `${accounts}@active` })
+//   //console.log("results after unplanted" + JSON.stringify(refundsAfterUnplanted, null, 2))
 
-  console.log('calculate transactions score')
-  await contracts.harvest.calctrxpts({ authorization: `${harvest}@active` })
-  await contracts.harvest.ranktxs({ authorization: `${harvest}@active` })
+//   const balanceAfterUnplanted = await getBalanceFloat(seconduser)
 
-  const txpoints = await getTableRows({
-    code: harvest,
-    scope: harvest,
-    table: 'txpoints',
-    json: true
-  })
+//   const assetIt = (string) => {
+//     let a = string.split(" ")
+//     return {
+//       amount: Number(a[0]) * 10000,
+//       symbol: a[1]
+//     }
+//   }
+
+//   const totalUnplanted = refundsAfterUnplanted.rows.reduce( (a, b) => a + assetIt(b.amount).amount, 0) / 10000
+
+//   console.log('claim refund\n')
+//   const balanceBeforeClaimed = await getBalanceFloat(seconduser)
+
+//   // rewind 16 days
+//   let day_seconds = 60 * 60 * 24
+//   let num_days_expired = 16
+//   let weeks_expired = parseInt(num_days_expired/7)
+//   await contracts.harvest.testclaim(seconduser, 1, day_seconds * num_days_expired, { authorization: `${harvest}@active` })
+
+//   const transactionRefund = await contracts.harvest.claimrefund(seconduser, 1, { authorization: `${seconduser}@active` })
+
+//   const refundsAfterClaimed = await getTableRows({
+//     code: harvest,
+//     scope: seconduser,
+//     table: 'refunds',
+//     json: true,
+//     limit: 100
+//   })
+
+//   const balanceAfterClaimed = await getBalanceFloat(seconduser)
+
+//   //console.log(weeks_expired + " balance before claim "+balanceBeforeClaimed)
+//   //console.log("balance after claim  "+balanceAfterClaimed)
+
+//   let difference = balanceAfterClaimed - balanceBeforeClaimed
+//   let expectedDifference = num_seeds_unplanted * weeks_expired / 12
+
+//   assert({
+//     given: 'claim refund after '+num_days_expired+' days',
+//     should: 'be able to claim '+weeks_expired+'/12 of total unplanted',
+//     actual: Math.floor(difference * 1000)/1000,
+//     expected: Math.floor(expectedDifference * 1000)/1000
+//   })
+
+//   console.log('cancel refund')
+//   const transactionCancelRefund = await contracts.harvest.cancelrefund(seconduser, 1, { authorization: `${seconduser}@active` })
+
+//   const refundsAfterCanceled = await getTableRows({
+//     code: harvest,
+//     scope: seconduser,
+//     table: 'refunds',
+//     json: true,
+//     limit: 100
+//   })
+
+//   console.log('sow seeds')
+//   await contracts.harvest.sow(seconduser, firstuser, '10.0000 SEEDS', { authorization: `${seconduser}@active` })
+
+//   var sowBalanceExceeded = false
+//   try {
+//     await contracts.harvest.sow(seconduser, firstuser, '100000000000.0000 SEEDS', { authorization: `${seconduser}@active` })
+//     sowBalanceExceeded = true
+//   } catch (err) {
+//     console.log("trying to sow more than user has planted throws error")
+//   }
+
+//   console.log('calculate planted score')
+//   await contracts.harvest.rankplanteds({ authorization: `${harvest}@active` })
+//   const planted = await getTableRows({
+//     code: harvest,
+//     scope: harvest,
+//     table: 'planted',
+//     json: true
+//   })
+//   const sizes = await getTableRows({
+//     code: harvest,
+//     scope: harvest,
+//     table: 'sizes',
+//     json: true
+//   })
+//   console.log("plantedXX  "+JSON.stringify(planted, null, 2))
+//   console.log("sizesxx  "+JSON.stringify(sizes, null, 2))
+
+
+//   console.log('calculate reputation multiplier')
+//   await contracts.accounts.addrep(firstuser, 1, { authorization: `${accounts}@active` })
+//   await contracts.accounts.addrep(seconduser, 2, { authorization: `${accounts}@active` })
+//   await contracts.accounts.rankreps({ authorization: `${accounts}@active` })
+
+//   console.log('calculate transactions score')
+//   await contracts.harvest.calctrxpts({ authorization: `${harvest}@active` })
+//   await contracts.harvest.ranktxs({ authorization: `${harvest}@active` })
+
+//   const txpoints = await getTableRows({
+//     code: harvest,
+//     scope: harvest,
+//     table: 'txpoints',
+//     json: true
+//   })
 
 
 
-  let transactionAsString = JSON.stringify(transactionRefund.processed)
+//   let transactionAsString = JSON.stringify(transactionRefund.processed)
 
-  console.log("includes history "+transactionAsString.includes(history))
-  console.log("includes history "+transactionAsString.includes("trxentry"))
+//   console.log("includes history "+transactionAsString.includes(history))
+//   console.log("includes history "+transactionAsString.includes("trxentry"))
 
-  assert({
-    given: 'sow more than planted',
-    should: 'throw exception',
-    actual: sowBalanceExceeded,
-    expected: false
-  })
+//   assert({
+//     given: 'sow more than planted',
+//     should: 'throw exception',
+//     actual: sowBalanceExceeded,
+//     expected: false
+//   })
 
-  assert({
-    given: 'claim refund transaction',
-    should: 'call inline action to history',
-    actual: transactionAsString.includes(history) && transactionAsString.includes("trxentry") ,
-    expected: true
-  })
+//   assert({
+//     given: 'claim refund transaction',
+//     should: 'call inline action to history',
+//     actual: transactionAsString.includes(history) && transactionAsString.includes("trxentry") ,
+//     expected: true
+//   })
 
-  assert({
-    given: 'unplant more than planted',
-    should: 'fail',
-    actual: unplantedOverdrawCheck,
-    expected: true
-  })
+//   assert({
+//     given: 'unplant more than planted',
+//     should: 'fail',
+//     actual: unplantedOverdrawCheck,
+//     expected: true
+//   })
   
-  assert({
-    given: 'cancel refund transaction',
-    should: 'call inline action to history',
-    actual: transactionCancelRefund.processed.action_traces[0].inline_traces[0].act.account,
-    expected: history
-  })
+//   assert({
+//     given: 'cancel refund transaction',
+//     should: 'call inline action to history',
+//     actual: transactionCancelRefund.processed.action_traces[0].inline_traces[0].act.account,
+//     expected: history
+//   })
 
-  assert({
-    given: 'after unplanting 100 seeds',
-    should: 'refund rows add up to 100',
-    actual: totalUnplanted,
-    expected: 100
-  })
+//   assert({
+//     given: 'after unplanting 100 seeds',
+//     should: 'refund rows add up to 100',
+//     actual: totalUnplanted,
+//     expected: 100
+//   })
 
-  assert({
-    given: 'unplant called',
-    should: 'create refunds rows',
-    actual: refundsAfterUnplanted.rows.length,
-    expected: 12
-  })
+//   assert({
+//     given: 'unplant called',
+//     should: 'create refunds rows',
+//     actual: refundsAfterUnplanted.rows.length,
+//     expected: 12
+//   })
 
-  assert({
-    given: 'claimed refund',
-    should: 'keep refunds rows',
-    actual: refundsAfterClaimed.rows.length,
-    expected: 10
-  })
+//   assert({
+//     given: 'claimed refund',
+//     should: 'keep refunds rows',
+//     actual: refundsAfterClaimed.rows.length,
+//     expected: 10
+//   })
 
-  assert({
-    given: 'canceled refund',
-    should: 'withdraw refunds to user',
-    actual: refundsAfterCanceled.rows.length,
-    expected: 0
-  })
+//   assert({
+//     given: 'canceled refund',
+//     should: 'withdraw refunds to user',
+//     actual: refundsAfterCanceled.rows.length,
+//     expected: 0
+//   })
 
-  assert({
-    given: 'unplanting process',
-    should: 'not change user balance before timeout',
-    actual: balanceAfterUnplanted,
-    expected: balanceBeforeUnplanted
-  })
+//   assert({
+//     given: 'unplanting process',
+//     should: 'not change user balance before timeout',
+//     actual: balanceAfterUnplanted,
+//     expected: balanceBeforeUnplanted
+//   })
 
-  assert({
-    given: 'planted calculation',
-    should: 'assign planted score to each user',
-    actual: planted.rows.map(row => ({
-      account: row.account,
-      score: row.rank
-    })),
-    expected: [{
-      account: firstuser,
-      score: 50
-    }, {
-      account: seconduser,
-      score: 0
-    }]
-  })
+//   assert({
+//     given: 'planted calculation',
+//     should: 'assign planted score to each user',
+//     actual: planted.rows.map(row => ({
+//       account: row.account,
+//       score: row.rank
+//     })),
+//     expected: [{
+//       account: firstuser,
+//       score: 50
+//     }, {
+//       account: seconduser,
+//       score: 0
+//     }]
+//   })
 
-  console.log("txpoints 77: "+JSON.stringify(txpoints, null, 2))
+//   console.log("txpoints 77: "+JSON.stringify(txpoints, null, 2))
   
-  assert({
-    given: 'transactions calculation',
-    should: 'assign transactions score to each user',
-    actual: txpoints.rows.map(({ rank }) => rank).sort((a, b) => b - a),
-    expected: [0]
-  })
+//   assert({
+//     given: 'transactions calculation',
+//     should: 'assign transactions score to each user',
+//     actual: txpoints.rows.map(({ rank }) => rank).sort((a, b) => b - a),
+//     expected: [0]
+//   })
 
-  assert({
-    given: 'payforcpu called',
-    should: 'work only when both authorizations are provided and user is seeds user',
-    actual: [payforCPURequireAuth, payforCPURequireUserAuth, payforcpuSeedsUserOnly],
-    expected: [true, true, true]
-  })
+//   assert({
+//     given: 'payforcpu called',
+//     should: 'work only when both authorizations are provided and user is seeds user',
+//     actual: [payforCPURequireAuth, payforCPURequireUserAuth, payforcpuSeedsUserOnly],
+//     expected: [true, true, true]
+//   })
 
-})
+// })
 
-describe("harvest planted score", async assert => {
+// describe("harvest planted score", async assert => {
 
-  if (!isLocal()) {
-    console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
-    return
-  }
+//   if (!isLocal()) {
+//     console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
+//     return
+//   }
 
-  const contracts = await initContracts({ accounts, token, harvest, settings })
+//   const contracts = await initContracts({ accounts, token, harvest, settings })
 
 
-  console.log('harvest reset')
-  await contracts.harvest.reset({ authorization: `${harvest}@active` })
+//   console.log('harvest reset')
+//   await contracts.harvest.reset({ authorization: `${harvest}@active` })
 
-  console.log('accounts reset')
-  await contracts.accounts.reset({ authorization: `${accounts}@active` })
+//   console.log('accounts reset')
+//   await contracts.accounts.reset({ authorization: `${accounts}@active` })
 
-  console.log('reset token stats')
-  await contracts.token.resetweekly({ authorization: `${token}@active` })
+//   console.log('reset token stats')
+//   await contracts.token.resetweekly({ authorization: `${token}@active` })
 
-  console.log('join users')
-  await contracts.accounts.adduser(firstuser, 'first user', 'individual', { authorization: `${accounts}@active` })
-  await contracts.accounts.adduser(seconduser, 'second user', 'individual', { authorization: `${accounts}@active` })
+//   console.log('join users')
+//   await contracts.accounts.adduser(firstuser, 'first user', 'individual', { authorization: `${accounts}@active` })
+//   await contracts.accounts.adduser(seconduser, 'second user', 'individual', { authorization: `${accounts}@active` })
 
-  console.log('plant seeds')
-  await contracts.token.transfer(firstuser, harvest, '500.0000 SEEDS', '', { authorization: `${firstuser}@active` })
-  await contracts.token.transfer(seconduser, harvest, '200.0000 SEEDS', '', { authorization: `${seconduser}@active` })
+//   console.log('plant seeds')
+//   await contracts.token.transfer(firstuser, harvest, '500.0000 SEEDS', '', { authorization: `${firstuser}@active` })
+//   await contracts.token.transfer(seconduser, harvest, '200.0000 SEEDS', '', { authorization: `${seconduser}@active` })
 
-  await contracts.harvest.rankplanteds({ authorization: `${harvest}@active` })
-  await contracts.accounts.rankreps({ authorization: `${accounts}@active` })
-  await contracts.harvest.calctrxpts({ authorization: `${harvest}@active` })
-  await contracts.harvest.ranktxs({ authorization: `${harvest}@active` })
+//   await contracts.harvest.rankplanteds({ authorization: `${harvest}@active` })
+//   await contracts.accounts.rankreps({ authorization: `${accounts}@active` })
+//   await contracts.harvest.calctrxpts({ authorization: `${harvest}@active` })
+//   await contracts.harvest.ranktxs({ authorization: `${harvest}@active` })
 
-  const planted = await eos.getTableRows({
-    code: harvest,
-    scope: harvest,
-    table: 'planted',
-    json: true,
-    limit: 100
-  })
+//   const planted = await eos.getTableRows({
+//     code: harvest,
+//     scope: harvest,
+//     table: 'planted',
+//     json: true,
+//     limit: 100
+//   })
 
-  console.log('planted '+JSON.stringify(planted, null, 2))
+//   console.log('planted '+JSON.stringify(planted, null, 2))
 
-  assert({
-    given: 'planted calculation',
-    should: 'have valies',
-    actual: planted.rows.map(({ rank }) => rank),
-    expected: [50, 0]
-  })
+//   assert({
+//     given: 'planted calculation',
+//     should: 'have valies',
+//     actual: planted.rows.map(({ rank }) => rank),
+//     expected: [50, 0]
+//   })
 
-})
+// })
 
 describe("harvest transaction score", async assert => {
 
@@ -455,6 +460,8 @@ describe("harvest transaction score", async assert => {
   const memoprefix = "" + (new Date()).getTime()
 
   const contracts = await initContracts({ accounts, token, harvest, settings, history })
+
+  const day = getBeginningOfDayInSeconds()
 
   console.log('harvest reset')
   await contracts.harvest.reset({ authorization: `${harvest}@active` })
@@ -472,6 +479,14 @@ describe("harvest transaction score", async assert => {
   let users = [firstuser, seconduser, thirduser, fourthuser]
   users.forEach( async (user, index) => await contracts.accounts.adduser(user, index+' user', 'individual', { authorization: `${accounts}@active` }))
   users.forEach( async (user, index) => await contracts.history.reset(user, { authorization: `${history}@active` }))
+  
+  await contracts.history.deldailytrx(day, { authorization: `${history}@active` })
+  await sleep(100)
+
+  const transfer = async (from, to, quantity, memo) => {
+    await contracts.token.transfer(from, to, `${quantity}.0000 SEEDS`, memo, { authorization: `${from}@active` })
+    await sleep(3000)
+  }
 
   const checkScores = async (points, scores, given, should) => {
 
@@ -504,45 +519,48 @@ describe("harvest transaction score", async assert => {
 
   }
 
-  console.log('make transaction, no reps')
-  await contracts.token.transfer(firstuser, seconduser, '10.0000 SEEDS', memoprefix, { authorization: `${firstuser}@active` })
   //await contracts.accounts.rankcbss({ authorization: `${accounts}@active` })
 
-  await checkScores([], [], "no reputation no points", "be empty")
+  // await checkScores([], [], "no reputation no points", "be empty")
 
   console.log('calculate tx scores with reputation')
   await contracts.accounts.testsetrs(seconduser, 49, { authorization: `${accounts}@active` })
+
+  console.log('make transaction, no reps')
+  await transfer(firstuser, seconduser, 10, memoprefix)
+
   await checkScores([10], [0], "1 reputation, 1 tx", "100 score")
 
-  console.log("transfer with 10 rep, 2 accounts have rep")
-  await contracts.token.transfer(seconduser, thirduser, '10.0000 SEEDS', '0'+memoprefix, { authorization: `${seconduser}@active` })
+  // console.log("transfer with 10 rep, 2 accounts have rep")
   await contracts.accounts.testsetrs(thirduser, 75, { authorization: `${accounts}@active` })
+  await transfer(seconduser, thirduser, 10, '0'+memoprefix)
+
   await checkScores([10, 16], [0, 50], "2 reputation, 2 tx", "0, 50 score")
 
   let expectedScore = 15 + 25 * (1 * 1.5) // 52.5
   console.log("More than 26 transactions. Expected tx points: "+ expectedScore)
-  for(let i = 0; i < 40; i++) {
+  for(let i = 0; i < 1; i++) {
     // 40 transactions
     // rep multiplier 2nd user: 1.5
     // vulume: 1
     // only 26 tx count
     // score from before was 15
-    await contracts.token.transfer(firstuser, seconduser, '1.0000 SEEDS', memoprefix+" tx "+i, { authorization: `${firstuser}@active` })
-    await sleep(400)
+    await transfer(firstuser, seconduser, 9, memoprefix+" tx "+i)
   }
-  await checkScores([26, 16], [50, 0], "2 reputation, 2 tx", "50, 0 score")
+  await checkScores([19, 16], [50, 0], "2 reputation, 2 tx", "50, 0 score")
 
   // test tx exceeds volume limit
   let tx_max_points = 1777
   let third_user_rep_multiplier = 2 * 0.7575
-  await contracts.token.transfer(seconduser, thirduser, '3000.0000 SEEDS', memoprefix+" tx max pt", { authorization: `${seconduser}@active` })
-  await checkScores([26, parseInt(16 + tx_max_points * third_user_rep_multiplier)], [0, 50], "large tx", "100, 75 score")
+  await transfer(seconduser, thirduser, 3000, memoprefix+" tx max pt")
+  await checkScores([19, parseInt(Math.ceil(16 + tx_max_points * third_user_rep_multiplier))], [0, 50], "large tx", "100, 75 score")
   
   // send back 
-  await contracts.token.transfer(thirduser, seconduser, '3000.0000 SEEDS', memoprefix+" tx max pt", { authorization: `${thirduser}@active` })
+  await transfer(thirduser, seconduser, 3000, memoprefix+" tx max pt")
 
   console.log("calc CS score")
   await contracts.harvest.calccss({ authorization: `${harvest}@active` })
+  await contracts.harvest.rankcss({ authorization: `${harvest}@active` })
 
   const cspoints = await eos.getTableRows({
     code: harvest,
@@ -554,6 +572,16 @@ describe("harvest transaction score", async assert => {
 
   // let secondCSpoints = cspoints.rows.filter( item => item.account == seconduser )[0].contribution_points
   // let secondCS = harvestStats.rows.filter( item => item.account == seconduser )[0].contribution_score
+
+  const txpoints = await eos.getTableRows({
+    code: harvest,
+    scope: harvest,
+    table: 'txpoints',
+    json: true,
+    limit: 100
+  })
+  console.log(" tx points "+JSON.stringify(txpoints, null, 2))
+  
 
   console.log("cs points "+JSON.stringify(cspoints, null, 2))
 
@@ -574,163 +602,163 @@ describe("harvest transaction score", async assert => {
 })
 
 
-describe("harvest community building score", async assert => {
+// describe("harvest community building score", async assert => {
 
-  if (!isLocal()) {
-    console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
-    return
-  }
+//   if (!isLocal()) {
+//     console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
+//     return
+//   }
 
-  const contracts = await initContracts({ accounts, harvest, settings, history })
+//   const contracts = await initContracts({ accounts, harvest, settings, history })
 
-  console.log('harvest reset')
-  await contracts.harvest.reset({ authorization: `${harvest}@active` })
+//   console.log('harvest reset')
+//   await contracts.harvest.reset({ authorization: `${harvest}@active` })
 
-  console.log('accounts reset')
-  await contracts.accounts.reset({ authorization: `${accounts}@active` })
+//   console.log('accounts reset')
+//   await contracts.accounts.reset({ authorization: `${accounts}@active` })
 
-  console.log('join users')
-  let users = [firstuser, seconduser, thirduser, fourthuser]
+//   console.log('join users')
+//   let users = [firstuser, seconduser, thirduser, fourthuser]
 
-  for (let i = 0; i < users.length; i++) {
-    await contracts.accounts.adduser(users[i], i+' user', 'individual', { authorization: `${accounts}@active` })
-    await sleep(400)
-  }
+//   for (let i = 0; i < users.length; i++) {
+//     await contracts.accounts.adduser(users[i], i+' user', 'individual', { authorization: `${accounts}@active` })
+//     await sleep(400)
+//   }
 
-  const checkScores = async (points, scores, given, should) => {
+//   const checkScores = async (points, scores, given, should) => {
 
-    console.log("checking points "+points + " scores: "+scores)
-    await sleep(300)
-    await contracts.accounts.rankcbss({ authorization: `${accounts}@active` })
+//     console.log("checking points "+points + " scores: "+scores)
+//     await sleep(300)
+//     await contracts.accounts.rankcbss({ authorization: `${accounts}@active` })
     
-    const cbs = await eos.getTableRows({
-      code: accounts,
-      scope: accounts,
-      table: 'cbs',
-      json: true,
-      limit: 100
-    })
+//     const cbs = await eos.getTableRows({
+//       code: accounts,
+//       scope: accounts,
+//       table: 'cbs',
+//       json: true,
+//       limit: 100
+//     })
 
-    //console.log(given + " cba points "+JSON.stringify(cbs, null, 2))
+//     //console.log(given + " cba points "+JSON.stringify(cbs, null, 2))
   
-    assert({
-      given: 'cbs points '+given,
-      should: 'have expected values '+should,
-      actual: cbs.rows.map(({ community_building_score }) => community_building_score),
-      expected: points
-    })
+//     assert({
+//       given: 'cbs points '+given,
+//       should: 'have expected values '+should,
+//       actual: cbs.rows.map(({ community_building_score }) => community_building_score),
+//       expected: points
+//     })
 
-    assert({
-      given: 'cbs scores '+given,
-      should: 'have expected values '+should,
-      actual: cbs.rows.map(({ rank }) => rank),
-      expected: scores
-    })
+//     assert({
+//       given: 'cbs scores '+given,
+//       should: 'have expected values '+should,
+//       actual: cbs.rows.map(({ rank }) => rank),
+//       expected: scores
+//     })
 
-  }
+//   }
 
-  console.log('add cbs')
-  //await contracts.accounts.rankcbss({ authorization: `${accounts}@active` })
+//   console.log('add cbs')
+//   //await contracts.accounts.rankcbss({ authorization: `${accounts}@active` })
 
-  //await checkScores([], [], "no cbs", "be empty")
+//   //await checkScores([], [], "no cbs", "be empty")
 
-  console.log('calculate cbs scores')
-  await contracts.accounts.testsetcbs(firstuser, 1, { authorization: `${accounts}@active` })
-  await sleep(200)
-  await checkScores([1], [0], "1 cbs", "0 score")
+//   console.log('calculate cbs scores')
+//   await contracts.accounts.testsetcbs(firstuser, 1, { authorization: `${accounts}@active` })
+//   await sleep(200)
+//   await checkScores([1], [0], "1 cbs", "0 score")
 
-  await contracts.accounts.testsetcbs(seconduser, 2, { authorization: `${accounts}@active` })
-  await sleep(200)
-  await contracts.accounts.testsetcbs(thirduser, 3, { authorization: `${accounts}@active` })
-  await sleep(200)
-  await contracts.accounts.testsetcbs(fourthuser, 0, { authorization: `${accounts}@active` })
+//   await contracts.accounts.testsetcbs(seconduser, 2, { authorization: `${accounts}@active` })
+//   await sleep(200)
+//   await contracts.accounts.testsetcbs(thirduser, 3, { authorization: `${accounts}@active` })
+//   await sleep(200)
+//   await contracts.accounts.testsetcbs(fourthuser, 0, { authorization: `${accounts}@active` })
 
-  await contracts.accounts.rankcbss({ authorization: `${accounts}@active` })
-  await checkScores([1, 2, 3, 0], [25, 50, 75, 0], "cbs distribution", "correct")
-})
+//   await contracts.accounts.rankcbss({ authorization: `${accounts}@active` })
+//   await checkScores([1, 2, 3, 0], [25, 50, 75, 0], "cbs distribution", "correct")
+// })
 
-describe("plant for other user", async assert => {
+// describe("plant for other user", async assert => {
 
-  if (!isLocal()) {
-    console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
-    return
-  }
+//   if (!isLocal()) {
+//     console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
+//     return
+//   }
 
-  const contracts = await Promise.all([
-    eos.contract(token),
-    eos.contract(accounts),
-    eos.contract(harvest),
-    eos.contract(settings),
-  ]).then(([token, accounts, harvest, settings]) => ({
-    token, accounts, harvest, settings
-  }))
+//   const contracts = await Promise.all([
+//     eos.contract(token),
+//     eos.contract(accounts),
+//     eos.contract(harvest),
+//     eos.contract(settings),
+//   ]).then(([token, accounts, harvest, settings]) => ({
+//     token, accounts, harvest, settings
+//   }))
 
-  console.log('harvest reset')
-  await contracts.harvest.reset({ authorization: `${harvest}@active` })
+//   console.log('harvest reset')
+//   await contracts.harvest.reset({ authorization: `${harvest}@active` })
 
-  console.log('accounts reset')
-  await contracts.accounts.reset({ authorization: `${accounts}@active` })
+//   console.log('accounts reset')
+//   await contracts.accounts.reset({ authorization: `${accounts}@active` })
 
-  console.log('reset token stats')
-  await contracts.token.resetweekly({ authorization: `${token}@active` })
+//   console.log('reset token stats')
+//   await contracts.token.resetweekly({ authorization: `${token}@active` })
 
-  console.log('join users')
-  await contracts.accounts.adduser(firstuser, 'first user', 'individual', { authorization: `${accounts}@active` })
-  await contracts.accounts.adduser(seconduser, 'second user', 'individual', { authorization: `${accounts}@active` })
+//   console.log('join users')
+//   await contracts.accounts.adduser(firstuser, 'first user', 'individual', { authorization: `${accounts}@active` })
+//   await contracts.accounts.adduser(seconduser, 'second user', 'individual', { authorization: `${accounts}@active` })
 
-  let memo = "sow "+seconduser
+//   let memo = "sow "+seconduser
 
-  console.log('plant seeds with memo: ' + memo)
+//   console.log('plant seeds with memo: ' + memo)
 
-  await contracts.token.transfer(firstuser, harvest, '77.0000 SEEDS', memo, { authorization: `${firstuser}@active` })
+//   await contracts.token.transfer(firstuser, harvest, '77.0000 SEEDS', memo, { authorization: `${firstuser}@active` })
 
-  const plantedBalances = await getTableRows({
-    code: harvest,
-    scope: harvest,
-    table: 'balances',
-    upper_bound: seconduser,
-    lower_bound: seconduser,
-    json: true,
-  })
+//   const plantedBalances = await getTableRows({
+//     code: harvest,
+//     scope: harvest,
+//     table: 'balances',
+//     upper_bound: seconduser,
+//     lower_bound: seconduser,
+//     json: true,
+//   })
 
-  let badMemos = false
-  const badMemo = async (badmemo) => {
-    try {
-      await contracts.token.transfer(firstuser, harvest, '77.0000 SEEDS', badmemo, { authorization: `${firstuser}@active` })
-      badMemos = true
-    } catch (error) {
-      //console.log("error as expected "+ badmemo)
-      //console.log(error)
-    }  
-  }
-  //console.log('planted: ' + JSON.stringify(plantedBalances, null, 2))
+//   let badMemos = false
+//   const badMemo = async (badmemo) => {
+//     try {
+//       await contracts.token.transfer(firstuser, harvest, '77.0000 SEEDS', badmemo, { authorization: `${firstuser}@active` })
+//       badMemos = true
+//     } catch (error) {
+//       //console.log("error as expected "+ badmemo)
+//       //console.log(error)
+//     }  
+//   }
+//   //console.log('planted: ' + JSON.stringify(plantedBalances, null, 2))
 
-  await badMemo("foobar");
-  await badMemo("ASDASDSDASDSADSDSDSDASDSDSDSSDSDSDSADSDSADSD");
-  await badMemo("sow X");
-  await badMemo("sow somethingspecial");
-  await badMemo("sow seedsuserfoo");
-  await badMemo("sow seedsuseraaa foo");
+//   await badMemo("foobar");
+//   await badMemo("ASDASDSDASDSADSDSDSDASDSDSDSSDSDSDSADSDSADSD");
+//   await badMemo("sow X");
+//   await badMemo("sow somethingspecial");
+//   await badMemo("sow seedsuserfoo");
+//   await badMemo("sow seedsuseraaa foo");
 
-  await badMemo("sow .");
-  await badMemo("sow \u03A9\u0122\u9099\u6660");
-  await badMemo("sow sadsadsakd;skdjlksajdlaskjd;lkaslaksdj;lkasjdals;kdjsal;kdj;aslKDJ;alskdj;alskdj;alskdj;alskdj;alskdjas;lKDJas;lkdj;alsKDJ;aslkdja;sLKDJas;lkdj");
+//   await badMemo("sow .");
+//   await badMemo("sow \u03A9\u0122\u9099\u6660");
+//   await badMemo("sow sadsadsakd;skdjlksajdlaskjd;lkaslaksdj;lkasjdals;kdjsal;kdj;aslKDJ;alskdj;alskdj;alskdj;alskdj;alskdjas;lKDJas;lkdj;alsKDJ;aslkdja;sLKDJas;lkdj");
 
-  assert({
-    given: 'user '+firstuser + 'planted for '+seconduser,
-    should: 'second user should have planted balance',
-    actual: plantedBalances.rows[0],
-    expected: {
-      "account": seconduser,
-      "planted": "77.0000 SEEDS",
-      "reward": "0.0000 SEEDS"
-    }
-  })
-  assert({
-    given: 'bad memo',
-    should: 'cause exception',
-    actual: badMemos,
-    expected: false
-  })
+//   assert({
+//     given: 'user '+firstuser + 'planted for '+seconduser,
+//     should: 'second user should have planted balance',
+//     actual: plantedBalances.rows[0],
+//     expected: {
+//       "account": seconduser,
+//       "planted": "77.0000 SEEDS",
+//       "reward": "0.0000 SEEDS"
+//     }
+//   })
+//   assert({
+//     given: 'bad memo',
+//     should: 'cause exception',
+//     actual: badMemos,
+//     expected: false
+//   })
 
-})
+// })

--- a/test/history.test.js
+++ b/test/history.test.js
@@ -251,7 +251,7 @@ describe("make a history entry", async (assert) => {
 
 })
 
-describe('QEV', async assert => {
+describe('individual transactions', async assert => {
 
   if (!isLocal()) {
     console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
@@ -268,6 +268,7 @@ describe('QEV', async assert => {
   await contracts.history.reset(firstuser, { authorization: `${history}@active` })
   await contracts.history.reset(seconduser, { authorization: `${history}@active` })
   await contracts.history.reset(thirduser, { authorization: `${history}@active` })
+  await contracts.history.reset(history, { authorization: `${history}@active` })
   await contracts.history.deldailytrx(day, { authorization: `${history}@active` })
 
   console.log('token reset weekly')
@@ -348,6 +349,7 @@ describe('QEV', async assert => {
   const infoFirstUser = await getTransactionEntries(firstuser)
   const infoSecondUser = await getTransactionEntries(seconduser)
   const infoThirdUser = await getTransactionEntries(thirduser)
+  const historyTotal = await getTransactionEntries(history)
 
   const totals = await getTableRows({
     code: history,
@@ -430,7 +432,11 @@ describe('QEV', async assert => {
   assert({
     given: 'transaction made',
     should: 'have the correct entries in trx points tables',
-    actual: [ infoFirstUser.trxPoints, infoSecondUser.trxPoints, infoThirdUser.trxPoints ],
+    actual: [
+      infoFirstUser.trxPoints,
+      infoSecondUser.trxPoints, 
+      infoThirdUser.trxPoints 
+    ],
     expected: [
       [{ timestamp: day, points: 412 }],
       [{ timestamp: day, points: 1120 }],
@@ -441,11 +447,17 @@ describe('QEV', async assert => {
   assert({
     given: 'transactions made',
     should: 'have the correct entries in qevs tables',
-    actual: [ infoFirstUser.qevVolume, infoSecondUser.qevVolume, infoThirdUser.qevVolume ],
+    actual: [ 
+      infoFirstUser.qevVolume, 
+      infoSecondUser.qevVolume, 
+      infoThirdUser.qevVolume, 
+      historyTotal.qevVolume 
+    ],
     expected: [
       [{ timestamp: day, qualifying_volume: 11500000 }],
       [{ timestamp: day, qualifying_volume: 9550000 }],
-      [{ timestamp: day, qualifying_volume: 100000 }]
+      [{ timestamp: day, qualifying_volume: 100000 }],
+      [{ timestamp: day, qualifying_volume: 21150000 }]
     ]
   })
 

--- a/test/history.test.js
+++ b/test/history.test.js
@@ -2,7 +2,16 @@ const { describe } = require("riteway")
 const { names, getTableRows, isLocal, initContracts } = require("../scripts/helper")
 const eosDevKey = "EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV"
 
-const { firstuser, seconduser, history, accounts, organization, token, settings } = names
+const { firstuser, seconduser, thirduser, history, accounts, organization, token, settings } = names
+
+function getBeginningOfDayInSeconds () {
+  const now = new Date()
+  return now.setUTCHours(0, 0, 0, 0) / 1000
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
 
 describe('make a transaction entry', async assert => {
 
@@ -10,10 +19,17 @@ describe('make a transaction entry', async assert => {
     console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
     return
   }
-  const contracts = await initContracts({ history, accounts })
-  
+  const contracts = await initContracts({ history, accounts, settings })
+
+  const day = getBeginningOfDayInSeconds()
+
+  console.log('settings reset')
+  await contracts.settings.reset({ authorization: `${settings}@active` })
+
   console.log('history reset')
   await contracts.history.reset(firstuser, { authorization: `${history}@active` })
+  await contracts.history.reset(seconduser, { authorization: `${history}@active` })
+  await contracts.history.deldailytrx(day, { authorization: `${history}@active` })
   
   console.log('accounts reset')
   await contracts.accounts.reset({ authorization: `${accounts}@active` })
@@ -22,21 +38,63 @@ describe('make a transaction entry', async assert => {
   await contracts.accounts.adduser(firstuser, '', 'individual', { authorization: `${accounts}@active` })
   await contracts.accounts.adduser(seconduser, '', 'individual', { authorization: `${accounts}@active` })
   await contracts.accounts.testresident(firstuser, { authorization: `${accounts}@active` })
-  await contracts.accounts.testcitizen(seconduser, { authorization: `${accounts}@active` })  
+  await contracts.accounts.testcitizen(seconduser, { authorization: `${accounts}@active` })
+
+  const firstuserRep = 10
+  const seconduserRep = 49
+  await contracts.accounts.testsetrs(firstuser, firstuserRep, { authorization: `${accounts}@active` })
+  await contracts.accounts.testsetrs(seconduser, seconduserRep, { authorization: `${accounts}@active` })
 
   console.log('add transaction entry')
   await contracts.history.trxentry(firstuser, seconduser, '10.0000 SEEDS', { authorization: `${history}@active` })
-  
+  await sleep(2000)
+
   const { rows } = await getTableRows({
     code: history,
+    scope: day,
+    table: 'dailytrxs',
+    json: true
+  })
+
+  const trxPointsTable = await getTableRows({
+    code: history,
     scope: firstuser,
-    table: 'transactions',
+    table: 'trxpoints',
+    json: true
+  })
+
+  const trxPointsTable2 = await getTableRows({
+    code: history,
+    scope: seconduser,
+    table: 'trxpoints',
+    json: true
+  })
+
+  const qevVolumeTable = await getTableRows({
+    code: history,
+    scope: firstuser,
+    table: 'qevs',
+    json: true
+  })
+
+  const qevVolumeTable2 = await getTableRows({
+    code: history,
+    scope: seconduser,
+    table: 'qevs',
+    json: true
+  })
+
+  const totals = await getTableRows({
+    code: history,
+    scope: history,
+    table: 'totals',
     json: true
   })
   
-console.log("transactions result "+JSON.stringify(rows, null, 2))
+  console.log("transactions result "+JSON.stringify(rows, null, 2))
 
   let txresult = rows[0]
+  const timestamp = txresult.timestamp
   delete txresult.timestamp
 
   assert({
@@ -45,10 +103,68 @@ console.log("transactions result "+JSON.stringify(rows, null, 2))
     actual: txresult,
     expected: {
       id: 0,
+      from: firstuser,
       to: seconduser,
-      quantity: '10.0000 SEEDS',
+      volume: 10 * 10000,
+      qualifying_volume: 10 * 10000,
+      from_points: 10,
+      to_points: 3
     }
   })
+
+  assert({
+    given: 'a transaction made by ' + firstuser,
+    should: 'have transaction points entry',
+    actual: trxPointsTable.rows,
+    expected: [
+      {
+        timestamp: day,
+        points: 10
+      }
+    ]
+  })
+
+  assert({
+    given: 'a transaction received by ' + seconduser,
+    should: 'not have transaction points entry',
+    actual: trxPointsTable2.rows,
+    expected: []
+  })
+
+  assert({
+    given: 'a transaction made by ' + firstuser,
+    should: 'have qualifying transactions entry',
+    actual: qevVolumeTable.rows,
+    expected: [
+      {
+        timestamp: day,
+        qualifying_volume: 10 * 10000
+      }
+    ]
+  })
+
+  assert({
+    given: 'a transaction received by ' + seconduser,
+    should: 'not have qualifying volume entry',
+    actual: qevVolumeTable2.rows,
+    expected: []
+  })
+
+  assert({
+    given: 'a transaction sent',
+    should: 'have an entry in the totals table',
+    actual: totals.rows,
+    expected: [
+      {
+        account: firstuser,
+        total_volume: 10 * 10000,
+        total_number_of_transactions: 1,
+        total_incoming_from_rep_orgs: 0,
+        total_outgoing_to_rep_orgs: 0
+      }
+    ]
+  })
+
 })
 
 describe("make a history entry", async (assert) => {
@@ -135,12 +251,244 @@ describe("make a history entry", async (assert) => {
 
 })
 
+describe('QEV', async assert => {
+
+  if (!isLocal()) {
+    console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
+    return
+  }
+  const contracts = await initContracts({ token, history, accounts, settings })
+
+  const day = getBeginningOfDayInSeconds()
+
+  console.log('settings reset')
+  await contracts.settings.reset({ authorization: `${settings}@active` })
+
+  console.log('history reset')
+  await contracts.history.reset(firstuser, { authorization: `${history}@active` })
+  await contracts.history.reset(seconduser, { authorization: `${history}@active` })
+  await contracts.history.reset(thirduser, { authorization: `${history}@active` })
+  await contracts.history.deldailytrx(day, { authorization: `${history}@active` })
+
+  console.log('token reset weekly')
+  await contracts.token.resetweekly({ authorization: `${token}@active` })
+  
+  console.log('accounts reset')
+  await contracts.accounts.reset({ authorization: `${accounts}@active` })
+  
+  console.log('update status')
+  await contracts.accounts.adduser(firstuser, '', 'individual', { authorization: `${accounts}@active` })
+  await contracts.accounts.adduser(seconduser, '', 'individual', { authorization: `${accounts}@active` })
+  await contracts.accounts.adduser(thirduser, '', 'individual', { authorization: `${accounts}@active` })
+  await contracts.accounts.testresident(firstuser, { authorization: `${accounts}@active` })
+  await contracts.accounts.testcitizen(seconduser, { authorization: `${accounts}@active` })
+  await contracts.accounts.testresident(thirduser, { authorization: `${accounts}@active` })
+
+  const firstuserRep = 1
+  const seconduserRep = 49
+  const thirduserRep = 99
+  await contracts.accounts.testsetrs(firstuser, firstuserRep, { authorization: `${accounts}@active` })
+  await contracts.accounts.testsetrs(seconduser, seconduserRep, { authorization: `${accounts}@active` })
+  await contracts.accounts.testsetrs(thirduser, thirduserRep, { authorization: `${accounts}@active` })
+
+  const transfer = async (from, to, quantity) => {
+    await contracts.token.transfer(from, to, `${quantity}.0000 SEEDS`, 'test', { authorization: `${from}@active` })
+    await sleep(2000)
+  }
+
+  const getTransactionEntries = async (user) => {
+    const dailyTrx = await getTableRows({
+      code: history,
+      scope: day,
+      table: 'dailytrxs',
+      json: true
+    })
+  
+    const trxPoints = await getTableRows({
+      code: history,
+      scope: user,
+      table: 'trxpoints',
+      json: true
+    })
+  
+    const qevVolume = await getTableRows({
+      code: history,
+      scope: user,
+      table: 'qevs',
+      json: true
+    })
+
+    return {
+      dailyTrx: dailyTrx.rows.map(r => {
+        delete r.timestamp
+        return r
+      }),
+      trxPoints: trxPoints.rows,
+      qevVolume: qevVolume.rows
+    }
+  }
+
+  console.log('add transaction entry')
+  await transfer(firstuser, seconduser, 200) // trx points = 
+  await transfer(firstuser, seconduser, 300)
+  await transfer(firstuser, seconduser, 400)
+
+  await contracts.accounts.testsetrs(seconduser, 1, { authorization: `${accounts}@active` })
+  await transfer(firstuser, seconduser, 750)
+
+  await transfer(seconduser, firstuser, 200)
+  await transfer(seconduser, firstuser, 200)
+
+  await transfer(seconduser, thirduser, 255)
+  await transfer(seconduser, thirduser, 300)
+  await transfer(seconduser, thirduser, 100)
+
+  await transfer(thirduser, firstuser, 10)
+
+  const infoFirstUser = await getTransactionEntries(firstuser)
+  const infoSecondUser = await getTransactionEntries(seconduser)
+  const infoThirdUser = await getTransactionEntries(thirduser)
+
+  const totals = await getTableRows({
+    code: history,
+    scope: history,
+    table: 'totals',
+    json: true
+  })
+
+  assert({
+    given: 'transactions made',
+    should: 'have daily transaction entries',
+    actual: infoFirstUser.dailyTrx,
+    expected: [
+      {
+        id: 2,
+        from: firstuser,
+        to: seconduser,
+        volume: 4000000,
+        qualifying_volume: 4000000,
+        from_points: 396,
+        to_points: 9
+      },
+      {
+        id: 3,
+        from: firstuser,
+        to: seconduser,
+        volume: 7500000,
+        qualifying_volume: 7500000,
+        from_points: 16,
+        to_points: 16
+      },
+      {
+        id: 4,
+        from: seconduser,
+        to: firstuser,
+        volume: 2000000,
+        qualifying_volume: 2000000,
+        from_points: 5,
+        to_points: 5
+      },
+      {
+        id: 5,
+        from: seconduser,
+        to: firstuser,
+        volume: 2000000,
+        qualifying_volume: 2000000,
+        from_points: 5,
+        to_points: 5
+      },
+      {
+        id: 6,
+        from: seconduser,
+        to: thirduser,
+        volume: 2550000,
+        qualifying_volume: 2550000,
+        from_points: 510,
+        to_points: 6
+      },
+      {
+        id: 7,
+        from: seconduser,
+        to: thirduser,
+        volume: 3000000,
+        qualifying_volume: 3000000,
+        from_points: 600,
+        to_points: 7
+      },
+      {
+        id: 8,
+        from: thirduser,
+        to: firstuser,
+        volume: 100000,
+        qualifying_volume: 100000,
+        from_points: 1,
+        to_points: 20
+      }
+    ]
+  })
+
+  assert({
+    given: 'transaction made',
+    should: 'have the correct entries in trx points tables',
+    actual: [ infoFirstUser.trxPoints, infoSecondUser.trxPoints, infoThirdUser.trxPoints ],
+    expected: [
+      [{ timestamp: day, points: 412 }],
+      [{ timestamp: day, points: 1120 }],
+      [{ timestamp: day, points: 1 }]
+    ]
+  })
+
+  assert({
+    given: 'transactions made',
+    should: 'have the correct entries in qevs tables',
+    actual: [ infoFirstUser.qevVolume, infoSecondUser.qevVolume, infoThirdUser.qevVolume ],
+    expected: [
+      [{ timestamp: day, qualifying_volume: 11500000 }],
+      [{ timestamp: day, qualifying_volume: 9550000 }],
+      [{ timestamp: day, qualifying_volume: 100000 }]
+    ]
+  })
+
+  assert({
+    given: 'transactions made',
+    should: 'have the correct entries in totals table',
+    actual: totals.rows,
+    expected: [
+      {
+        account: firstuser,
+        total_volume: 16500000,
+        total_number_of_transactions: 4,
+        total_incoming_from_rep_orgs: 0,
+        total_outgoing_to_rep_orgs: 0
+      },
+      {
+        account: seconduser,
+        total_volume: 10550000,
+        total_number_of_transactions: 5,
+        total_incoming_from_rep_orgs: 0,
+        total_outgoing_to_rep_orgs: 0
+      },
+      {
+        account: thirduser,
+        total_volume: 100000,
+        total_number_of_transactions: 1,
+        total_incoming_from_rep_orgs: 0,
+        total_outgoing_to_rep_orgs: 0
+      }
+    ]
+  })
+
+})
+
+
 describe('org transaction entry', async assert => {
 
   if (!isLocal()) {
     console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
     return
   }
+
+  const day = getBeginningOfDayInSeconds()
 
   const firstorg = 'testorg111'
   const secondorg = 'testorg222'
@@ -149,7 +497,11 @@ describe('org transaction entry', async assert => {
   
   console.log('history reset')
   await contracts.history.reset(firstuser, { authorization: `${history}@active` })
+  await contracts.history.reset(seconduser, { authorization: `${history}@active` })
+  await contracts.history.reset(thirduser, { authorization: `${history}@active` })
   await contracts.history.reset(firstorg, { authorization: `${history}@active` })
+  await contracts.history.reset(secondorg, { authorization: `${history}@active` })
+  await contracts.history.deldailytrx(day, { authorization: `${history}@active` })
   
   console.log('accounts reset')
   await contracts.accounts.reset({ authorization: `${accounts}@active` })
@@ -167,115 +519,224 @@ describe('org transaction entry', async assert => {
   await contracts.accounts.adduser(firstuser, 'Bob', 'individual', { authorization: `${accounts}@active` })
   await contracts.accounts.adduser(seconduser, 'Alice', 'individual', { authorization: `${accounts}@active` })
   await contracts.accounts.testcitizen(firstuser, { authorization: `${accounts}@active` })
+  await contracts.accounts.testcitizen(seconduser, { authorization: `${accounts}@active` })
+  await contracts.accounts.testsetrs(firstuser, 15, { authorization: `${accounts}@active` })
+  await contracts.accounts.testsetrs(seconduser, 2, { authorization: `${accounts}@active` })
 
   await contracts.token.transfer(firstuser, organization, "400.0000 SEEDS", "Initial supply", { authorization: `${firstuser}@active` })
   await contracts.token.transfer(seconduser, organization, "400.0000 SEEDS", "Initial supply", { authorization: `${seconduser}@active` })
-  
-  console.log('create organization')
-  const amount1 = '12.0000 SEEDS'
-  const amount2 = '11.1111 SEEDS'
 
+  console.log('create organization')
   await contracts.organization.create(firstuser, firstorg, "Org Number 1", eosDevKey, { authorization: `${firstuser}@active` })
   await contracts.organization.create(seconduser, secondorg, "Org Number 2", eosDevKey, { authorization: `${seconduser}@active` })
+  
+  await contracts.accounts.testsetrs(firstorg, 60, { authorization: `${accounts}@active` })
+  
+  const transfer = async (from, to, quantity) => {
+    await contracts.token.transfer(from, to, `${quantity}.0000 SEEDS`, 'test', { authorization: `${from}@active` })
+    await sleep(2000)
+  }
+
+  const getTransactionEntries = async (user) => {
+    const dailyTrx = await getTableRows({
+      code: history,
+      scope: day,
+      table: 'dailytrxs',
+      json: true
+    })
+  
+    const trxPoints = await getTableRows({
+      code: history,
+      scope: user,
+      table: 'trxpoints',
+      json: true
+    })
+  
+    const qevVolume = await getTableRows({
+      code: history,
+      scope: user,
+      table: 'qevs',
+      json: true
+    })
+
+    return {
+      dailyTrx: dailyTrx.rows.map(r => {
+        delete r.timestamp
+        return r
+      }),
+      trxPoints: trxPoints.rows,
+      qevVolume: qevVolume.rows
+    }
+  }
 
   console.log('add transaction entry from user to org')
-  await contracts.history.trxentry(firstuser, firstorg, amount1, { authorization: `${history}@active` })
-  
-  const transactions = await getTableRows({
-    code: history,
-    scope: firstuser,
-    table: 'transactions',
-    json: true
-  })
-  const orgtx = await getTableRows({
-    code: history,
-    scope: firstorg,
-    table: 'orgtx',
-    json: true
-  })
+  await transfer(firstuser, firstorg, 300)
+  await transfer(firstuser, firstorg, 200)
+  await transfer(firstuser, firstorg, 100)
+  await transfer(firstuser, firstorg, 50)
 
-  await contracts.history.trxentry(firstorg, secondorg, amount2, { authorization: `${history}@active` })
+  await transfer(firstorg, seconduser, 1)
+  await transfer(firstorg, seconduser, 2)
+  await transfer(firstorg, seconduser, 3)
+  await transfer(firstorg, seconduser, 1)
 
-  const transactions2 = await getTableRows({
-    code: history,
-    scope: firstuser,
-    table: 'transactions',
-    json: true
-  })
+  await transfer(firstorg, firstuser, 1)
+  await transfer(firstorg, firstuser, 1)
+  await transfer(firstorg, firstuser, 1)
+  await transfer(firstorg, firstuser, 5)
 
-  const orgtx2 = await getTableRows({
-    code: history,
-    scope: firstorg,
-    table: 'orgtx',
-    json: true
-  })
+  await transfer(firstorg, secondorg, 1)
 
-  const orgtx3 = await getTableRows({
+  await transfer(seconduser, firstorg, 1)
+
+  const infoFirstUser = await getTransactionEntries(firstuser)
+  const infoFirstOrg = await getTransactionEntries(firstorg)
+  const infoSecondUser = await getTransactionEntries(seconduser)
+  const infoSecondOrg = await getTransactionEntries(secondorg)
+
+  const totals = await getTableRows({
     code: history,
-    scope: secondorg,
-    table: 'orgtx',
+    scope: history,
+    table: 'totals',
     json: true
   })
 
   assert({
-    given: 'transactions table',
-    should: 'no change when org transact',
-    actual: transactions2.rows.length,
-    expected: transactions.rows.length
-  })
-
-  assert({
-    given: 'org tx table',
-    should: 'have 2 tx entry',
-    actual: orgtx2.rows.length,
-    expected: 2
-  })
-
-  delete transactions.rows[0].timestamp
-  delete orgtx.rows[0].timestamp
-  delete orgtx2.rows[0].timestamp
-  delete orgtx2.rows[1].timestamp
-  delete orgtx3.rows[0].timestamp
-
-  assert({
-    given: 'transactions table',
-    should: 'have transaction entry',
-    actual: transactions.rows[0],
-    expected: {
-      id: 0,
-      to: firstorg,
-      quantity: amount1,
-    }
-  })
-
-  assert({
-    given: 'org transactions table',
-    should: 'have transaction entry',
-    actual: orgtx.rows[0],
-    expected: {
-      id: 0,
-      other: firstuser,
-      quantity: amount1,
-      in: 1
-    }
-  })
-
-  assert({
-    given: 'org transactions table 2',
-    should: 'have transaction entries for both in and out',
-    actual: orgtx2.rows,
+    given: 'transactions made to orgs',
+    should: 'have the correct daily transactions',
+    actual: infoSecondUser.dailyTrx,
     expected: [
       {
-        "id": 0,
-        "other": "seedsuseraaa",
-        "in": 1,
-        "quantity": "12.0000 SEEDS"
+        id: 0,
+        from: firstuser,
+        to: firstorg,
+        volume: 3000000,
+        qualifying_volume: 3000000,
+        from_points: 364,
+        to_points: 91
       },
       {
-        "id": 1,
-        "other": "testorg222",
-        "in": 0,
-        "quantity": "11.1111 SEEDS"
+        id: 1,
+        from: firstuser,
+        to: firstorg,
+        volume: 2000000,
+        qualifying_volume: 2000000,
+        from_points: 243,
+        to_points: 61
+      },
+      {
+        id: 3,
+        from: firstorg,
+        to: seconduser,
+        volume: 20000,
+        qualifying_volume: 20000,
+        from_points: 1,
+        to_points: 3
+      },
+      {
+        id: 4,
+        from: firstorg,
+        to: seconduser,
+        volume: 30000,
+        qualifying_volume: 30000,
+        from_points: 1,
+        to_points: 4
+      },
+      {
+        id: 7,
+        from: firstorg,
+        to: firstuser,
+        volume: 10000,
+        qualifying_volume: 10000,
+        from_points: 1,
+        to_points: 2
+      },
+      {
+        id: 8,
+        from: firstorg,
+        to: firstuser,
+        volume: 50000,
+        qualifying_volume: 50000,
+        from_points: 2,
+        to_points: 7
+      },
+      {
+        id: 9,
+        from: firstorg,
+        to: secondorg,
+        volume: 10000,
+        qualifying_volume: 10000,
+        from_points: 0,
+        to_points: 2
+      },
+      {
+        id: 10,
+        from: seconduser,
+        to: firstorg,
+        volume: 10000,
+        qualifying_volume: 10000,
+        from_points: 2,
+        to_points: 1
+      }
+    ]
+  })
+
+  assert({
+    given: 'transfer to org',
+    should: 'have correct transaction points',
+    actual: [ infoFirstUser.trxPoints, infoFirstOrg.trxPoints, infoSecondUser.trxPoints, infoSecondOrg.trxPoints ],
+    expected: [
+      [{ timestamp: day, points: 607 }],
+      [{ timestamp: day, points: 158 }],
+      [{ timestamp: day, points: 2 }],
+      [{ timestamp: day, points: 2 }]
+    ]
+  })
+
+  assert({
+    given: 'transfer to org',
+    should: 'have correct qualifying volume',
+    actual: [ infoFirstUser.qevVolume, infoFirstOrg.qevVolume, infoSecondUser.qevVolume, infoSecondOrg.qevVolume ],
+    expected: [
+      [{ timestamp: day, qualifying_volume: 5000000 }],
+      [{ timestamp: day, qualifying_volume: 120000 }],
+      [{ timestamp: day, qualifying_volume: 10000 }],
+      []
+    ]
+  })
+
+  assert({
+    given: 'transfer to org',
+    should: 'have the correct entries in totals table',
+    actual: totals.rows,
+    expected: [
+      {
+        account: firstuser,
+        total_volume: 6500000,
+        total_number_of_transactions: 4,
+        total_incoming_from_rep_orgs: 4,
+        total_outgoing_to_rep_orgs: 4
+      },
+      {
+        account: seconduser,
+        total_volume: 10000,
+        total_number_of_transactions: 1,
+        total_incoming_from_rep_orgs: 4,
+        total_outgoing_to_rep_orgs: 1
+      },
+      {
+        account: firstorg,
+        total_volume: 160000,
+        total_number_of_transactions: 9,
+        total_incoming_from_rep_orgs: 0,
+        total_outgoing_to_rep_orgs: 1
+      },
+      {
+        account: secondorg,
+        total_volume: 0,
+        total_number_of_transactions: 0,
+        total_incoming_from_rep_orgs: 1,
+        total_outgoing_to_rep_orgs: 0
       }
     ]
   })

--- a/test/history.test.js
+++ b/test/history.test.js
@@ -108,7 +108,7 @@ describe('make a transaction entry', async assert => {
       volume: 10 * 10000,
       qualifying_volume: 10 * 10000,
       from_points: 10,
-      to_points: 3
+      to_points: 0
     }
   })
 
@@ -370,7 +370,7 @@ describe('individual transactions', async assert => {
         volume: 4000000,
         qualifying_volume: 4000000,
         from_points: 396,
-        to_points: 9
+        to_points: 0
       },
       {
         id: 3,
@@ -379,7 +379,7 @@ describe('individual transactions', async assert => {
         volume: 7500000,
         qualifying_volume: 7500000,
         from_points: 16,
-        to_points: 16
+        to_points: 0
       },
       {
         id: 4,
@@ -388,7 +388,7 @@ describe('individual transactions', async assert => {
         volume: 2000000,
         qualifying_volume: 2000000,
         from_points: 5,
-        to_points: 5
+        to_points: 0
       },
       {
         id: 5,
@@ -397,7 +397,7 @@ describe('individual transactions', async assert => {
         volume: 2000000,
         qualifying_volume: 2000000,
         from_points: 5,
-        to_points: 5
+        to_points: 0
       },
       {
         id: 6,
@@ -406,7 +406,7 @@ describe('individual transactions', async assert => {
         volume: 2550000,
         qualifying_volume: 2550000,
         from_points: 510,
-        to_points: 6
+        to_points: 0
       },
       {
         id: 7,
@@ -415,7 +415,7 @@ describe('individual transactions', async assert => {
         volume: 3000000,
         qualifying_volume: 3000000,
         from_points: 600,
-        to_points: 7
+        to_points: 0
       },
       {
         id: 8,
@@ -424,7 +424,7 @@ describe('individual transactions', async assert => {
         volume: 100000,
         qualifying_volume: 100000,
         from_points: 1,
-        to_points: 20
+        to_points: 0
       }
     ]
   })
@@ -643,7 +643,7 @@ describe('org transaction entry', async assert => {
         volume: 20000,
         qualifying_volume: 20000,
         from_points: 1,
-        to_points: 3
+        to_points: 0
       },
       {
         id: 4,
@@ -652,7 +652,7 @@ describe('org transaction entry', async assert => {
         volume: 30000,
         qualifying_volume: 30000,
         from_points: 1,
-        to_points: 4
+        to_points: 0
       },
       {
         id: 7,
@@ -661,7 +661,7 @@ describe('org transaction entry', async assert => {
         volume: 10000,
         qualifying_volume: 10000,
         from_points: 1,
-        to_points: 2
+        to_points: 0
       },
       {
         id: 8,
@@ -670,7 +670,7 @@ describe('org transaction entry', async assert => {
         volume: 50000,
         qualifying_volume: 50000,
         from_points: 2,
-        to_points: 7
+        to_points: 0
       },
       {
         id: 9,

--- a/test/scheduler.test.js
+++ b/test/scheduler.test.js
@@ -10,115 +10,115 @@ function sleep(ms) {
 
 var contracts = null
 
-// describe('scheduler', async assert => {
+describe('scheduler', async assert => {
 
-//     if (!isLocal()) {
-//         console.log("only run unit tests on local - don't reset on mainnet or testnet")
-//         return
-//     }
+    if (!isLocal()) {
+        console.log("only run unit tests on local - don't reset on mainnet or testnet")
+        return
+    }
 
-//     contracts = await Promise.all([
-//         eos.contract(scheduler),
-//         eos.contract(settings)
-//     ]).then(([scheduler, settings]) => ({
-//         scheduler, settings
-//     }))
+    contracts = await Promise.all([
+        eos.contract(scheduler),
+        eos.contract(settings)
+    ]).then(([scheduler, settings]) => ({
+        scheduler, settings
+    }))
 
-//     console.log('scheduler reset')
-//     await contracts.scheduler.reset({ authorization: `${scheduler}@active` })
+    console.log('scheduler reset')
+    await contracts.scheduler.reset({ authorization: `${scheduler}@active` })
 
-//     console.log('settings reset')
-//     await contracts.settings.reset({ authorization: `${settings}@active` })
+    console.log('settings reset')
+    await contracts.settings.reset({ authorization: `${settings}@active` })
 
-//     console.log('configure')
-//     await contracts.settings.configure('secndstoexec', 1, { authorization: `${settings}@active` })
+    console.log('configure')
+    await contracts.settings.configure('secndstoexec', 1, { authorization: `${settings}@active` })
 
-//     console.log('add operations')
-//     await contracts.scheduler.configop('one', 'test1', 'cycle.seeds', 1, 0, { authorization: `${scheduler}@active` })
-//     await contracts.scheduler.configop('two', 'test2', 'cycle.seeds', 7, 0, { authorization: `${scheduler}@active` })
+    console.log('add operations')
+    await contracts.scheduler.configop('one', 'test1', 'cycle.seeds', 1, 0, { authorization: `${scheduler}@active` })
+    await contracts.scheduler.configop('two', 'test2', 'cycle.seeds', 7, 0, { authorization: `${scheduler}@active` })
 
-//     console.log('init test 1')
-//     await contracts.scheduler.test1({ authorization: `${scheduler}@active` })
+    console.log('init test 1')
+    await contracts.scheduler.test1({ authorization: `${scheduler}@active` })
 
-//     console.log('init test 2')
-//     await contracts.scheduler.test2({ authorization: `${scheduler}@active` })
+    console.log('init test 2')
+    await contracts.scheduler.test2({ authorization: `${scheduler}@active` })
 
-//     const beforeValues = await getTableRows({
-//         code: scheduler,
-//         scope: scheduler,
-//         table: 'test',
-//         json: true, 
-//         lower_bound: 'unit.test.1',
-//         upper_bound: 'unit.test.2',    
-//         limit: 100
-//     })
+    const beforeValues = await getTableRows({
+        code: scheduler,
+        scope: scheduler,
+        table: 'test',
+        json: true, 
+        lower_bound: 'unit.test.1',
+        upper_bound: 'unit.test.2',    
+        limit: 100
+    })
 
-//     console.log("before "+JSON.stringify(beforeValues, null, 2))
+    console.log("before "+JSON.stringify(beforeValues, null, 2))
 
-//     console.log('scheduler execute')
-//     await contracts.scheduler.start( { authorization: `${scheduler}@active` } )
+    console.log('scheduler execute')
+    await contracts.scheduler.start( { authorization: `${scheduler}@active` } )
 
-//     await sleep(30 * 1000)
+    await sleep(30 * 1000)
 
-//     await contracts.scheduler.stop( { authorization: `${scheduler}@active` } )
+    await contracts.scheduler.stop( { authorization: `${scheduler}@active` } )
 
-//     const afterValues = await getTableRows({
-//         code: scheduler,
-//         scope: scheduler,
-//         table: 'test',
-//         json: true, 
-//         lower_bound: 'unit.test.1',
-//         upper_bound: 'unit.test.2',    
-//         limit: 100
-//     })
+    const afterValues = await getTableRows({
+        code: scheduler,
+        scope: scheduler,
+        table: 'test',
+        json: true, 
+        lower_bound: 'unit.test.1',
+        upper_bound: 'unit.test.2',    
+        limit: 100
+    })
 
-//     await sleep(5 * 1000)
+    await sleep(5 * 1000)
 
-//     const afterValues2 = await getTableRows({
-//         code: scheduler,
-//         scope: scheduler,
-//         table: 'test',
-//         json: true, 
-//         lower_bound: 'unit.test.1',
-//         upper_bound: 'unit.test.2',    
-//         limit: 100
-//     })
+    const afterValues2 = await getTableRows({
+        code: scheduler,
+        scope: scheduler,
+        table: 'test',
+        json: true, 
+        lower_bound: 'unit.test.1',
+        upper_bound: 'unit.test.2',    
+        limit: 100
+    })
 
-//     console.log("after "+JSON.stringify(afterValues, null, 2))
+    console.log("after "+JSON.stringify(afterValues, null, 2))
 
-//     let delta1 = afterValues.rows[0].value - beforeValues.rows[0].value
-//     let delta2 = afterValues.rows[1].value - beforeValues.rows[1].value
+    let delta1 = afterValues.rows[0].value - beforeValues.rows[0].value
+    let delta2 = afterValues.rows[1].value - beforeValues.rows[1].value
 
-//     // TODO: test pause op
+    // TODO: test pause op
 
-//     // TODO: test remove op
+    // TODO: test remove op
 
-//     // TODO: test change op to different op
+    // TODO: test change op to different op
 
-//     assert({
-//         given: '1 second delay was executed 30 seonds',
-//         should: 'be executed close to 30 times (was: '+delta1+')',
-//         actual: delta1 >= 26 && delta1 <= 28, // NOTE: ACTUALLY 27 => 31 - 4, 4 is the other action
-//         expected: true
-//     })
+    assert({
+        given: '1 second delay was executed 30 seonds',
+        should: 'be executed close to 30 times (was: '+delta1+')',
+        actual: delta1 >= 26 && delta1 <= 28, // NOTE: ACTUALLY 27 => 31 - 4, 4 is the other action
+        expected: true
+    })
 
-//     assert({
-//         given: '7 second delay was executed 30 seconds',
-//         should: 'be executed 4 times',
-//         actual: delta2,
-//         expected: 5
-//     })
+    assert({
+        given: '7 second delay was executed 30 seconds',
+        should: 'be executed 4 times',
+        actual: delta2,
+        expected: 5
+    })
 
-//     assert({
-//         given: 'stopped',
-//         should: 'no more executions',
-//         actual: [afterValues.rows[0].value, afterValues.rows[1].value],
-//         expected: [afterValues2.rows[0].value, afterValues2.rows[1].value],
-//     })
+    assert({
+        given: 'stopped',
+        should: 'no more executions',
+        actual: [afterValues.rows[0].value, afterValues.rows[1].value],
+        expected: [afterValues2.rows[0].value, afterValues2.rows[1].value],
+    })
 
     
 
-// })
+})
 
 describe('scheduler, organization.cleandaus', async assert => {
 
@@ -346,6 +346,85 @@ describe('scheduler, forum', async assert => {
             id: 'forum.give',
             operation: 'givereps',
             contract: forum
+        }
+    ]
+
+    console.log('add operations')
+    for (const op of operations) {
+        await contracts.scheduler.configop(op.id, op.operation, op.contract, 1, 0, { authorization: `${scheduler}@active` })
+        await sleep(200)
+    }
+    
+    console.log('scheduler execute')
+    let canExecute = false
+    try {
+        for(const op of operations) {
+            console.log('to execute:', op.operation)
+            await contracts.scheduler.execute({ authorization: `${scheduler}@active` })
+            await sleep(300)
+            await contracts.scheduler.stop( { authorization: `${scheduler}@active` } )
+            await sleep(300)
+            await contracts.scheduler.configop(op.id, op.operation, op.contract, 200, 0, { authorization: `${scheduler}@active` })
+        }
+        canExecute = true
+    } catch (error) {
+        console.log(error)
+        console.log('can not execute (unexpected, permission may be needed)')
+        
+    }
+    assert({
+        given: 'called execute',
+        should: 'be able to execute organization scores actions',
+        actual: canExecute,
+        expected: true
+    })
+
+    await sleep(1 * 1000)
+
+    await contracts.scheduler.stop( { authorization: `${scheduler}@active` } )
+
+    console.log('scheduler reset')
+    await contracts.scheduler.reset({ authorization: `${scheduler}@active` })
+
+})
+
+describe('scheduler, harvest', async assert => {
+
+    contracts = await Promise.all([
+        eos.contract(scheduler),
+        eos.contract(settings)
+    ]).then(([scheduler, settings]) => ({
+        scheduler, settings
+    }))
+
+    console.log('scheduler reset')
+    await contracts.scheduler.reset({ authorization: `${scheduler}@active` })
+
+    console.log('settings reset')
+    await contracts.settings.reset({ authorization: `${settings}@active` })
+
+    const opTable = await getTableRows({
+        code: scheduler,
+        scope: scheduler,
+        table: 'operations',
+        json: true
+    })
+
+    for (const op of opTable.rows) {
+        await contracts.scheduler.removeop(op.id, { authorization: `${scheduler}@active` })
+        await sleep(200)
+    }
+
+    const operations = [
+        {
+            id: 'hrvst.trx',
+            operation: 'calctrxpts',
+            contract: harvest
+        },
+        {
+            id: 'hrvst.qevs',
+            operation: 'calcmqevs',
+            contract: harvest
         }
     ]
 


### PR DESCRIPTION
- Added new tables to store daily transactions and total points per day. Added a totals table
- Added QEV calculation
- Modified transaction points calculation for orgs and users
- Modified number of transactions validation for becoming a resident/citizen user or reputable/regenerative org
- Added tests

I also pushed a branch called migration/unified-qev-calculation, there I put a method called `migrateusers`, that action will copy the transactions for users and orgs and store them in the new tables using the new criteria to count transactions. The method doesn't clean the old transactions tables just in case.

## Deployment

- [x] ./scripts/seeds.js run accounts harvest history organization settings

- [x] Test accounts
- [x] Test harvest
- [x] Test history
- [x] Test organization

## Deploy Testnet
- [ ] Deploy 4 contracts to testnet
- [ ] ./scripts/seeds.js updatePermissions
- [ ] reset scheduler
- [ ] Run migration on testnet
- [ ] Ensure all values are as expected

## Deploy Mainnet
- [ ] Deploy 4 contracts
- [ ] ./scripts/seeds.js updatePermissions
- [ ] reset scheduler
- [ ] Run migration
- [ ] Ensure all values are as expected
