### PR TITLE
Bioregion Contribution Score #161

### DIFF
--- a/include/seeds.harvest.hpp
+++ b/include/seeds.harvest.hpp
@@ -35,12 +35,14 @@ CONTRACT harvest : public contract {
         harveststat(receiver, receiver.value),
         monthlyqevs(receiver, receiver.value),
         mintrate(receiver, receiver.value),
+        biocstemp(receiver, receiver.value),
         config(contracts::settings, contracts::settings.value),
         users(contracts::accounts, contracts::accounts.value),
         rep(contracts::accounts, contracts::accounts.value),
         cbs(contracts::accounts, contracts::accounts.value),
         circulating(contracts::token, contracts::token.value),
-        bioregions(contracts::bioregion, contracts::bioregion.value)
+        bioregions(contracts::bioregion, contracts::bioregion.value),
+        members(contracts::bioregion, contracts::bioregion.value)
         {}
         
     ACTION reset();
@@ -73,6 +75,9 @@ CONTRACT harvest : public contract {
 
     ACTION rankcss(); // rank contribution score //
     ACTION rankcs(uint64_t start_val, uint64_t chunk, uint64_t chunksize);
+
+    ACTION rankbiocss();
+    ACTION rankbiocs(uint64_t start, uint64_t chunk, uint64_t chunksize);
 
     ACTION updatetxpt(name account);
     ACTION calctotal(uint64_t startval);
@@ -108,6 +113,7 @@ CONTRACT harvest : public contract {
     name sum_rank_users = "usr.rnk.sz"_n;
     name sum_rank_orgs = "org.rnk.sz"_n;
     name sum_rank_bios = "bio.rnk.sz"_n;
+    name cs_bio_size = "bio.cs.sz"_n;
 
     void init_balance(name account);
     void init_harvest_stat(name account);
@@ -121,6 +127,7 @@ CONTRACT harvest : public contract {
     void sub_planted(name account, asset quantity);
     void change_total(bool add, asset quantity);
     void calc_contribution_score(name account, name type);
+    void add_cs_to_bioregion(name account, uint32_t points);
 
     void size_change(name id, int delta);
     void size_set(name id, uint64_t newsize);
@@ -288,6 +295,14 @@ CONTRACT harvest : public contract {
       uint64_t primary_key()const { return id; }
     };
 
+    TABLE bioregion_cs_temporal_table {
+      name bioregion;
+      uint32_t points;
+
+      uint64_t primary_key()const { return bioregion.value; }
+      uint64_t by_cs_points()const { return uint64_t(points); }
+    };
+
     typedef eosio::multi_index<"trxpoints"_n, transaction_points_table,
       indexed_by<"bypoints"_n,
       const_mem_fun<transaction_points_table, uint64_t, &transaction_points_table::by_points>>
@@ -306,7 +321,10 @@ CONTRACT harvest : public contract {
     typedef singleton<"circulating"_n, circulating_supply_table> circulating_supply_tables;
     typedef eosio::multi_index<"circulating"_n, circulating_supply_table> dump_for_circulating;
 
-    // new tables ------------------------------
+    typedef eosio::multi_index<"biocstemp"_n, bioregion_cs_temporal_table,
+      indexed_by<"bycspoints"_n,
+      const_mem_fun<bioregion_cs_temporal_table, uint64_t, &bioregion_cs_temporal_table::by_cs_points>>
+    > bioregion_cs_temporal_tables;
 
     TABLE mint_rate_table {
       uint64_t id;
@@ -318,31 +336,19 @@ CONTRACT harvest : public contract {
     };
 
     typedef eosio::multi_index<"mintrate"_n, mint_rate_table> mint_rate_tables;
-    
-    // // From bioregions contract
-    // TABLE bioregion_table {
-    //   name id;
-    //   name founder;
-    //   name status; // "active" "inactive"
-    //   string description;
-    //   string locationjson; // json description of the area
-    //   float latitude;
-    //   float longitude;
-    //   uint64_t members_count;
-    //   time_point created_at = current_block_time().to_time_point();
 
-    //   uint64_t primary_key() const { return id.value; }
-    //   uint64_t by_status() const { return status.value; }
-    //   uint64_t by_count() const { return members_count; }
-    // };
+    TABLE members_table {
+      name bioregion;
+      name account;
+      time_point joined_date = current_block_time().to_time_point();
 
-    // typedef eosio::multi_index <"bioregions"_n, bioregion_table,
-    //   indexed_by<"bystatus"_n,const_mem_fun<bioregion_table, uint64_t, &bioregion_table::by_status>>,
-    //   indexed_by<"bycount"_n,const_mem_fun<bioregion_table, uint64_t, &bioregion_table::by_count>>
-    // > bioregion_tables;
+      uint64_t primary_key() const { return account.value; }
+      uint64_t by_bio() const { return bioregion.value; }
+    };
+    typedef eosio::multi_index <"members"_n, members_table,
+        indexed_by<"bybio"_n,const_mem_fun<members_table, uint64_t, &members_table::by_bio>>
+    > members_tables;
 
-
-    // -----------------------------------------
 
 
     // Contract Tables
@@ -353,6 +359,7 @@ CONTRACT harvest : public contract {
     size_tables sizes;
     monthly_qev_tables monthlyqevs;
     mint_rate_tables mintrate;
+    bioregion_cs_temporal_tables biocstemp;
 
     // DEPRECATED - remove
     typedef eosio::multi_index<"harvest"_n, harvest_table> harvest_tables;
@@ -367,6 +374,7 @@ CONTRACT harvest : public contract {
     total_tables total;
     circulating_supply_tables circulating;
     bioregion_tables bioregions;
+    members_tables members;
 
 };
 
@@ -378,7 +386,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
           EOSIO_DISPATCH_HELPER(harvest, 
           (payforcpu)(reset)
           (unplant)(claimrefund)(cancelrefund)(sow)
-          (ranktx)(calctrxpt)(calctrxpts)(rankplanted)(rankplanteds)(calccss)(calccs)(rankcss)(rankcs)(ranktxs)(rankorgtxs)(updatecs)
+          (ranktx)(calctrxpt)(calctrxpts)(rankplanted)(rankplanteds)(calccss)(calccs)(rankcss)(rankcs)(ranktxs)(rankorgtxs)(updatecs)(rankbiocss)(rankbiocs)
           (updatetxpt)(updtotal)(calctotal)
           (setorgtxpt)
           (testclaim)(testupdatecs)(testcalcmqev)(testcspoints)

--- a/include/seeds.harvest.hpp
+++ b/include/seeds.harvest.hpp
@@ -300,7 +300,7 @@ CONTRACT harvest : public contract {
       uint32_t points;
 
       uint64_t primary_key()const { return bioregion.value; }
-      uint64_t by_cs_points()const { return uint64_t(points); }
+      uint64_t by_cs_points() const { return (uint64_t(points) << 32) +  ( (bioregion.value <<32) >> 32) ; }
     };
 
     typedef eosio::multi_index<"trxpoints"_n, transaction_points_table,

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -599,6 +599,9 @@ var permissions = [{
 }, { 
   target: `${accounts.harvest.account}@active`,
   actor: `${accounts.organization.account}@active`
+}, {
+  target: `${accounts.harvest.account}@execute`,
+  action: 'rankbiocss'
 }]
 
 const isTestnet = chainId == networks.telosTestnet

--- a/src/seeds.harvest.cpp
+++ b/src/seeds.harvest.cpp
@@ -655,15 +655,21 @@ void harvest::add_cs_to_bioregion(name account, uint32_t points) {
 
   auto csitr = biocstemp.find(bitr -> bioregion.value);
   if (csitr == biocstemp.end()) {
-    biocstemp.emplace(_self, [&](auto & item){
-      item.bioregion = bitr -> bioregion;
-      item.points = points;
-    });
-    size_change(cs_bio_size, 1);
+    if (points > 0) {
+      biocstemp.emplace(_self, [&](auto & item){
+        item.bioregion = bitr -> bioregion;
+        item.points = points;
+      });
+      size_change(cs_bio_size, 1);
+    }
   } else {
-    biocstemp.modify(csitr, _self, [&](auto & item){
-      item.points += points;
-    });
+    if (points > 0) {
+      biocstemp.modify(csitr, _self, [&](auto & item){
+        item.points += points;
+      });
+    } else {
+      biocstemp.erase(csitr);
+    }
   }
 }
 

--- a/src/seeds.scheduler.cpp
+++ b/src/seeds.scheduler.cpp
@@ -80,6 +80,7 @@ void scheduler::reset_aux(bool destructive) {
         name("hrvst.calccs"), // after the above 4
         name("hrvst.rankcs"), 
         name("hrvst.calctx"), // 24h
+        name("hrvst.biocs"),
 
         name("org.clndaus"),
         name("org.rankregn"),
@@ -109,6 +110,7 @@ void scheduler::reset_aux(bool destructive) {
         name("calccss"),
         name("rankcss"),
         name("calctrxpts"),
+        name("rankbiocss"),
 
         name("cleandaus"),
         name("rankregens"),
@@ -135,6 +137,7 @@ void scheduler::reset_aux(bool destructive) {
         contracts::harvest,
         contracts::harvest,
 
+        contracts::harvest,
         contracts::harvest,
         contracts::harvest,
         contracts::harvest,
@@ -167,6 +170,7 @@ void scheduler::reset_aux(bool destructive) {
         utils::seconds_per_hour,
         utils::seconds_per_hour,
         utils::seconds_per_day,
+        utils::seconds_per_day,
 
         utils::seconds_per_day / 2,
         utils::seconds_per_day,
@@ -198,6 +202,7 @@ void scheduler::reset_aux(bool destructive) {
         now + 300 - utils::seconds_per_hour, // kicks off 5 minutes later
         now + 600 - utils::seconds_per_hour, // kicks off 10 minutes later
         now,
+        now + 600 - utils::seconds_per_hour, // kicks off 10 minutes later
 
         now,
         now,

--- a/test/harvest.test.js
+++ b/test/harvest.test.js
@@ -1077,7 +1077,6 @@ describe('Mint Rate and Harvest', async assert => {
 
 })
 
-
 describe('bioregions contribution score', async assert => {
 
   if (!isLocal()) {
@@ -1193,9 +1192,8 @@ describe('bioregions contribution score', async assert => {
     should: 'have the correct ranks',
     actual: cspointsBios.rows,
     expected: [
-      { account: 'bio1.bdc', contribution_points: 0, rank: 0 },
-      { account: 'bio2.bdc', contribution_points: 77, rank: 33 },
-      { account: 'bio3.bdc', contribution_points: 117, rank: 66 }
+      { account: 'bio2.bdc', contribution_points: 77, rank: 0 },
+      { account: 'bio3.bdc', contribution_points: 117, rank: 50 }
     ]
   })
 

--- a/test/harvest.test.js
+++ b/test/harvest.test.js
@@ -3,7 +3,7 @@ const { eos, encodeName, getBalance, getBalanceFloat, names, getTableRows, isLoc
 const { equals } = require("ramda")
 const { parse } = require("commander")
 
-const { accounts, harvest, token, firstuser, seconduser, thirduser, bank, settings, history, fourthuser, proposals, organization, bioregion, globaldho } = names
+const { accounts, harvest, token, firstuser, seconduser, thirduser, bank, settings, history, fourthuser, proposals, organization, bioregion, globaldho, fifthuser } = names
 
 function getBeginningOfDayInSeconds () {
   const now = new Date()
@@ -1073,6 +1073,137 @@ describe('Mint Rate and Harvest', async assert => {
       mint_rate: expectedMintRate,
       volume_growth: parseInt(expectedVolumeGrowth * 10000)
     }]
+  })
+
+})
+
+
+describe('bioregions contribution score', async assert => {
+
+  if (!isLocal()) {
+    console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
+    return
+  }
+
+  let eosDevKey = "EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV"
+
+  const contracts = await Promise.all([
+    eos.contract(token),
+    eos.contract(accounts),
+    eos.contract(harvest),
+    eos.contract(settings),
+    eos.contract(history),
+    eos.contract(organization),
+    eos.contract(bioregion)
+  ]).then(([token, accounts, harvest, settings, history, organization, bioregion]) => ({
+    token, accounts, harvest, settings, history, organization, bioregion
+  }))
+
+  const day = getBeginningOfDayInSeconds()
+  console.log('reset history')
+  await contracts.history.reset(history, { authorization: `${history}@active` })
+  await contracts.history.deldailytrx(day, { authorization: `${history}@active` })
+
+  console.log('harvest reset')
+  await contracts.harvest.reset({ authorization: `${harvest}@active` })
+
+  console.log('accounts reset')
+  await contracts.accounts.reset({ authorization: `${accounts}@active` })
+
+  console.log('reset token stats')
+  await contracts.token.resetweekly({ authorization: `${token}@active` })
+
+  console.log('reset bios')
+  await contracts.bioregion.reset({ authorization: `${bioregion}@active` })
+
+  console.log('reset settings')
+  await contracts.settings.reset({ authorization: `${settings}@active` })
+
+  console.log('join users')
+  const users = [firstuser, seconduser, thirduser, fourthuser, fifthuser]
+  for (let i = 0; i < users.length; i++) {
+    const user = users[i]
+    await contracts.accounts.adduser(user, i + ' user', 'individual', { authorization: `${accounts}@active` })
+    await contracts.accounts.testsetrs(user, 49, { authorization: `${accounts}@active` })
+    await contracts.history.reset(user, { authorization: `${history}@active` })
+  }
+
+  console.log('add bioregions')
+  const keypair = await createKeypair();
+  await contracts.settings.configure("bio.fee", 10000 * 1, { authorization: `${settings}@active` })
+  const bios = ['bio1.bdc', 'bio2.bdc', 'bio3.bdc']
+  for (let index = 0; index < bios.length; index++) {
+    const bio = bios[index]
+    await contracts.token.transfer(users[index], bioregion, "1.0000 SEEDS", "Initial supply", { authorization: `${users[index]}@active` })
+    await contracts.bioregion.create(
+      users[index], 
+      bio, 
+      'test bio region',
+      '{lat:0.0111,lon:1.3232}', 
+      1.1, 
+      1.23, 
+      keypair.public, 
+      { authorization: `${users[index]}@active` })
+  }
+
+  await contracts.bioregion.join('bio2.bdc', fourthuser,{ authorization: `${fourthuser}@active` })
+  await contracts.bioregion.join('bio3.bdc', fifthuser,{ authorization: `${fifthuser}@active` })
+
+  console.log('transfer')
+  for (let i = 0; i < users.length; i++) {
+    const user = users[i]
+    if (i === 0) {
+      await contracts.token.transfer(user, seconduser, '1000.0000 SEEDS', 'supply', { authorization: `${user}@active` })
+    } else {
+      await contracts.token.transfer(user, firstuser, '1000.0000 SEEDS', 'supply', { authorization: `${user}@active` })
+    }
+    await sleep(2000)
+  }
+
+  console.log('rank transactions')
+  await contracts.harvest.calctrxpts({ authorization: `${harvest}@active` })
+  await contracts.harvest.ranktxs({ authorization: `${harvest}@active` })
+
+  console.log('calc contribution score')
+  await contracts.harvest.calccss({ authorization: `${harvest}@active` })
+
+  console.log('change max limit transactions')
+  await contracts.settings.configure('batchsize', 1, { authorization: `${settings}@active` })
+
+  console.log('calc contribution score')
+  await contracts.harvest.rankbiocss({ authorization: `${harvest}@active` })
+  await sleep(5000)
+
+  const cspointsBios = await getTableRows({
+    code: harvest,
+    scope: 'bio',
+    table: 'cspoints',
+    json: true
+  })
+
+  const cspointsBiosTemp = await getTableRows({
+    code: harvest,
+    scope: harvest,
+    table: 'biocstemp',
+    json: true
+  })
+
+  assert({
+    given: 'cs for bioregions',
+    should: 'have the correct ranks',
+    actual: cspointsBios.rows,
+    expected: [
+      { account: 'bio1.bdc', contribution_points: 0, rank: 0 },
+      { account: 'bio2.bdc', contribution_points: 77, rank: 33 },
+      { account: 'bio3.bdc', contribution_points: 117, rank: 66 }
+    ]
+  })
+
+  assert({
+    given: 'cs for bioregions, the table biocstemp',
+    should: 'not have entries',
+    actual: cspointsBiosTemp.rows,
+    expected: []
   })
 
 })


### PR DESCRIPTION
- Added cs for bioregions
- Added tests
- Added `rankbiocss` to scheduler

I added the table `bioregion_cs_temporal_table` as an auxiliary table for storing the sum of the users' contribution points, and it is cleaned every time the bioregions are ranked with the function `rankbiocss`. 