### PR TITLE
Bugfix/actives refactoring

### DIFF
--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -66,12 +66,8 @@ CONTRACT proposals : public contract {
 
       ACTION addactive(name account);
 
-      ACTION removeactive(name account);
+      ACTION calcvotepow();
 
-      ACTION updateactivs();
-
-      ACTION updateactive(uint64_t start);
-      
       ACTION decayvoices();
 
       ACTION decayvoice(uint64_t start, uint64_t chunksize);
@@ -84,8 +80,6 @@ CONTRACT proposals : public contract {
 
       ACTION testsetvoice(name user, uint64_t amount);
       ACTION initsz();
-
-      ACTION initactives();
 
       ACTION initnumprop();
 
@@ -163,6 +157,8 @@ CONTRACT proposals : public contract {
       void check_voice_scope(name scope);
       bool is_trust_delegated(name account, name scope);
       void send_mimic_delegatee_vote(name delegatee, name scope, uint64_t proposal_id, double percentage_used, name option);
+      uint64_t active_cutoff_date();
+      bool is_active(name account, uint64_t cutoff_date);
 
       uint64_t config_get(name key) {
         DEFINE_CONFIG_TABLE
@@ -250,7 +246,6 @@ CONTRACT proposals : public contract {
       TABLE active_table {
         name account;
         uint64_t timestamp;
-        bool active;
 
         uint64_t primary_key()const { return account.value; }
       };
@@ -308,8 +303,10 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
       switch (action) {
         EOSIO_DISPATCH_HELPER(proposals, (reset)(create)(createx)(update)(updatex)(addvoice)(changetrust)(favour)(against)
         (neutral)(erasepartpts)(checkstake)(onperiod)(decayvoice)(cancel)(updatevoices)(updatevoice)(decayvoices)
-        (addactive)(removeactive)(updateactivs)(updateactive)(testvdecay)(initsz)(initactives)(testquorum)(initnumprop)
-        (migratevoice)(testsetvoice)(delegate)(mimicvote)(undelegate))
+        (addactive)(testvdecay)(initsz)(testquorum)(initnumprop)
+        (migratevoice)(testsetvoice)(delegate)(mimicvote)(undelegate)
+        (calcvotepow)
+        )
       }
   }
 }

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -47,6 +47,7 @@ namespace utils {
   }
 
   inline bool is_valid_quorum(uint64_t voters_number, uint64_t quorum, uint64_t total_number) {
+    if (total_number == 0) { return false; }
     uint64_t voted_percentage = voters_number * 100 / total_number;
     return voted_percentage >= quorum;
   }

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -224,6 +224,7 @@ void proposals::calcvotepow() {
       }
 
       vote_power += points;
+      
       print("| active: " + 
         vitr->account.to_string() +
         " pt: " + std::to_string(points) + " " 
@@ -236,8 +237,8 @@ void proposals::calcvotepow() {
     vitr++;
   }
 
-  size_set(cycle_vote_power_size, vote_power);
-  size_set("voice.sz"_n, voice_size);
+  //size_set(cycle_vote_power_size, vote_power);
+  //size_set("voice.sz"_n, voice_size);
 
 }
 
@@ -1047,9 +1048,16 @@ void proposals::erase_voice (name user) {
   auto vaitr = voice_alliance.find(user.value);
 
   voice.erase(vitr);
-  size_change("voice.sz"_n, -1);
-
   voice_alliance.erase(vaitr);
+
+  size_change("voice.sz"_n, -1);
+  
+  auto aitr = actives.find(user.value);
+  if (aitr != actives.end()) {
+    actives.erase(aitr);
+    size_change(user_active_size, -1);
+  }
+
 }
 
 void proposals::changetrust(name user, bool trust) {

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -263,6 +263,8 @@ void proposals::onperiod() {
 
     uint64_t number_active_proposals = get_size(prop_active_size);
     uint64_t total_eligible_voters = get_size(user_active_size);
+    check(total_eligible_voters > 0, "no eligible voters - likely an error; can't run proposals.");
+    
     uint64_t quorum =  get_quorum(number_active_proposals);
 
     cycle_table c = cycle.get_or_create(get_self(), cycle_table());

--- a/test/proposals.test.js
+++ b/test/proposals.test.js
@@ -1056,8 +1056,6 @@ describe('Proposals Quorum', async assert => {
   await contracts.token.transfer(firstuser, proposals, '2.0000 SEEDS', '2', { authorization: `${firstuser}@active` })
   console.log('deposit stake 3')
   await contracts.token.transfer(seconduser, proposals, '2.0000 SEEDS', '3', { authorization: `${seconduser}@active` })
-  console.log('move proposals to active')
-  await contracts.proposals.onperiod({ authorization: `${proposals}@active` })
 
   let users = [firstuser, seconduser, thirduser, fourthuser, fifthuser, sixthuser]
   for (i = 0; i<users.length; i++ ) {
@@ -1066,6 +1064,9 @@ describe('Proposals Quorum', async assert => {
     await contracts.accounts.testcitizen(user, { authorization: `${accounts}@active` })
     await contracts.proposals.addvoice(user, 44, { authorization: `${proposals}@active` })
   }
+
+  console.log('move proposals to active')
+  await contracts.proposals.onperiod({ authorization: `${proposals}@active` })
 
   console.log('vote on first proposal')
   await contracts.proposals.favour(seconduser, 1, 10, { authorization: `${seconduser}@active` })
@@ -1244,6 +1245,7 @@ describe('Stake limits', async assert => {
   await contracts.accounts.adduser(seconduser, 'seconduser', 'individual', { authorization: `${accounts}@active` })
   await contracts.accounts.adduser(thirduser, 'thirduser', 'individual', { authorization: `${accounts}@active` })
   await contracts.accounts.adduser(fourthuser, 'fourthuser', 'individual', { authorization: `${accounts}@active` })
+  await contracts.accounts.testcitizen(firstuser, { authorization: `${accounts}@active` })
 
   console.log('create proposal '+campaignbank)
   await contracts.proposals.createx(firstuser, firstuser, '1000.0000 SEEDS', '1000 seeds please', 'summary', 'description', 'image', 'url', campaignbank, [ 10, 30, 30, 30 ], { authorization: `${firstuser}@active` })

--- a/test/proposals.test.js
+++ b/test/proposals.test.js
@@ -172,6 +172,8 @@ describe('Proposals', async assert => {
   })
   let voice = voiceBefore.rows[0].balance
 
+  console.log("voice "+JSON.stringify(voice, null, 2))
+
   console.log('favour first proposal')
   await contracts.proposals.favour(seconduser, 1, 8, { authorization: `${seconduser}@active` })
   await contracts.proposals.against(firstuser, 1, 2, { authorization: `${firstuser}@active` })
@@ -813,9 +815,6 @@ describe('Participants', async assert => {
   await contracts.accounts.testcitizen(firstuser, { authorization: `${accounts}@active` })
   await contracts.accounts.testcitizen(seconduser, { authorization: `${accounts}@active` })
   await contracts.accounts.testcitizen(thirduser, { authorization: `${accounts}@active` })
-  await contracts.proposals.addvoice(firstuser, 44, { authorization: `${proposals}@active` })
-  await contracts.proposals.addvoice(seconduser, 44, { authorization: `${proposals}@active` })
-  await contracts.proposals.addvoice(thirduser, 44, { authorization: `${proposals}@active` })
 
   console.log('move proposals to active')
   await contracts.proposals.onperiod({ authorization: `${proposals}@active` })
@@ -835,7 +834,11 @@ describe('Participants', async assert => {
     json: true,
   })
 
-  console.log('favour first proposal')
+  console.log('favour first proposal x')
+  await contracts.proposals.addvoice(firstuser, 20, { authorization: `${proposals}@active` })
+  await contracts.proposals.addvoice(seconduser, 40, { authorization: `${proposals}@active` })
+  await contracts.proposals.addvoice(thirduser, 60, { authorization: `${proposals}@active` })
+
   await contracts.proposals.favour(seconduser, 1, 8, { authorization: `${seconduser}@active` })
   await contracts.proposals.against(firstuser, 1, 8, { authorization: `${firstuser}@active` })
   await contracts.proposals.neutral(firstuser, 2, { authorization: `${firstuser}@active` })
@@ -1072,6 +1075,14 @@ describe('Proposals Quorum', async assert => {
   await contracts.proposals.favour(firstuser, 2, 3, { authorization: `${firstuser}@active` })
 
   console.log('execute proposals')
+  const sizes = await getTableRows({
+    code: proposals,
+    scope: proposals,
+    table: 'sizes',
+    json: true
+  })
+  console.log("sizes "+JSON.stringify(sizes, null, 2))
+
   await contracts.proposals.onperiod({ authorization: `${proposals}@active` })
 
   const props = await getTableRows({
@@ -1402,7 +1413,7 @@ describe('Stake limits', async assert => {
 
 })
 
-describe.only('Active count and vote power', async assert => {
+describe('Active count and vote power', async assert => {
 
   if (!isLocal()) {
     console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
@@ -1428,29 +1439,6 @@ describe.only('Active count and vote power', async assert => {
 
   console.log('escrow reset')
   await contracts.escrow.reset({ authorization: `${escrow}@active` })
-
-  const testActives = async expectedValues => {
-    const actives = await eos.getTableRows({
-      code: proposals,
-      scope: proposals,
-      table: 'actives',
-      json: true,
-    })
-
-    console.log("ACTIVES: "+JSON.stringify(actives, null, 2))
-
-    assert({
-      given: 'test active',
-      should: 'match expected',
-      expected: expectedValues,
-      actual: actives.rows.map(r => {
-        return {
-          account: r.account,
-          active: r.active
-        }
-      })
-    })
-  }
 
   const testActiveSize = async (active, voteP) => {
     const sizes = await eos.getTableRows({
@@ -1501,14 +1489,9 @@ describe.only('Active count and vote power', async assert => {
 
   const now = parseInt(Date.now() / 1000)
 
-  const actives = [
-    { account: 'seedsuseraaa', active: 1 },
-    { account: 'seedsuserbbb', active: 1 },
-    { account: 'seedsuserccc', active: 1 }
-  ]  
-
   console.log('testActives - inital actives')
-  await testActives(actives)
+  await contracts.proposals.initsz( { authorization: `${proposals}@active` })
+
   await testActiveSize(3, 0)
 
   await sleep(1000)
@@ -1529,40 +1512,49 @@ describe.only('Active count and vote power', async assert => {
   console.log('onperiod 1')
   await contracts.proposals.onperiod({ authorization: `${proposals}@active` })
 
-  await testActives(actives)
-
   await testActiveSize(3, votePower3 + votePower2 + votePower1)
 
   console.log('sleep 2 cycle lengths + 1/2 cycle length')
-  await sleep(5000)
+  await sleep(4500)
 
   console.log('onperiod 2')
   await contracts.proposals.onperiod({ authorization: `${proposals}@active` })
 
-  await sleep(1000)
+  await sleep(500)
+
+
+  const sizes = await eos.getTableRows({
+    code: proposals,
+    scope: proposals,
+    table: 'sizes',
+    json: true,
+  })
+  const actives = await eos.getTableRows({
+    code: proposals,
+    scope: proposals,
+    table: 'actives',
+    json: true,
+  })
+
+  console.log('sizes: '+JSON.stringify(sizes, null, 2))
+
+  console.log('actives '+JSON.stringify(actives, null, 2))
 
   console.log('only 1 remoains active')
-  actives[0].active = 0
-  actives[2].active = 0
-  await testActives(actives)
   await testActiveSize(1, votePower2)
   
   console.log('vote on prop to become active again')
   await createprop()
   await contracts.proposals.favour(firstuser, 2, 5, { authorization: `${firstuser}@active` })
   await contracts.proposals.favour(seconduser, 2, 1, { authorization: `${seconduser}@active` })
+  await contracts.proposals.initsz( { authorization: `${proposals}@active` })
 
-  actives[0].active = 1
-  actives[2].active = 0
-
-  await testActives(actives)
   await testActiveSize(2, 0) // it's 0 here because cycle ran before the votes and everyone was out of active
 
   console.log("run props")
   await contracts.proposals.onperiod({ authorization: `${proposals}@active` })
   await sleep(2000)
 
-  await testActives(actives)
   await testActiveSize(2, votePower2 + votePower1)
 
 })


### PR DESCRIPTION
* Refactor actives list for the fact we don't need the "active" flag since the time stamp contains the same information

This is possible now because users can't jump in and out of being citizens - no more demoting citizens or coming back.

So we really only need the information as to when someone voted last to determined if we should consider them active.