### PR TITLE
Bugfix/show actual limits

### DIFF
--- a/src/seeds.exchange.cpp
+++ b/src/seeds.exchange.cpp
@@ -19,7 +19,7 @@ void exchange::reset() {
   setflag(tlos_paused_flag, 1);
 
   // COMMENT in for testing, never check in commented in
-/**/
+/**
   // we never want to erase rounds or sold table or history except for unit testing
   
   sold.remove();

--- a/src/seeds.exchange.cpp
+++ b/src/seeds.exchange.cpp
@@ -6,8 +6,8 @@ void exchange::reset() {
 
   config.remove();
 
-  asset citizen_limit =  asset(uint64_t(2600000000), seeds_symbol);
-  asset resident_limit =  asset(uint64_t(2600000000), seeds_symbol);
+  asset citizen_limit =  asset(uint64_t(2500000000), seeds_symbol);
+  asset resident_limit =  asset(uint64_t(2500000000), seeds_symbol);
   asset visitor_limit =  asset(26000 * 10000, seeds_symbol);
 
   asset tlos_per_usd =  asset(0.03 * 10000, seeds_symbol);
@@ -19,7 +19,7 @@ void exchange::reset() {
   setflag(tlos_paused_flag, 1);
 
   // COMMENT in for testing, never check in commented in
-/**
+/**/
   // we never want to erase rounds or sold table or history except for unit testing
   
   sold.remove();
@@ -130,8 +130,10 @@ void exchange::purchase_usd(name buyer, asset usd_quantity, string paymentSymbol
   if (sitr != dailystats.end()) {
     seeds_purchased = sitr->seeds_purchased;
   }
+  
+  uint64_t price_volatility_leeway = seeds_limit.amount / 20; // 5% leeway
 
-  check(seeds_limit.amount >= seeds_purchased + seeds_amount, 
+  check( (seeds_limit.amount + price_volatility_leeway) >= seeds_purchased + seeds_amount, 
    "account: " + buyer.to_string() + 
    " symbol: " + paymentSymbol + 
    " tx_id: " + memo + 


### PR DESCRIPTION
Build 5% slippage tolerance into exchange, reset the initial values to be precise numbers

Before we just increased the limits from 25k to 26k and from 250k to 260k so that exchange rate changes would not trigger a failed transaction - example if a person was buying 5 Seeds more than their 25k allotment, we don't want to fail as this is very common due to the volatility of crypto. 

But the problem with setting the values higher is that the website doesnt know where to look up the official limits now. 

So this change restores the official limits, so everyone can look them up on chain, and allows for some price volatility in the contract. Anything up to 5% more is allowed. 