### PR TITLE
Quorum is generated from the avg voice cast form the last 2 cycles #207

### DIFF
--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -92,6 +92,9 @@ CONTRACT proposals : public contract {
 
       ACTION undelegate(name delegator, name scope);
 
+
+      ACTION migrtevotedp ();
+
   private:
       symbol seeds_symbol = symbol("SEEDS", 4);
       name trust = "trust"_n;
@@ -344,6 +347,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
         (addactive)(testvdecay)(initsz)(testquorum)(initnumprop)
         (migratevoice)(testsetvoice)(delegate)(mimicvote)(undelegate)(voteonbehalf)
         (calcvotepow)
+        (migrtevotedp)
         )
       }
   }

--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -94,6 +94,7 @@ CONTRACT proposals : public contract {
 
 
       ACTION migrtevotedp ();
+      ACTION migrpass ();
 
   private:
       symbol seeds_symbol = symbol("SEEDS", 4);
@@ -279,7 +280,7 @@ CONTRACT proposals : public contract {
         uint64_t start_time; 
         uint64_t end_time; 
         uint64_t num_proposals;
-        uint64_t num_votes;
+        uint64_t num_voters;
         uint64_t total_voice_cast;
         uint64_t total_favour;
         uint64_t total_against; 
@@ -347,7 +348,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
         (addactive)(testvdecay)(initsz)(testquorum)(initnumprop)
         (migratevoice)(testsetvoice)(delegate)(mimicvote)(undelegate)(voteonbehalf)
         (calcvotepow)
-        (migrtevotedp)
+        (migrtevotedp)(migrpass)
         )
       }
   }

--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -95,8 +95,10 @@ CONTRACT proposals : public contract {
 
       ACTION migrtevotedp ();
       ACTION migrpass ();
+
       ACTION migstats (uint64_t cycle);
-      
+      ACTION migcycstat ();
+
       ACTION testperiod ();
 
   private:
@@ -351,7 +353,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
         (addactive)(testvdecay)(initsz)(testquorum)(initnumprop)
         (migratevoice)(testsetvoice)(delegate)(mimicvote)(undelegate)(voteonbehalf)
         (calcvotepow)
-        (migrtevotedp)(migrpass)(testperiod)(migstats)
+        (migrtevotedp)(migrpass)(testperiod)(migstats)(migcycstat)
         )
       }
   }

--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -95,6 +95,7 @@ CONTRACT proposals : public contract {
 
       ACTION migrtevotedp ();
       ACTION migrpass ();
+      ACTION testperiod ();
 
   private:
       symbol seeds_symbol = symbol("SEEDS", 4);
@@ -280,7 +281,7 @@ CONTRACT proposals : public contract {
         uint64_t start_time; 
         uint64_t end_time; 
         uint64_t num_proposals;
-        uint64_t num_voters;
+        uint64_t num_votes;
         uint64_t total_voice_cast;
         uint64_t total_favour;
         uint64_t total_against; 
@@ -348,7 +349,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
         (addactive)(testvdecay)(initsz)(testquorum)(initnumprop)
         (migratevoice)(testsetvoice)(delegate)(mimicvote)(undelegate)(voteonbehalf)
         (calcvotepow)
-        (migrtevotedp)(migrpass)
+        (migrtevotedp)(migrpass)(testperiod)
         )
       }
   }

--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -95,6 +95,8 @@ CONTRACT proposals : public contract {
 
       ACTION migrtevotedp ();
       ACTION migrpass ();
+      ACTION migstats (uint64_t cycle);
+      
       ACTION testperiod ();
 
   private:
@@ -349,7 +351,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
         (addactive)(testvdecay)(initsz)(testquorum)(initnumprop)
         (migratevoice)(testsetvoice)(delegate)(mimicvote)(undelegate)(voteonbehalf)
         (calcvotepow)
-        (migrtevotedp)(migrpass)(testperiod)
+        (migrtevotedp)(migrpass)(testperiod)(migstats)
         )
       }
   }

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -680,7 +680,7 @@ void proposals::update_cycle_stats (std::vector<uint64_t>active_props, std::vect
   cycle_table c = cycle.get();
 
   uint64_t quorum_vote_base = calc_quorum_base(c.propcycle - 1);
-  uint64_t num_proposals = active_props.size() + eval_props.size();
+  uint64_t num_proposals = active_props.size();
 
   cyclestats.emplace(_self, [&](auto & item){
     item.propcycle = c.propcycle;
@@ -1761,6 +1761,32 @@ ACTION proposals::migstats (uint64_t cycle) {
     item.total_voice_cast = total_voice_cast;
     item.total_favour = total_favour;
     item.total_against = total_against;
+  });
+
+}
+
+void proposals::migcycstat() {
+  cycle_table c = cycle.get();
+
+  uint64_t quorum_vote_base = calc_quorum_base(c.propcycle - 1);
+
+  auto pitr = cyclestats.find(c.propcycle);
+
+  uint64_t num_proposals = pitr->active_props.size();
+
+  cyclestats.modify(pitr, _self, [&](auto & item){
+    item.propcycle = c.propcycle;
+    item.start_time = c.t_onperiod;
+    item.end_time = c.t_onperiod + config_get("propcyclesec"_n);
+    item.num_proposals = num_proposals;
+    item.num_votes = 0;
+    item.total_voice_cast = 0;
+    item.total_favour = 0;
+    item.total_against = 0;
+    item.total_citizens = get_size("voice.sz"_n);
+    item.quorum_vote_base = quorum_vote_base;
+    item.quorum_votes_needed = quorum_vote_base * (get_quorum(num_proposals) / 100.0);
+    item.unity_needed = double(config_get("propmajority"_n)) / 100.0;
   });
 
 }

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -1770,20 +1770,12 @@ void proposals::migcycstat() {
 
   uint64_t quorum_vote_base = calc_quorum_base(c.propcycle - 1);
 
-  auto pitr = cyclestats.find(c.propcycle);
+  auto citr = cyclestats.find(c.propcycle);
 
-  uint64_t num_proposals = pitr->active_props.size();
+  uint64_t num_proposals = citr->active_props.size();
 
-  cyclestats.modify(pitr, _self, [&](auto & item){
-    item.propcycle = c.propcycle;
-    item.start_time = c.t_onperiod;
-    item.end_time = c.t_onperiod + config_get("propcyclesec"_n);
+  cyclestats.modify(citr, _self, [&](auto & item){
     item.num_proposals = num_proposals;
-    item.num_votes = 0;
-    item.total_voice_cast = 0;
-    item.total_favour = 0;
-    item.total_against = 0;
-    item.total_citizens = get_size("voice.sz"_n);
     item.quorum_vote_base = quorum_vote_base;
     item.quorum_votes_needed = quorum_vote_base * (get_quorum(num_proposals) / 100.0);
     item.unity_needed = double(config_get("propmajority"_n)) / 100.0;

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -63,6 +63,8 @@ void proposals::reset() {
     citr = cyclestats.erase(citr);
   }
 
+  cycle.remove();
+
 }
 
 bool proposals::is_enough_stake(asset staked, asset quantity, name fund) {
@@ -278,19 +280,24 @@ void proposals::onperiod() {
     std::vector<uint64_t> active_props;
     std::vector<uint64_t> eval_props;
 
+    // TODO this is not working at the moment, use old way... FIX after this cycle.
+
     // find smallesd prop id that's in open or eval stage
     // this way we skip all proposals that are definitely already passed or rejected
-    auto pps_itr = props_by_status.begin();
-    uint64_t smallest_prop_id = 0;
-    while (pps_itr != props_by_status.end() && 
-      (pps_itr -> status == status_open || pps_itr -> status_evaluate) ) {
-      smallest_prop_id  = std::min(smallest_prop_id, pps_itr -> id);
-    }
+    // auto pps_itr = props_by_status.begin();
+    // uint64_t smallest_prop_id = 0;
+    // while (pps_itr != props_by_status.end() && 
+    //   (pps_itr -> status == status_open || pps_itr -> status == status_evaluate) ) {
+    //   smallest_prop_id  = std::min(smallest_prop_id, pps_itr -> id);
+    //   pps_itr++;
+    // }
 
-    print("smallest id: "+std::to_string(smallest_prop_id));
+    // print("smallest id: "+std::to_string(smallest_prop_id));
       
-    pitr = props.find(smallest_prop_id);
+    // auto pitr = props.find(smallest_prop_id);
 
+    auto pitr = props.begin();
+    
     while (pitr != props.end()) {
       uint64_t prop_id = pitr -> id;
 
@@ -399,6 +406,7 @@ void proposals::onperiod() {
         active_props.push_back(prop_id);
       }
 
+      pitr++;
     } 
 
     update_cycle();
@@ -431,18 +439,22 @@ void proposals::testperiod() {
     std::vector<uint64_t> active_props;
     std::vector<uint64_t> eval_props;
 
+    // TODO this is not working at the moment, use old way... FIX after this cycle.
+
     // find smallesd prop id that's in open or eval stage
     // this way we skip all proposals that are definitely already passed or rejected
-    auto pps_itr = props_by_status.begin();
-    uint64_t smallest_prop_id = 0;
-    while (pps_itr != props_by_status.end() && 
-      (pps_itr -> status == status_open || pps_itr -> status_evaluate) ) {
-      smallest_prop_id  = std::min(smallest_prop_id, pps_itr -> id);
-    }
+    // auto pps_itr = props_by_status.begin();
+    // uint64_t smallest_prop_id = 0;
+    // while (pps_itr != props_by_status.end() && 
+    //   (pps_itr -> status == status_open || pps_itr -> status == status_evaluate) ) {
+    //   smallest_prop_id  = std::min(smallest_prop_id, pps_itr -> id);
+    //   pps_itr++;
+    // }
 
-    print("smallest id: "+std::to_string(smallest_prop_id) );
+    // print("smallest id: "+std::to_string(smallest_prop_id) );
       
-    pitr = props.find(smallest_prop_id);
+    // auto pitr = props.find(smallest_prop_id);
+    auto pitr = props.find(50);
 
     while (pitr != props.end()) {
       uint64_t prop_id = pitr -> id;
@@ -477,7 +489,7 @@ void proposals::testperiod() {
         }
       
       }
-      
+      pitr++;
     } 
 }
 void proposals::updatevoices() {
@@ -1705,7 +1717,7 @@ ACTION proposals::migrpass () {
   }
 }
 
-ACTION proposals::migstats (utint64_t cycle) {
+ACTION proposals::migstats (uint64_t cycle) {
   require_auth(get_self());
 
   // calculate vote power for cycle

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -1720,17 +1720,23 @@ ACTION proposals::migrpass () {
 ACTION proposals::migstats (uint64_t cycle) {
   require_auth(get_self());
 
+  auto citr = cyclestats.find(cycle);
+  while(citr != cyclestats.end()) {
+    citr = cyclestats.erase(citr);
+  }
+
   // calculate vote power for cycle
   auto pitr = props.find(72);
 
-  uint64_t num_proposals;
-  uint64_t num_votes;
-  uint64_t total_voice_cast;
-  uint64_t total_favour;
-  uint64_t total_against; 
+  uint64_t num_proposals = 0;
+  uint64_t num_votes = 0;
+  uint64_t total_voice_cast = 0;
+  uint64_t total_favour = 0;
+  uint64_t total_against = 0; 
 
   while(pitr != props.end() && pitr->passed_cycle <= cycle) {
     if (pitr->passed_cycle == cycle) {
+      print("passed: "+std::to_string(cycle) + " " + std::to_string(pitr->id));
       num_proposals++;
       votes_tables votes(get_self(), pitr->id);
       auto vitr = votes.begin();

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -1562,3 +1562,23 @@ void proposals::add_voted_proposal (uint64_t proposal_id) {
 
 }
 
+ACTION proposals::migrtevotedp () {
+  require_auth(get_self());
+
+  auto pitr = props.begin();
+  
+  while (pitr != props.end()) {
+    if (pitr -> passed_cycle != 0) {
+      voted_proposals_tables votedprops(get_self(), pitr -> passed_cycle);
+      auto vpitr = votedprops.find(pitr -> id);
+      if (vpitr == votedprops.end()) {
+        votedprops.emplace(_self, [&](auto & item){
+          item.proposal_id = pitr -> id;
+        });
+      }
+    }
+    pitr++;
+  }
+
+}
+

--- a/src/seeds.settings.cpp
+++ b/src/seeds.settings.cpp
@@ -18,6 +18,8 @@ void settings::reset() {
   confwithdesc(name("prop.al.pct"), uint64_t(1 * 10000), "Alliance proposals funding fee in % - 1% [x 10,000 for 4 digits of precision]", high_impact);
 
   confwithdesc(name("proppass.rep"), 10, "Reputation points for passed proposal", high_impact); // rep points for passed proposal
+
+  confwithdesc(name("prop.cyc.qb"), 2, "Prop cycles to take into account for calculating quorum basis", high_impact);
   
   confwithdesc(name("unity.high"), 80, "High unity threshold (in percentage)", high_impact);
   confwithdesc(name("unity.medium"), 70, "Medium unity threshold (in percentage)", high_impact);

--- a/src/seeds.settings.cpp
+++ b/src/seeds.settings.cpp
@@ -32,12 +32,12 @@ void settings::reset() {
   confwithdesc(name("refsnewprice"), 25 * 10000, "Minimum price to create a referendum", high_impact);
   confwithdesc(name("refsmajority"), 80, "Majority referendums threshold", high_impact);
   confwithdesc(name("refsquorum"), 80, "Quorum referendums threshold", high_impact);
-  confwithdesc(name("propmajority"), 80, "Majority proposals threshold", high_impact);
+  confwithdesc(name("propmajority"), 90, "Majority proposals threshold", high_impact);
   confwithdesc(name("propquorum"), 5, "Quorum proposals threshold", high_impact); // Deprecated
 
-  confwithdesc(name("quorum.base"), 90, "Quorum base percentage = 90% / number of proposals.", high_impact);
-  confwithdesc(name("quor.min.pct"), 5, "Quorum percentage lower cap - quorum required between 5% and 20%", high_impact);
-  confwithdesc(name("quor.max.pct"), 20, "Quorum percentage upper cap- quorum required between 5% and 20%", high_impact);
+  confwithdesc(name("quorum.base"), 100, "Quorum base percentage = 90% / number of proposals.", high_impact);
+  confwithdesc(name("quor.min.pct"), 7, "Quorum percentage lower cap - quorum required between 5% and 20%", high_impact);
+  confwithdesc(name("quor.max.pct"), 40, "Quorum percentage upper cap- quorum required between 5% and 20%", high_impact);
 
   confwithdesc(name("propvoice"), 77, "Voice base per period", high_impact); // voice base per period
   confwithdesc(name("hrvstreward"), 100000, "Harvest reward", high_impact);

--- a/test/proposals.test.js
+++ b/test/proposals.test.js
@@ -153,6 +153,15 @@ describe('Proposals', async assert => {
   await contracts.proposals.onperiod({ authorization: `${proposals}@active` })
   await sleep(3000)
 
+  console.log('------------------------------------')
+  const cyclestats1 = await eos.getTableRows({
+    code: proposals,
+    scope: proposals,
+    table: 'cyclestats',
+    json: true,
+  })
+  console.log(cyclestats1)
+
   const activeProposals = await eos.getTableRows({
     code: proposals,
     scope: proposals,
@@ -235,6 +244,15 @@ describe('Proposals', async assert => {
 
   console.log('execute proposals')
   await contracts.proposals.onperiod({ authorization: `${proposals}@active` })
+
+  console.log('------------------------------------')
+  const cyclestats2 = await eos.getTableRows({
+    code: proposals,
+    scope: proposals,
+    table: 'cyclestats',
+    json: true,
+  })
+  console.log(cyclestats2)
 
   const repsAfter = await eos.getTableRows({
     code: accounts,
@@ -590,6 +608,86 @@ describe('Proposals', async assert => {
     should: 'send reward',
     actual: balancesAfterFinish[0] - balancesBefore[0],
     expected: 600
+  })
+
+  delete cyclestats1.rows[0].start_time
+  delete cyclestats1.rows[0].end_time
+
+  assert({
+    given: 'onperiod executed',
+    should: 'store cycle stats',
+    actual: cyclestats1.rows,
+    expected: [
+      {
+        propcycle: initialCycle + 1,
+        num_proposals: 4,
+        num_votes: 0,
+        total_voice_cast: 0,
+        total_favour: 0,
+        total_against: 0,
+        total_citizens: 3,
+        quorum_vote_base: 1,
+        quorum_votes_needed: 0,
+        unity_needed: '0.80000001192092896',
+        active_props: [ 1, 2, 3, 4 ],
+        eval_props: []
+      }
+    ]
+  })
+
+  delete cyclestats2.rows[0].start_time
+  delete cyclestats2.rows[0].end_time
+  delete cyclestats2.rows[1].start_time
+  delete cyclestats2.rows[1].end_time
+
+  assert({
+    given: 'onperiod executed',
+    should: 'store cycle stats',
+    actual: cyclestats2.rows,
+    expected: [
+      {
+        propcycle: initialCycle + 1,
+        num_proposals: 4,
+        num_votes: 8,
+        total_voice_cast: 33,
+        total_favour: 26,
+        total_against: 7,
+        total_citizens: 3,
+        quorum_vote_base: 1,
+        quorum_votes_needed: 0,
+        unity_needed: '0.80000001192092896',
+        active_props: [ 1, 2, 3, 4 ],
+        eval_props: []
+      },
+      {
+        propcycle: initialCycle + 2,
+        num_proposals: 2,
+        num_votes: 0,
+        total_voice_cast: 0,
+        total_favour: 0,
+        total_against: 0,
+        total_citizens: 4,
+        quorum_vote_base: 33,
+        quorum_votes_needed: 6,
+        unity_needed: '0.80000001192092896',
+        active_props: [],
+        eval_props: [ 1, 4 ]
+      }
+    ]
+  })
+
+  const votedProps = await getTableRows({
+    code: proposals,
+    scope: initialCycle + 1,
+    table: 'cycvotedprps',
+    json: true
+  })
+
+  assert({
+    given: 'voted props in first cycle',
+    should: 'have the correct entries',
+    actual: votedProps.rows.map(r => r.proposal_id),
+    expected: [1,2,3,4]
   })
 
   const escrowLocksAfterFinish = await eos.getTableRows({

--- a/test/proposals.test.js
+++ b/test/proposals.test.js
@@ -471,7 +471,7 @@ describe('Proposals', async assert => {
       status: 'rejected',
       fund: campaignbank,
       pay_percentages: [10,30,30,30],
-      passed_cycle: 0,
+      passed_cycle: 1,
       age: 0,
       current_payout: '0.0000 SEEDS'
     }
@@ -500,7 +500,7 @@ describe('Proposals', async assert => {
       status: 'rejected',
       fund: campaignbank,
       pay_percentages: [10,30,30,30],
-      passed_cycle: 0,
+      passed_cycle: 1,
       age: 0,
       current_payout: '0.0000 SEEDS'
     }
@@ -628,8 +628,8 @@ describe('Proposals', async assert => {
         total_favour: 0,
         total_against: 0,
         total_citizens: 3,
-        quorum_vote_base: 1,
-        quorum_votes_needed: 0,
+        quorum_vote_base: 75,
+        quorum_votes_needed: 15,
         unity_needed: '0.80000001192092896',
         active_props: [ 1, 2, 3, 4 ],
         eval_props: []
@@ -655,8 +655,8 @@ describe('Proposals', async assert => {
         total_favour: 26,
         total_against: 7,
         total_citizens: 3,
-        quorum_vote_base: 1,
-        quorum_votes_needed: 0,
+        quorum_vote_base: 75,
+        quorum_votes_needed: 15,
         unity_needed: '0.80000001192092896',
         active_props: [ 1, 2, 3, 4 ],
         eval_props: []

--- a/test/proposals.test.js
+++ b/test/proposals.test.js
@@ -522,6 +522,8 @@ describe('Proposals', async assert => {
 
   let escrowLock = escrowLocks.rows[0]
 
+  console.log(escrowLock)
+
   delete escrowLock.vesting_date
   delete escrowLock.created_date
   delete escrowLock.updated_date


### PR DESCRIPTION
## Spec 
#207 

## Deployment

### Before moon cycle
- Disable quorum check in code for initial deploy - all current proposals are passing the existing quorum calculation so this does not impact any existing proposal in this cycle. 
- Deploy Proposals, Settings
- Update settings
- Manually set the old unity setting back to 80%
- Call migration action on proposals
- run moon cycle as usual

### After moon cycle
- Re-enable quorum check
- Deploy proposals
- Update settings


## Dev Notes
- Added `cyclestats` and `cycvotedprps` tables
- Added tests

The `cyclestats` table is the table that you described in the issue. The quorum base is being calculated using the value `total_voice_cast` which is the sum of all the voice amount spent during the cycles. I got a bit confused when you say "avg votes cast" that's why I added the field `num_votes` which is the sum of all the number of votes during the cycle. I added a comment in the method `calc_quorum_base` in case the quorum base should be calculated using the total num of votes instead of the voice.

>I also have been wanting to have information which proposals were voted on in which cycles so if we can do that would be great. If it's easy enough. It's a bit tricky though as some may have been skipped due to low stake, but I think that was only 1 or 2.

I added the table `cycvotedprps` scoped by propcycle, to store which proposals have been voted during the cycle. I added the action `migrtevotedp` which walks through the props table and uses the passed_cycle property to determine the cycle the proposal was voted. Unfortunately, I couldn't figure out a way to know in which cycle the rest of the proposals were voted.

> We can also eventually switch to iterating through proposals by "open" status rather than always checking all proposals which will eventually fail when we have too many.

About that, I think the index `by_status` that is in proposals table might not be enough, because when a proposal change status, the whole structure rearranges and then I think it increments the computational complexity. It also starts doing weird things due to the reordering and it's difficult to predict where the pointer will be next, I think that if I try to fix that it will be not as efficient as it should be.
Another way, is to use the new vectors active_props and eval_props but I still need to think how to solve efficiently the staged props, maybe creating another vector of staged proposals before evaluate them. Another solution might be to create a vector of pointers storing the pointers of the props in open status, that vector won't be rearranged but it will be like passing twice over the open and evaluate proposals 