### PR TITLE
Bug fix in vote delegation

### DIFF
--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -54,6 +54,8 @@ CONTRACT proposals : public contract {
 
       ACTION neutral(name user, uint64_t id);
 
+      ACTION voteonbehalf(name voter, uint64_t id, uint64_t amount, name option);
+
       ACTION erasepartpts(uint64_t active_proposals);
 
       ACTION onperiod();
@@ -159,6 +161,7 @@ CONTRACT proposals : public contract {
       void send_mimic_delegatee_vote(name delegatee, name scope, uint64_t proposal_id, double percentage_used, name option);
       uint64_t active_cutoff_date();
       bool is_active(name account, uint64_t cutoff_date);
+      void send_vote_on_behalf(name voter, uint64_t id, uint64_t amount, name option);
 
       uint64_t config_get(name key) {
         DEFINE_CONFIG_TABLE
@@ -304,7 +307,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
         EOSIO_DISPATCH_HELPER(proposals, (reset)(create)(createx)(update)(updatex)(addvoice)(changetrust)(favour)(against)
         (neutral)(erasepartpts)(checkstake)(onperiod)(decayvoice)(cancel)(updatevoices)(updatevoice)(decayvoices)
         (addactive)(testvdecay)(initsz)(testquorum)(initnumprop)
-        (migratevoice)(testsetvoice)(delegate)(mimicvote)(undelegate)
+        (migratevoice)(testsetvoice)(delegate)(mimicvote)(undelegate)(voteonbehalf)
         (calcvotepow)
         )
       }

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -929,6 +929,15 @@ void proposals::neutral(name voter, uint64_t id) {
   vote_aux(voter, id, (uint64_t)0, abstain, true, false);
 }
 
+void proposals::voteonbehalf(name voter, uint64_t id, uint64_t amount, name option) {
+  require_auth(get_self());
+  bool is_new = true;
+  if (option == distrust) {
+    is_new = !(revert_vote(voter, id));
+  }
+  vote_aux(voter, id, amount, option, is_new, true);
+}
+
 void proposals::addvoice(name user, uint64_t amount) {
   require_auth(_self);
   voice_change(user, amount, false, ""_n);
@@ -1340,6 +1349,19 @@ ACTION proposals::delegate (name delegator, name delegatee, name scope) {
 
 }
 
+void proposals::send_vote_on_behalf (name voter, uint64_t id, uint64_t amount, name option) {
+  action vote_on_behalf_action(
+    permission_level{get_self(), "active"_n},
+    get_self(),
+    "voteonbehalf"_n,
+    std::make_tuple(voter, id, amount, option)
+  );
+  transaction tx;
+  tx.actions.emplace_back(vote_on_behalf_action);
+  // tx.delay_sec = 1;
+  tx.send(voter.value, _self);
+}
+
 void proposals::send_mimic_delegatee_vote (name delegatee, name scope, uint64_t proposal_id, double percentage_used, name option) {
 
   uint64_t batch_size = config_get("batchsize"_n);
@@ -1387,12 +1409,11 @@ ACTION proposals::mimicvote (name delegatee, name delegator, name scope, uint64_
     auto vitr = voices.find(voter.value);
 
     if (option == trust) {
-      vote_aux(voter, proposal_id, vitr -> balance * percentage_used, trust, true, true);
+      send_vote_on_behalf(voter, proposal_id, vitr -> balance * percentage_used, trust);
     } else if (option == distrust) {
-      bool vote_reverted = revert_vote(voter, proposal_id);
-      vote_aux(voter, proposal_id, vitr -> balance * percentage_used, distrust, !vote_reverted, true);
+      send_vote_on_behalf(voter, proposal_id, vitr -> balance * percentage_used, distrust);
     } else if (option == abstain) {
-      vote_aux(voter, proposal_id, uint64_t(0), abstain, true, true);
+      send_vote_on_behalf(voter, proposal_id, uint64_t(0), abstain);
     }
 
     ditr++;

--- a/test/proposals.test.js
+++ b/test/proposals.test.js
@@ -1786,8 +1786,8 @@ describe('delegate trust', async assert => {
   await contracts.settings.configure('batchsize', 1, { authorization: `${settings}@active` })
 
   console.log('join users')
-  const users = [firstuser, seconduser, thirduser, fourthuser]
-  const voices = [20, 10, 50, 35]
+  const users = [firstuser, seconduser, thirduser, fourthuser, fifthuser]
+  const voices = [20, 10, 50, 35, 22]
   for (let i = 0; i < users.length; i++) {
     await contracts.accounts.adduser(users[i], `user ${i}`, 'individual', { authorization: `${accounts}@active` })
     await contracts.accounts.testcitizen(users[i], { authorization: `${accounts}@active` })
@@ -1886,6 +1886,9 @@ describe('delegate trust', async assert => {
     await contracts.proposals.testsetvoice(users[i], voices[i], { authorization: `${proposals}@active` })
   }
 
+  console.log('add another delegation')
+  await contracts.proposals.delegate(fifthuser, firstuser, scopeCampaigns, { authorization: `${fifthuser}@active` }) 
+
   console.log('cancel trust delegation')
   await contracts.proposals.undelegate(fourthuser, scopeCampaigns, { authorization: `${fourthuser}@active` })
   
@@ -1898,6 +1901,7 @@ describe('delegate trust', async assert => {
   console.log('cancel trust delegation')
   await contracts.proposals.undelegate(seconduser, scopeCampaigns, { authorization: `${firstuser}@active` })
   await contracts.proposals.undelegate(thirduser, scopeCampaigns, { authorization: `${firstuser}@active` })
+  await contracts.proposals.undelegate(fifthuser, scopeCampaigns, { authorization: `${fifthuser}@active` })
 
   const delCampaigns = await eos.getTableRows({
     code: proposals,
@@ -1943,7 +1947,7 @@ describe('delegate trust', async assert => {
     given: 'user delegated its voice',
     should: 'give a user a percentage of the earned reputation',
     actual: reps,
-    expected: [2, 1, 1, 1]
+    expected: [2, 1, 1, 1, 0]
   })
 
   assert({
@@ -1955,13 +1959,15 @@ describe('delegate trust', async assert => {
         { account: firstuser, balance: 15 },
         { account: seconduser, balance: 8 },
         { account: thirduser, balance: 38 },
-        { account: fourthuser, balance: 27 }
+        { account: fourthuser, balance: 27 },
+        { account: fifthuser, balance: 22 }
       ],
       alliances: [
         { account: firstuser, balance: 20 },
         { account: seconduser, balance: 0 },
         { account: thirduser, balance: 0 },
-        { account: fourthuser, balance: 0 }
+        { account: fourthuser, balance: 0 },
+        { account: fifthuser, balance: 22 }
       ]
     }
   })
@@ -1975,13 +1981,15 @@ describe('delegate trust', async assert => {
         { account: firstuser, balance: 10 },
         { account: seconduser, balance: 5 },
         { account: thirduser, balance: 25 },
-        { account: fourthuser, balance: 35 }
+        { account: fourthuser, balance: 35 },
+        { account: fifthuser, balance: 22 }
       ],
       alliances: [
         { account: firstuser, balance: 20 },
         { account: seconduser, balance: 10 },
         { account: thirduser, balance: 50 },
-        { account: fourthuser, balance: 35 }
+        { account: fourthuser, balance: 35 },
+        { account: fifthuser, balance: 22 }
       ]
     }
   })


### PR DESCRIPTION
The way the action `mimicvote` was calling the function `vote_aux` was in the same transaction so if some delegator for some reason can not vote, then the whole action will fail. 

One example of that could be when the user A voted trust for a proposal that is now in evaluation phase, then user B delegates its voice to user A, and then user A votes distrust. This will cause a fail because B can't vote for the proposal.
 
That's why I added the action `voteonbehalf`, so it could be called in a deferred transaction inside `mimicvote`, in that way if a particular vote fails the rest of the mimicked votes don't.