### PR TITLE
bugfix: don't check quorum for evaluate stage proposals

### DIFF
--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -74,6 +74,8 @@ CONTRACT proposals : public contract {
       
       ACTION decayvoices();
 
+      ACTION checkeval();
+
       ACTION decayvoice(uint64_t start, uint64_t chunksize);
 
       ACTION testquorum(uint64_t total_proposals);
@@ -151,6 +153,7 @@ CONTRACT proposals : public contract {
       void erase_voice (name user);
       void check_percentages(std::vector<uint64_t> pay_percentages);
       asset get_payout_amount(std::vector<uint64_t> pay_percentages, uint64_t age, asset total_amount, asset current_payout);
+      bool has_unity(uint64_t prop_majority, uint64_t favour, uint64_t against);
 
       uint64_t config_get(name key) {
         DEFINE_CONFIG_TABLE
@@ -280,7 +283,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
         EOSIO_DISPATCH_HELPER(proposals, (reset)(create)(createx)(update)(updatex)(addvoice)(changetrust)(favour)(against)
         (neutral)(erasepartpts)(checkstake)(onperiod)(decayvoice)(cancel)(updatevoices)(updatevoice)(decayvoices)
         (addactive)(removeactive)(updateactivs)(updateactive)(testvdecay)(initsz)(initactives)(testquorum)(initnumprop)
-        (migratevoice)(testsetvoice))
+        (migratevoice)(testsetvoice)(checkeval))
       }
   }
 }

--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -74,8 +74,6 @@ CONTRACT proposals : public contract {
       
       ACTION decayvoices();
 
-      ACTION checkeval();
-
       ACTION decayvoice(uint64_t start, uint64_t chunksize);
 
       ACTION testquorum(uint64_t total_proposals);
@@ -153,7 +151,6 @@ CONTRACT proposals : public contract {
       void erase_voice (name user);
       void check_percentages(std::vector<uint64_t> pay_percentages);
       asset get_payout_amount(std::vector<uint64_t> pay_percentages, uint64_t age, asset total_amount, asset current_payout);
-      bool has_unity(uint64_t prop_majority, uint64_t favour, uint64_t against);
 
       uint64_t config_get(name key) {
         DEFINE_CONFIG_TABLE
@@ -283,7 +280,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
         EOSIO_DISPATCH_HELPER(proposals, (reset)(create)(createx)(update)(updatex)(addvoice)(changetrust)(favour)(against)
         (neutral)(erasepartpts)(checkstake)(onperiod)(decayvoice)(cancel)(updatevoices)(updatevoice)(decayvoices)
         (addactive)(removeactive)(updateactivs)(updateactive)(testvdecay)(initsz)(initactives)(testquorum)(initnumprop)
-        (migratevoice)(testsetvoice)(checkeval))
+        (migratevoice)(testsetvoice))
       }
   }
 }

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -231,11 +231,9 @@ void proposals::onperiod() {
 
         bool valid_quorum = false;
 
-        if (pitr->status != status_evaluate) {
-          // in evaluate status, we only check unity. 
+        if (pitr->status == status_evaluate) { // in evaluate status, we only check unity. 
           valid_quorum = true;
-        } else {
-          // in open status, quorum is calculated
+        } else { // in open status, quorum is calculated
           valid_quorum = utils::is_valid_quorum(voters_number, quorum, total_eligible_voters);
         }
 
@@ -545,6 +543,69 @@ void proposals::migratevoice(uint64_t start) {
     tx.delay_sec = 1;
     tx.send(next_value, _self);
   }
+}
+
+bool proposals::has_unity(uint64_t prop_majority, uint64_t favour, uint64_t against) {
+  double majority = double(prop_majority) / 100.0;
+  bool passed = favour > 0 && double(favour) >= double(favour + against) * majority;
+  return passed;
+}
+
+// check and restore all proposals in eval mode
+void proposals::checkeval() {
+  require_auth(get_self());
+  uint64_t prop_majority = config_get(name("propmajority"));
+
+  cycle_table c = cycle.get_or_create(get_self(), cycle_table());
+
+  uint64_t last_cycle = c.propcycle - 1;
+
+  auto pitr = props.begin();
+  while (pitr != props.end()) {
+    if (
+      pitr->passed_cycle != 0 && 
+      pitr->passed_cycle + pitr->age < last_cycle &&
+      pitr->current_payout != pitr->quantity && 
+      has_unity(prop_majority, pitr->favour, pitr->against)
+    ) {
+
+      name prop_type = get_type(pitr->fund);
+      bool is_alliance_type = prop_type == alliance_type;
+
+      uint64_t age = pitr -> age + 1;
+
+      asset payout_amount = get_payout_amount(pitr->pay_percentages, age, pitr->quantity, pitr->current_payout);
+
+      print("\n === re-instating prop id "+std::to_string(pitr->id) + " --> "+ payout_amount.to_string());
+
+      if (is_alliance_type) {
+        send_to_escrow(pitr->fund, pitr->recipient, payout_amount, "proposal id: "+std::to_string(pitr->id));
+      } else {
+        withdraw(pitr->recipient, payout_amount, pitr->fund, "");// TODO limit by amount available
+      }
+
+      uint64_t num_cycles = pitr -> pay_percentages.size() - 1;
+
+      props.modify(pitr, _self, [&](auto & proposal){
+        proposal.age = age;
+        if (age == num_cycles) {
+          proposal.executed = true;
+          proposal.status = status_passed;
+          proposal.stage = stage_done;
+        } else {
+          proposal.executed = false;
+          proposal.status = status_evaluate;
+          proposal.stage = stage_active;
+        }
+        proposal.current_payout += payout_amount;
+      });
+      
+
+    }
+    
+    pitr++;
+  }
+
 }
 
 void proposals::update_cycle() {

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -225,10 +225,19 @@ void proposals::onperiod() {
         double majority = double(prop_majority) / 100.0;
         double fav = double(pitr->favour);
         bool passed = pitr->favour > 0 && fav >= double(pitr->favour + pitr->against) * majority;
-        bool valid_quorum = utils::is_valid_quorum(voters_number, quorum, total_eligible_voters);
         name prop_type = get_type(pitr->fund);
         bool is_alliance_type = prop_type == alliance_type;
         bool is_campaign_type = prop_type == campaign_type;
+
+        bool valid_quorum = false;
+
+        if (pitr->status != status_evaluate) {
+          // in evaluate status, we only check unity. 
+          valid_quorum = true;
+        } else {
+          // in open status, quorum is calculated
+          valid_quorum = utils::is_valid_quorum(voters_number, quorum, total_eligible_voters);
+        }
 
         if (passed && valid_quorum) {
 


### PR DESCRIPTION
the quorum is dynamic and always changing depending on the number of proposals, number of eligible voters, and their vote power. Therefore we only check quorum on the initial vote. Once a proposal has been voted in and is in eval stage, we only check unity, in case someone changed their mind. But we don't check quorum.

@IanMendozaJaimes  please check