### PR TITLE
Gratitude token contract

### DIFF
--- a/include/contracts.hpp
+++ b/include/contracts.hpp
@@ -23,6 +23,7 @@ namespace contracts {
   name exchange = "tlosto.seeds"_n;
   name escrow = "escrow.seeds"_n;
   name bioregion = "bio.seeds"_n;
+  name gratitude = "gratz.seeds"_n;
 }
 namespace bankaccts {
   name milestone = "milest.seeds"_n;

--- a/include/seeds.gratitude.hpp
+++ b/include/seeds.gratitude.hpp
@@ -1,0 +1,107 @@
+#include <eosio/eosio.hpp>
+#include <eosio/asset.hpp>
+#include <eosio/transaction.hpp>
+#include <eosio/singleton.hpp>
+#include <seeds.token.hpp>
+#include <contracts.hpp>
+#include <utils.hpp>
+#include <tables/user_table.hpp>
+#include <tables/config_table.hpp>
+#include <tables/size_table.hpp>
+
+using namespace eosio;
+using namespace utils;
+using std::string;
+
+CONTRACT gratitude : public contract {
+
+  public:
+
+    using contract::contract;
+    gratitude(name receiver, name code, datastream<const char*> ds)
+      : contract(receiver, code, ds),
+        balances(receiver, receiver.value),
+        stats(receiver, receiver.value),
+        sizes(receiver, receiver.value),
+        users(contracts::accounts, contracts::accounts.value),
+        config(contracts::settings, contracts::settings.value)
+        {}
+
+    ACTION reset();
+
+    // Give gratitude to another user
+    ACTION give(name from, name to, asset quantity, string memo);
+
+    // Generates a new gratitude round, regenerating gratitude and splitting stored SEEDS
+    ACTION newround();
+
+  private:
+
+    void check_user(name account);
+    void init_balances(name account);
+    void add_gratitude(name account, asset quantity);
+    void sub_gratitude(name account, asset quantity);
+    uint64_t get_current_volume();
+    void increase_volume(uint64_t newvolume);
+    void _transfer(name beneficiary, asset quantity, string memo);
+    uint64_t config_get(name key);
+    void size_change(name id, int delta);
+    void size_set(name id, uint64_t newsize);
+    uint64_t get_size(name id);
+
+    symbol gratitude_symbol = symbol("GRATZ", 4);
+    inline void check_asset(asset quantity) {
+      check(quantity.is_valid(), "invalid asset");
+      check(quantity.symbol == gratitude_symbol, "invalid asset");
+    }
+
+    DEFINE_USER_TABLE
+
+    DEFINE_USER_TABLE_MULTI_INDEX
+
+    DEFINE_CONFIG_TABLE
+
+    DEFINE_CONFIG_TABLE_MULTI_INDEX
+
+    DEFINE_SIZE_TABLE
+
+    DEFINE_SIZE_TABLE_MULTI_INDEX
+
+    TABLE balance_table {
+      name account;
+      asset remaining; // Can only give the remaining gratitude
+      asset received; // Stores the received gratitude
+
+      uint64_t primary_key() const { return account.value; }
+      uint64_t by_received() const { return received.amount; }
+    };
+
+    TABLE stats_table {
+      uint64_t round_id;
+      uint64_t num_transfers;
+      asset volume;
+
+      uint64_t primary_key() const { return round_id; }
+    };
+
+    typedef eosio::multi_index<"balances"_n, balance_table,
+        indexed_by<"byreceived"_n,
+        const_mem_fun<balance_table, uint64_t, &balance_table::by_received>>
+    > balance_tables;
+
+    typedef eosio::multi_index<"stats"_n, stats_table> stats_tables;
+
+    balance_tables balances;
+    stats_tables stats;
+
+    // External tables
+    user_tables users;
+    config_tables config;
+    size_tables sizes;
+
+    const name gratzgen = "gratz.gen"_n; // Gratitude generated per cycle setting
+};
+
+EOSIO_DISPATCH(gratitude, 
+  (reset)(give)(newround)
+);

--- a/include/seeds.gratitude.hpp
+++ b/include/seeds.gratitude.hpp
@@ -42,7 +42,7 @@ CONTRACT gratitude : public contract {
     void add_gratitude(name account, asset quantity);
     void sub_gratitude(name account, asset quantity);
     uint64_t get_current_volume();
-    void increase_volume(uint64_t newvolume);
+    void update_stats(name from, name to, asset quantity);
     void _transfer(name beneficiary, asset quantity, string memo);
     uint64_t config_get(name key);
     void size_change(name id, int delta);

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -169,6 +169,7 @@ const accountsMetadata = (network) => {
       bioregion: contract('bio.seeds', 'bioregion'),
       msig: contract('msig.seeds', 'msig'),
       guardians: contract('guard.seeds', 'guardians'),
+      gratitude: contract('gratz.seeds', 'gratitude'),
     }
   } else if (network == networks.telosMainnet) {
     return {
@@ -606,6 +607,9 @@ var permissions = [{
 }, {
   target: `${accounts.harvest.account}@execute`,
   action: 'rankbiocss'
+}, {
+  target: `${accounts.gratitude.account}@active`,
+  actor: `${accounts.gratitude.account}@eosio.code`
 }]
 
 const isTestnet = chainId == networks.telosTestnet

--- a/src/seeds.gratitude.cpp
+++ b/src/seeds.gratitude.cpp
@@ -1,0 +1,190 @@
+#include <seeds.gratitude.hpp>
+
+
+ACTION gratitude::reset () {
+  require_auth(get_self());
+
+  auto bitr = balances.begin();
+  while (bitr != balances.end()) {
+    bitr = balances.erase(bitr);
+  }
+
+  auto sitr = sizes.begin();
+  while (sitr != sizes.end()) {
+    sitr = sizes.erase(sitr);
+  }
+
+  auto stitr = stats.begin();
+  while (stitr != stats.end()) {
+    stitr = stats.erase(stitr);
+  }
+
+  // setup first round
+  stats.emplace(_self, [&](auto& item) {
+    item.round_id = 1;
+    item.num_transfers = 0;
+    item.volume = asset(0, gratitude_symbol);
+  });
+
+}
+
+ACTION gratitude::give (name from, name to, asset quantity, string memo) {
+  require_auth(from);
+
+  // Should create balances if not there yet
+  init_balances(to);
+  init_balances(from);
+
+  sub_gratitude(from, quantity);
+  add_gratitude(to, quantity);
+
+  increase_volume(quantity.amount);
+}
+
+ACTION gratitude::newround() {
+  require_auth(get_self());
+  auto generated_gratz = config_get(gratzgen);
+
+  auto contract_balance = eosio::token::get_balance(contracts::token, get_self(), seeds_symbol.code());
+  uint64_t tot_accounts = get_size("balances.sz"_n);
+  uint64_t volume = get_current_volume();
+
+
+  auto balances_by_received = balances.get_index<"byreceived"_n>();
+
+  auto bitr = balances_by_received.begin();
+  while (bitr != balances_by_received.end()) {
+    uint64_t my_received = bitr->received.amount;
+    balances_by_received.modify(bitr, _self, [&](auto& item) {
+        item.received = asset(0, gratitude_symbol);
+        item.remaining = asset(generated_gratz, gratitude_symbol);
+    });
+    float split_factor = my_received / (float)volume;
+    uint64_t payout = contract_balance.amount * split_factor;
+    // Pay out SEEDS in store
+    if (payout > 0) _transfer(bitr->account, asset(payout, seeds_symbol), "gratitude bonus");
+    bitr++;
+  }
+}
+
+/// ----------================ PRIVATE ================----------
+
+void gratitude::check_user (name account) {
+  auto uitr = users.find(account.value);
+  check(uitr != users.end(), "gratitude: user not found");
+}
+
+uint64_t gratitude::get_current_volume() {
+  auto stitr = stats.rbegin();
+  // Should always work because reset always creates first round
+  return stitr->volume.amount;
+}
+
+void gratitude::increase_volume(uint64_t added) {
+  auto stitr = stats.rbegin();
+  auto round_id = stitr->round_id;
+
+  auto stitr2 = stats.find(round_id);
+  auto oldvolume = stitr2->volume.amount;
+  stats.modify(stitr2, _self, [&](auto& item) {
+      item.volume = asset(oldvolume+added, gratitude_symbol);
+  });
+}
+
+void gratitude::init_balances (name account) {
+  auto bitr = balances.find(account.value);
+
+  auto generated_gratz = config_get(gratzgen);
+
+  if (bitr == balances.end()) {
+    balances.emplace(_self, [&](auto & item){
+      item.account = account;
+      item.received = asset(0, gratitude_symbol);
+      item.remaining = asset(generated_gratz, gratitude_symbol);
+    });
+    size_change("balances.sz"_n, 1);
+  }
+}
+
+void gratitude::add_gratitude (name account, asset quantity) {
+  check_asset(quantity);
+
+  auto bitr = balances.find(account.value);
+  check(bitr != balances.end(), "gratitude: no balance object found for " + account.to_string());
+
+  balances.modify(bitr, _self, [&](auto & item){
+    item.received += quantity;
+  });
+
+}
+
+void gratitude::sub_gratitude (name account, asset quantity) {
+  check_asset(quantity);
+
+  auto bitr = balances.find(account.value);
+  check(bitr != balances.end(), "gratitude: no balances object found for " + account.to_string());
+  check(bitr -> remaining.amount >= quantity.amount, "gratitude: not enough gratitude to give");
+
+  balances.modify(bitr, _self, [&](auto & item){
+    item.remaining -= quantity;
+  });
+}
+
+void gratitude::size_change(name id, int delta) {
+  auto sitr = sizes.find(id.value);
+  if (sitr == sizes.end()) {
+    sizes.emplace(_self, [&](auto& item) {
+      item.id = id;
+      item.size = delta;
+    });
+  } else {
+    uint64_t newsize = sitr->size + delta; 
+    if (delta < 0) {
+      if (sitr->size < -delta) {
+        newsize = 0;
+      }
+    }
+    sizes.modify(sitr, _self, [&](auto& item) {
+      item.size = newsize;
+    });
+  }
+}
+
+void gratitude::size_set(name id, uint64_t newsize) {
+  auto sitr = sizes.find(id.value);
+  if (sitr == sizes.end()) {
+    sizes.emplace(_self, [&](auto& item) {
+      item.id = id;
+      item.size = newsize;
+    });
+  } else {
+    sizes.modify(sitr, _self, [&](auto& item) {
+      item.size = newsize;
+    });
+  }
+}
+
+uint64_t gratitude::get_size(name id) {
+  auto sitr = sizes.find(id.value);
+  if (sitr == sizes.end()) {
+    return 0;
+  } else {
+    return sitr->size;
+  }
+}
+
+
+uint64_t gratitude::config_get(name key) {
+  auto citr = config.find(key.value);
+  if (citr == config.end()) { 
+    check(false, ("settings: the "+key.to_string()+" parameter has not been initialized").c_str());
+  }
+  return citr->value;
+}
+
+// Transfers out stored SEEDS
+void gratitude::_transfer (name beneficiary, asset quantity, string memo) {
+  utils::check_asset(quantity);
+  token::transfer_action action{contracts::token, {contracts::gratitude, "active"_n}};
+  action.send(contracts::gratitude, beneficiary, quantity, memo);
+}

--- a/src/seeds.gratitude.cpp
+++ b/src/seeds.gratitude.cpp
@@ -54,13 +54,10 @@ ACTION gratitude::newround() {
   uint64_t tot_accounts = get_size("balances.sz"_n);
   uint64_t volume = get_current_volume();
 
-
-  auto balances_by_received = balances.get_index<"byreceived"_n>();
-
-  auto bitr = balances_by_received.begin();
-  while (bitr != balances_by_received.end()) {
+  auto bitr = balances.begin();
+  while (bitr != balances.end()) {
     uint64_t my_received = bitr->received.amount;
-    balances_by_received.modify(bitr, _self, [&](auto& item) {
+    balances.modify(bitr, _self, [&](auto& item) {
         item.received = asset(0, gratitude_symbol);
         item.remaining = asset(generated_gratz, gratitude_symbol);
     });

--- a/src/seeds.settings.cpp
+++ b/src/seeds.settings.cpp
@@ -229,6 +229,11 @@ void settings::reset() {
   conffloatdsc(name("cyctrx.trail"), 3.0, "Number of cycles to take into account for calculating transaction points for individuals and orgs", high_impact);
 
 
+  // =====================================
+  // gratitude 
+  // =====================================
+  confwithdesc(name("gratz.gen"), 100 * 10000, "Base quantity of gratitude tokens received per cycle", high_impact);
+
   // contracts
   setcontract(name("accounts"), "accts.seeds"_n);
   setcontract(name("harvest"), "harvst.seeds"_n);

--- a/test/gratitude.test.js
+++ b/test/gratitude.test.js
@@ -1,0 +1,125 @@
+const { describe } = require("riteway")
+const { eos, names, getTableRows, isLocal, initContracts, getBalance } = require("../scripts/helper")
+const eosDevKey = "EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV"
+
+const { firstuser, seconduser, settings, gratitude, accounts, token, bank } = names
+
+describe('gratitude general', async assert => {
+
+  if (!isLocal()) {
+    console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
+    return
+  }
+
+  const contracts = await initContracts({ gratitude, accounts, settings, token })
+
+  const get_settings = async (key) => {
+    const value = await eos.getTableRows({
+      code: settings,
+      scope: settings,
+      table: 'config',
+      lower_bound: key,
+      upper_bound: key,
+      json: true,
+    })
+    return value.rows[0].value
+  }
+
+  const getRemainingGratitude = async account => {
+    const balanceTable = await getTableRows({
+      code: gratitude,
+      scope: gratitude,
+      table: 'balances',
+      json: true
+    })
+    const balance = balanceTable.rows.filter(r => r.account == account)
+    return parseInt(balance[0].remaining)
+  }
+
+  const checkRemainingGratitude = async (account, expected) => {
+    const remaining = await getRemainingGratitude(account)
+    assert({
+      given: `${account} given gratitude`,
+      should: 'have the correct remaining balance',
+      actual: remaining,
+      expected: expected
+    })
+  }
+
+  const getReceivedGratitude = async account => {
+    const balanceTable = await getTableRows({
+      code: gratitude,
+      scope: gratitude,
+      table: 'balances',
+      json: true
+    })
+    const balance = balanceTable.rows.filter(r => r.account == account)
+    return parseInt(balance[0].received)
+  }
+
+  const checkReceivedGratitude = async (account, expected) => {
+    const received = await getReceivedGratitude(account)
+    assert({
+      given: `${account} received gratitude`,
+      should: 'have the correct received balance',
+      actual: received,
+      expected: expected
+    })
+  }
+
+  console.log('gratitude reset')
+  await contracts.gratitude.reset({ authorization: `${gratitude}@active` })
+
+  console.log('accounts reset')
+  await contracts.accounts.reset({ authorization: `${accounts}@active` })
+  
+  console.log('token reset weekly')
+  await contracts.token.resetweekly({ authorization: `${token}@active` })
+
+  console.log('reset settings')
+  await contracts.settings.reset({ authorization: `${settings}@active` })
+
+  const initialGratitude = await get_settings("gratz.gen") / 10000; // in GRATZ
+
+  console.log('add SEEDS users')
+  const users = [firstuser, seconduser]
+  for (const user of users) {
+    await contracts.accounts.adduser(user, '', 'individual', { authorization: `${accounts}@active` })
+  }
+
+  const amount = 1000
+  const contractBalanceBefore = await getBalance(gratitude) || 0
+  console.log('refill gratitude contract')
+  await contracts.token.transfer(firstuser, gratitude, `${amount}.0000 SEEDS`, 'test', { authorization: `${firstuser}@active` })
+  const contractBalanceStart = await getBalance(gratitude)
+
+  console.log('give gratitude')
+  const transferAmount = 10
+  await contracts.gratitude.give(firstuser, seconduser, `${transferAmount}.0000 GRATZ`, '', { authorization: `${firstuser}@active` })
+
+  checkRemainingGratitude(firstuser, initialGratitude-transferAmount)
+  checkReceivedGratitude(seconduser, transferAmount)
+
+  console.log('restart gratitude round')
+
+  const secondBalanceBefore = await getBalance(seconduser)  
+  await contracts.gratitude.newround({ authorization: `${gratitude}@active` })
+  const contractBalanceAfter = await getBalance(gratitude)
+
+  const secondBalanceAfter = await getBalance(seconduser)
+
+  assert({
+    given: 'gratitude round finished',
+    should: 'contract balance',
+    actual: contractBalanceAfter,
+    expected: contractBalanceBefore
+  })
+
+  assert({
+    given: 'gratitude round finished',
+    should: 'second user received seeds',
+    actual: secondBalanceAfter,
+    expected: secondBalanceBefore + amount
+  })
+
+})


### PR DESCRIPTION
This is the first implementation of the SEEDS gratitude token.

The basic idea is that you can allocate some funds to the `gratz.seeds` contract, then everyone gets some gratitude tokens to share. At the end of the round, the amount of SEEDS resting at the contract gets split among everyone that received gratitude during the round, in proportion to how much they got, for example:

If the round volume was 1000 gratitude tokens, and you got 100 in total, you get 100/1000 (1/10) of the stash of SEEDS.

When the round ends, all gratitude tokens available for giving are reset to the original quantity, and all earned tokens are back to zero for all users.

Still need to schedule the "newround()" action on seeds.scheduler, for once every cycle.

- contracts to deploy: settings, gratitude
- permissions added Y `gratitude@active`
- new accounts created Y `gratz.seeds`
- settings changed Y
- scheduler changed N (not yet)
- migrate functions required (none yet)