### PR TITLE
Feature/five level of organizations #242

### DIFF
--- a/include/seeds.history.hpp
+++ b/include/seeds.history.hpp
@@ -24,8 +24,6 @@ CONTRACT history : public contract {
           sizes(receiver, receiver.value),
           residents(receiver, receiver.value),
           citizens(receiver, receiver.value),
-          reputables(receiver, receiver.value),
-          regens(receiver, receiver.value),
           totals(receiver, receiver.value),
           organizations(contracts::organization, contracts::organization.value),
           members(contracts::bioregion, contracts::bioregion.value)
@@ -42,10 +40,6 @@ CONTRACT history : public contract {
         ACTION addresident(name account);
         
         ACTION numtrx(name account);
-
-        ACTION addreputable(name organization);
-
-        ACTION addregen(name organization);
 
         ACTION updatestatus(name account, name scope);
 
@@ -132,24 +126,6 @@ CONTRACT history : public contract {
       
       // --------------------------------------------------- //
       // old tables
-
-      TABLE reputable_table {
-        uint64_t id;
-        name organization;
-        uint64_t timestamp;
-
-        uint64_t primary_key()const { return id; }
-        uint64_t by_org()const { return organization.value; }
-      };
-
-      TABLE regenerative_table {
-        uint64_t id;
-        name organization;
-        uint64_t timestamp;
-
-        uint64_t primary_key()const { return id; }
-        uint64_t by_org()const { return organization.value; }
-      };
 
       TABLE transaction_table {
         uint64_t id;
@@ -273,16 +249,6 @@ CONTRACT history : public contract {
         const_mem_fun<account_status_table, uint64_t, &account_status_table::by_timestamp>>
       > account_status_tables;
 
-      typedef eosio::multi_index<"reputables"_n, reputable_table,
-        indexed_by<"byorg"_n,
-        const_mem_fun<reputable_table, uint64_t, &reputable_table::by_org>>
-      > reputable_tables;
-
-      typedef eosio::multi_index<"regens"_n, regenerative_table,
-        indexed_by<"byorg"_n,
-        const_mem_fun<regenerative_table, uint64_t, &regenerative_table::by_org>>
-      > regenerative_tables;
-
       typedef eosio::multi_index<"dailytrxs"_n, daily_transactions_table,
         indexed_by<"byfrom"_n,
         const_mem_fun<daily_transactions_table, uint64_t, &daily_transactions_table::by_from>>,
@@ -323,8 +289,6 @@ CONTRACT history : public contract {
       user_tables users;
       resident_tables residents;
       citizen_tables citizens;
-      reputable_tables reputables;
-      regenerative_tables regens;
       totals_tables totals;
       size_tables sizes;
       organization_tables organizations;
@@ -335,7 +299,7 @@ EOSIO_DISPATCH(history,
   (reset)
   (historyentry)(trxentry)
   (addcitizen)(addresident)
-  (addreputable)(addregen)(updatestatus)
+  (updatestatus)
   (numtrx)
   (deldailytrx)(savepoints)
   (testtotalqev)

--- a/include/seeds.history.hpp
+++ b/include/seeds.history.hpp
@@ -58,7 +58,7 @@ CONTRACT history : public contract {
 
 
     private:
-      const uint64_t regenerative_org = 2;
+      const uint64_t status_sustainable = 2;
 
       void check_user(name account);
       uint32_t num_transactions(name account, uint32_t limit);

--- a/include/seeds.organization.hpp
+++ b/include/seeds.organization.hpp
@@ -24,7 +24,6 @@ CONTRACT organization : public contract {
               cbsorgs(receiver, receiver.value),
               sizes(receiver, receiver.value),
               avgvotes(receiver, receiver.value),
-              rep(contracts::accounts, contracts::accounts.value),
               refs(contracts::accounts, contracts::accounts.value),
               users(contracts::accounts, contracts::accounts.value),
               balances(contracts::harvest, contracts::harvest.value),
@@ -70,27 +69,22 @@ CONTRACT organization : public contract {
 
         ACTION rankregen(uint64_t start, uint64_t chunk, uint64_t chunksize);
 
-        // ACTION rankcbsorgs();
-
-        // ACTION rankcbsorg(uint64_t start, uint64_t chunk, uint64_t chunksize);
-
-        // ACTION addcbpoints(name organization, uint32_t cbscore);
-
-        // ACTION subcbpoints(name organization, uint32_t cbscore);
+        ACTION makethrivble(name organization);
 
         ACTION makeregen(name organization);
 
+        ACTION makesustnble(name organization);
+
         ACTION makereptable(name organization);
-
-        ACTION testregen(name organization);
-
-        ACTION testreptable(name organization);
 
         void deposit(name from, name to, asset quantity, std::string memo);
 
         ACTION scoretrxs();
 
         ACTION scoreorgs(name next);
+
+        ACTION testregensc(name organization, uint64_t score);
+        ACTION teststatus(name organization, uint64_t status);
 
     private:
         symbol seeds_symbol = symbol("SEEDS", 4);
@@ -107,12 +101,12 @@ CONTRACT organization : public contract {
         const uint64_t status_regenerative = 3;
         const uint64_t status_thrivable = 4;
 
-        std::vector<string> status_names = {
-            "Regular",
-            "Reputable",
-            "Sustainable",
-            "Regenerative",
-            "Thrivable"
+        std::vector<name> status_names = {
+            "regular"_n,
+            "reputable"_n,
+            "sustainable"_n,
+            "regenerative"_n,
+            "thrivable"_n
         };
 
         TABLE organization_table {
@@ -348,14 +342,12 @@ CONTRACT organization : public contract {
         regen_score_tables regenscores;
         cbs_organization_tables cbsorgs;
         size_tables sizes;
-        rep_tables rep;
         balance_tables balances;
         ref_tables refs;
         avg_vote_tables avgvotes;
         totals_tables totals;
         planted_tables planted;
 
-        uint64_t get_config(name key);
         void create_account(name sponsor, name orgaccount, string fullname, string publicKey);
         void check_owner(name organization, name owner);
         void init_balance(name account);
@@ -369,15 +361,11 @@ CONTRACT organization : public contract {
         void increase_size_by_one(name id);
         void decrease_size_by_one(name id);
         uint32_t calc_transaction_points(name organization);
-        void check_can_make_regen(name organization);
-        void check_can_make_reputable(name organization);
-        uint64_t count_refs(name user, uint32_t check_num_residents);
         void update_status(name organization, uint64_t status);
-        uint64_t get_regen_score(name organization);
-        void history_add_regenerative(name organization);
-        void history_add_reputable(name organization);
-        uint64_t count_transactions(name organization);
         uint64_t config_get(name key);
+        void check_referrals(name organization, uint64_t min_visitors_invited, uint64_t min_residents_invited);
+        void check_status_requirements(name organization, uint64_t status);
+        void history_update_org_status(name organization, uint64_t status);
 };
 
 
@@ -388,8 +376,8 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
       switch (action) {
           EOSIO_DISPATCH_HELPER(organization, (reset)(addmember)(removemember)(changerole)(changeowner)(addregen)
             (subregen)(create)(destroy)(refund)(appuse)(registerapp)(banapp)(cleandaus)(cleandau)
-            (rankregens)(rankregen)(makeregen)
-            (makereptable)(testregen)(testreptable)(scoreorgs)(scoretrxs))
+            (rankregens)(rankregen)(scoreorgs)(scoretrxs)
+            (makethrivble)(makeregen)(makesustnble)(makereptable)(testregensc)(teststatus))
       }
   }
 }

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -4,6 +4,8 @@
 #include <tables/rep_table.hpp>
 #include <tables/size_table.hpp>
 #include <tables/user_table.hpp>
+#include <tables/config_table.hpp>
+#include <tables/config_float_table.hpp>
 
 using namespace eosio;
 using std::string;

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -11,8 +11,7 @@ const networks = {
   mainnet: 'aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906',
   jungle: 'e70aaab8997e1dfce58fbfac80cbbb8fecec7b99cf982a9444273cbc64c41473',
   kylin: '5fff1dae8dc8e2fc4d5b23b2c7665c97f9e9d8edf2b6485a86ba311c25639191',
-  // local: process.env.COMPILER === 'local' ? eosioLocalChainID : dockerLocalChainID,
-  local: 'cf057bbfb72640471fd910bcb67639c22df9f92470936cddc1ade0e2f2e7dc4f',
+  local: process.env.COMPILER === 'local' ? eosioLocalChainID : dockerLocalChainID,
   telosTestnet: '1eaa0824707c8c16bd25145493bf062aecddfeb56c736f6ba6397f3195f33c9f',
   telosMainnet: '4667b205c6838ef70ff7988f6e8257e8be0e1284a2f59699054a018f743b1d11'
 }
@@ -85,7 +84,7 @@ const payForCPUKeys = {
 const payForCPUPublicKey = payForCPUKeys[chainId]
 
 const applicationKeys = {
-  [networks.local]: 'EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV', // 'EOS7HXZn1yhQJAiHbUXeEnPTVHoZLgAScNNELAyvWxoqQJzcLbbjq',
+  [networks.local]: 'EOS7HXZn1yhQJAiHbUXeEnPTVHoZLgAScNNELAyvWxoqQJzcLbbjq',
   [networks.telosMainnet]: 'EOS7HXZn1yhQJAiHbUXeEnPTVHoZLgAScNNELAyvWxoqQJzcLbbjq',
   [networks.telosTestnet]: 'EOS7HXZn1yhQJAiHbUXeEnPTVHoZLgAScNNELAyvWxoqQJzcLbbjq'
 }

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -11,7 +11,8 @@ const networks = {
   mainnet: 'aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906',
   jungle: 'e70aaab8997e1dfce58fbfac80cbbb8fecec7b99cf982a9444273cbc64c41473',
   kylin: '5fff1dae8dc8e2fc4d5b23b2c7665c97f9e9d8edf2b6485a86ba311c25639191',
-  local: process.env.COMPILER === 'local' ? eosioLocalChainID : dockerLocalChainID,
+  // local: process.env.COMPILER === 'local' ? eosioLocalChainID : dockerLocalChainID,
+  local: 'cf057bbfb72640471fd910bcb67639c22df9f92470936cddc1ade0e2f2e7dc4f',
   telosTestnet: '1eaa0824707c8c16bd25145493bf062aecddfeb56c736f6ba6397f3195f33c9f',
   telosMainnet: '4667b205c6838ef70ff7988f6e8257e8be0e1284a2f59699054a018f743b1d11'
 }
@@ -84,7 +85,7 @@ const payForCPUKeys = {
 const payForCPUPublicKey = payForCPUKeys[chainId]
 
 const applicationKeys = {
-  [networks.local]: 'EOS7HXZn1yhQJAiHbUXeEnPTVHoZLgAScNNELAyvWxoqQJzcLbbjq',
+  [networks.local]: 'EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV', // 'EOS7HXZn1yhQJAiHbUXeEnPTVHoZLgAScNNELAyvWxoqQJzcLbbjq',
   [networks.telosMainnet]: 'EOS7HXZn1yhQJAiHbUXeEnPTVHoZLgAScNNELAyvWxoqQJzcLbbjq',
   [networks.telosTestnet]: 'EOS7HXZn1yhQJAiHbUXeEnPTVHoZLgAScNNELAyvWxoqQJzcLbbjq'
 }

--- a/src/seeds.accounts.cpp
+++ b/src/seeds.accounts.cpp
@@ -1,4 +1,3 @@
- 
 #include <seeds.accounts.hpp>
 #include <eosio/system.hpp>
 #include <eosio/symbol.hpp>

--- a/src/seeds.accounts.cpp
+++ b/src/seeds.accounts.cpp
@@ -202,7 +202,7 @@ void accounts::pnishvouched (name sponsor, uint64_t start_account) {
   require_auth(get_self());
 
   uint64_t batch_size = config_get("batchsize"_n);
-  uint128_t id = uint128_t(sponsor.value) << 64;
+  uint128_t id = (uint128_t(sponsor.value) << 64) + start_account;
 
   auto vouches_by_account = vouches.get_index<"byaccount"_n>();
   auto vouches_by_sponsor_account = vouches.get_index<"byspnsoracct"_n>();

--- a/src/seeds.history.cpp
+++ b/src/seeds.history.cpp
@@ -89,36 +89,6 @@ void history::addcitizen(name account) {
   size_change("citizens.sz"_n, 1);
 }
 
-void history::addreputable(name organization) {
-  require_auth(get_self());
-
-  auto uitr = users.find(organization.value);
-  check(uitr != users.end(), "no user found");
-  check(uitr -> type == name("organisation"), "the user type must be organization");
-
-  reputables.emplace(_self, [&](auto & org){
-    org.id = reputables.available_primary_key();
-    org.organization = organization;
-    org.timestamp = eosio::current_time_point().sec_since_epoch();
-  });
-  size_change("reptables.sz"_n, 1);
-}
-
-void history::addregen(name organization) {
-  require_auth(get_self());
-
-  auto uitr = users.find(organization.value);
-  check(uitr != users.end(), "no user found");
-  check(uitr -> type == name("organisation"), "the user type must be organization");
-
-  regens.emplace(_self, [&](auto & org){
-    org.id = regens.available_primary_key();
-    org.organization = organization;
-    org.timestamp = eosio::current_time_point().sec_since_epoch();
-  });
-  size_change("regens.sz"_n, 1);
-}
-
 void history::updatestatus (name account, name scope) {
   require_auth(get_self());
 
@@ -398,22 +368,6 @@ void history::migrate() {
     count++;
   }
   size_set("residents.sz"_n, count);
-
-  count = 0;
-  auto reptr = reputables.begin();
-  while(reptr != reputables.end()) {
-    reptr++;
-    count++;
-  }
-  size_set("reptables.sz"_n, count);
-
-  count = 0;
-  auto regtr = regens.begin();
-  while(regtr != regens.end()) {
-    regtr++;
-    count++;
-  }
-  size_set("regens.sz"_n, count);
 }
 
 void history::size_change(name id, int delta) {

--- a/src/seeds.history.cpp
+++ b/src/seeds.history.cpp
@@ -114,7 +114,7 @@ double history::get_transaction_multiplier (name account, name other) {
   double multiplier = utils::get_rep_multiplier(account);
   
   auto oitr = organizations.find(account.value);
-  if (oitr != organizations.end() && oitr -> status == regenerative_org) {
+  if (oitr != organizations.end() && oitr -> status == status_sustainable) {
     multiplier *= config_float_get("regen.mul"_n);
   }
 

--- a/src/seeds.organization.cpp
+++ b/src/seeds.organization.cpp
@@ -74,6 +74,16 @@ void organization::decrease_size_by_one(name id) {
     }
 }
 
+uint64_t config_get (name key) {
+    auto citr = config.find(key.value);
+        if (citr == config.end()) { 
+        // only create the error message string in error case for efficiency
+        eosio::check(false, ("settings: the "+key.to_string()+" parameter has not been initialized").c_str());
+    }
+    return citr->value;
+}
+
+
 void organization::deposit(name from, name to, asset quantity, string memo) {
     if (get_first_receiver() == contracts::token  &&  // from SEEDS token account
         to  ==  get_self() &&                     // to here
@@ -178,13 +188,13 @@ ACTION organization::create(name sponsor, name orgaccount, string orgfullname, s
 {
     require_auth(sponsor);
 
-    auto bitr = sponsors.find(sponsor.value);
-    check(bitr != sponsors.end(), "The sponsor account does not have a balance entry in this contract.");
+    auto sitr = sponsors.find(sponsor.value);
+    check(sitr != sponsors.end(), "The sponsor account does not have a balance entry in this contract.");
 
-    auto feeparam = config.get(min_planted.value, "The org.minplant parameter has not been initialized yet.");
-    asset quantity(feeparam.value, seeds_symbol);
+    asset quantity(config_get("orgminplnt.1"_n), seeds_symbol);
 
-    check(bitr->balance >= quantity, "The user does not have enough credit to create an organization" + bitr->balance.to_string() + " min: "+quantity.to_string());
+    check(sitr->balance >= quantity, 
+        "The user does not have enough credit to create an organization" + sitr->balance.to_string() + " min: "+quantity.to_string());
 
     auto orgitr = organizations.find(orgaccount.value);
     check(orgitr == organizations.end(), "This organization already exists.");
@@ -204,7 +214,7 @@ ACTION organization::create(name sponsor, name orgaccount, string orgfullname, s
     ).send();
 
 
-    sponsors.modify(bitr, _self, [&](auto & mbalance) {
+    sponsors.modify(sitr, _self, [&](auto & mbalance) {
         mbalance.balance -= quantity;           
     });
 
@@ -212,7 +222,7 @@ ACTION organization::create(name sponsor, name orgaccount, string orgfullname, s
         norg.org_name = orgaccount;
         norg.owner = sponsor;
         norg.planted = quantity;
-        norg.status = regular_org;
+        norg.status = status_regular;
     });
 
     addmember(orgaccount, sponsor, sponsor, ""_n);
@@ -483,145 +493,209 @@ ACTION organization::rankregen(uint64_t start, uint64_t chunk, uint64_t chunksiz
     }
 }
 
-uint64_t organization::get_regen_score(name organization) {
-    auto ritr = regenscores.find(organization.value);
-    if (ritr == regenscores.end()) {
-        return 0;
-    }
-    return ritr -> rank;
-}
+// uint64_t organization::get_regen_score(name organization) {
+//     auto ritr = regenscores.find(organization.value);
+//     if (ritr == regenscores.end()) {
+//         return 0;
+//     }
+//     return ritr -> rank;
+// }
 
-uint64_t organization::count_refs(name organization, uint32_t check_num_residents) {
+// uint64_t organization::count_refs(name organization, uint32_t check_num_residents) {
+//     auto refs_by_referrer = refs.get_index<"byreferrer"_n>();
+//     if (check_num_residents == 0) {
+//       return std::distance(refs_by_referrer.lower_bound(organization.value), refs_by_referrer.upper_bound(organization.value));
+//     } else {
+//       uint64_t count = 0;
+//       int residents = 0;
+//       auto ritr = refs_by_referrer.lower_bound(organization.value);
+//       while (ritr != refs_by_referrer.end() && ritr->referrer == organization) {
+//         auto uitr = users.find(ritr->invited.value);
+//         if (uitr != users.end()) {
+//           if (uitr->status == "resident"_n || uitr->status == "citizen"_n) {
+//             residents++;
+//           }
+//         }
+//         ritr++;
+//         count++;
+//       }
+//       check(residents >= check_num_residents, "organization has not referred enough residents or citizens: "+std::to_string(residents));
+//       return count;
+//     }
+// }
+
+// uint64_t organization::count_transactions(name organization) {
+//     auto totals_itr = totals.find(organization.value);
+
+//     if (totals_itr == totals.end()) {
+//         return 0;
+//     }
+
+//     return totals_itr -> total_number_of_transactions;
+// }
+
+void organization::check_referrals (name organization, uint64_t min_visitors_invited, uint64_t min_residents_invited) {
     auto refs_by_referrer = refs.get_index<"byreferrer"_n>();
-    if (check_num_residents == 0) {
-      return std::distance(refs_by_referrer.lower_bound(organization.value), refs_by_referrer.upper_bound(organization.value));
-    } else {
-      uint64_t count = 0;
-      int residents = 0;
-      auto ritr = refs_by_referrer.lower_bound(organization.value);
-      while (ritr != refs_by_referrer.end() && ritr->referrer == organization) {
+
+    uint64_t residents = 0;
+    uint64_t visitors = 0;
+
+    auto ritr = refs_by_referrer.find(organization.value);
+
+    while (ritr != refs_by_referrer.end() && ritr->referrer == organization && residents < min_residents_invited) {
         auto uitr = users.find(ritr->invited.value);
         if (uitr != users.end()) {
           if (uitr->status == "resident"_n || uitr->status == "citizen"_n) {
             residents++;
           }
+          visitors++;
         }
         ritr++;
-        count++;
-      }
-      check(residents >= check_num_residents, "organization has not referred enough residents or citizens: "+std::to_string(residents));
-      return count;
-    }
-}
-
-uint64_t organization::count_transactions(name organization) {
-    auto totals_itr = totals.find(organization.value);
-
-    if (totals_itr == totals.end()) {
-        return 0;
     }
 
-    return totals_itr -> total_number_of_transactions;
+    check(residents >= min_residents_invited, "organization has less than the required number of referred residents");
+    check(visitors >= min_visitors_invited, "organization has less than the required number of referred visitors");
 }
 
-void organization::check_can_make_reputable(name organization) {
+void organization::check_status_requirements (name organization, uint64_t status) {
     auto oitr = organizations.find(organization.value);
-    check(oitr != organizations.end(), "the organization does not exist");
-    check(oitr->status == regular_org, "the organization is not a regular organization");
+    check(oitr != organizations.end(), "organization not found");
 
-    auto bitr = balances.find(organization.value);
+    if (status == status_regular) { return; }
 
-    uint64_t planted_min = get_config(name("rep.minplnt"));
-    uint64_t regen_min_rank = get_config(name("rep.minrank"));
-    uint64_t min_invited = get_config(name("rep.refrred"));
-    uint64_t min_residents_invited = get_config(name("rep.resref"));
-    uint64_t min_trx = get_config(name("rep.mintrx"));
+    // check if the org has the previous status ???
+    check(oitr->status == status-1, "organization is not " + status_names[status-1] + ", it can not become " + status_names[status]);
 
-    uint64_t invited_users_number = count_refs(organization, min_residents_invited);
-    uint64_t regen_score = get_regen_score(organization);
-    uint64_t valid_trxs = count_transactions(organization);
+    string status_str = std::to_string(status+1);
 
-    check(bitr -> planted.amount >= planted_min, "organization has less than the required amount of seeds planted");
-    check(regen_score >= regen_min_rank, "organization has less than the required regenerative score");
-    check(invited_users_number >= min_invited, "organization has less than required referrals. required: " + 
-        std::to_string(min_invited) + " actual: " + std::to_string(invited_users_number));
-    check(valid_trxs >= min_trx, 
-        "organization has exchanged less than the required transactions with other Reputable/Regenerative organizations or Citizens");
+    uint64_t min_planted = config_get(name("orgminplnt." + status_str));
+    uint64_t min_rep_rank = config_get(name("orgminrank." + status_str));
+    uint64_t min_regen_rank = config_get(name("org.rated." + status_str));
+    uint64_t min_visitors_invited = config_get(name("org.visref" + status_str));
+    uint64_t min_residents_invited = config_get(name("org.resref" + status_str));
+
+    auto pitr = planted.get(organization.value, "organization does not have seeds planted");
+    check(pitr.planted >= min_planted, "organization has less than the required amount of seeds planted");
+
+    auto repitr = rep.get(organization.value, "organization does not have reputation");
+    check(repitr.rank >= min_rep_rank, "organization has less than the required reputation rank");
+
+    auto ritr = regenscores.get(organization.value, "organization does not have a regen score");
+    check(ritr.rank >= min_regen_rank, "organization has less than the required regen rank");
+
+    check_referrals(organization, min_visitors_invited, min_residents_invited);
 }
 
-void organization::check_can_make_regen(name organization) {
-    auto oitr = organizations.find(organization.value);
-    check(oitr != organizations.end(), "the organization does not exist");
-    check(oitr->status == reputable_org, "the organization is not reputable");
+// void organization::check_can_make_reputable(name organization) {
+//     auto oitr = organizations.find(organization.value);
+//     check(oitr != organizations.end(), "the organization does not exist");
+//     check(oitr->status == status_regular, "the organization is not a regular organization");
 
-    auto bitr = balances.find(organization.value);
+//     auto bitr = balances.find(organization.value);
 
-    uint64_t planted_min = get_config(name("rgen.minplnt"));
-    uint64_t regen_min_rank = get_config(name("rgen.minrank"));
-    uint64_t min_invited = get_config(name("rgen.refrred"));
-    uint64_t min_residents_invited = get_config(name("rgen.resref"));
-    uint64_t min_trx = get_config(name("rgen.mintrx"));
+//     uint64_t planted_min = get_config(name("rep.minplnt"));
+//     uint64_t regen_min_rank = get_config(name("rep.minrank"));
+//     uint64_t min_invited = get_config(name("rep.refrred"));
+//     uint64_t min_residents_invited = get_config(name("rep.resref"));
+//     uint64_t min_trx = get_config(name("rep.mintrx"));
 
-    uint64_t invited_users_number = count_refs(organization, min_residents_invited);
-    uint64_t regen_score = get_regen_score(organization);
-    uint64_t valid_trxs = count_transactions(organization);
+//     uint64_t invited_users_number = count_refs(organization, min_residents_invited);
+//     uint64_t regen_score = get_regen_score(organization);
+//     uint64_t valid_trxs = count_transactions(organization);
 
-    check(bitr -> planted.amount >= planted_min, "organization has less than the required amount of seeds planted");
-    check(regen_score >= regen_min_rank, "organization has less than the required regenerative score");
-    check(invited_users_number >= min_invited, "organization has less than required referrals. required: " + 
-        std::to_string(min_invited) + " actual: " + std::to_string(invited_users_number));
-    check(valid_trxs >= min_trx, 
-        "organization has exchanged less than the required transactions with other Reputable/Regenerative organizations or Citizens");
-}
+//     check(bitr -> planted.amount >= planted_min, "organization has less than the required amount of seeds planted");
+//     check(regen_score >= regen_min_rank, "organization has less than the required regenerative score");
+//     check(invited_users_number >= min_invited, "organization has less than required referrals. required: " + 
+//         std::to_string(min_invited) + " actual: " + std::to_string(invited_users_number));
+//     check(valid_trxs >= min_trx, 
+//         "organization has exchanged less than the required transactions with other Reputable/Regenerative organizations or Citizens");
+// }
 
-void organization::update_status(name organization, uint64_t status) {
+// void organization::check_can_make_regen(name organization) {
+//     auto oitr = organizations.find(organization.value);
+//     check(oitr != organizations.end(), "the organization does not exist");
+//     check(oitr->status == status_reputable, "the organization is not reputable");
+
+//     auto bitr = balances.find(organization.value);
+
+//     uint64_t planted_min = get_config(name("rgen.minplnt"));
+//     uint64_t regen_min_rank = get_config(name("rgen.minrank"));
+//     uint64_t min_invited = get_config(name("rgen.refrred"));
+//     uint64_t min_residents_invited = get_config(name("rgen.resref"));
+//     uint64_t min_trx = get_config(name("rgen.mintrx"));
+
+//     uint64_t invited_users_number = count_refs(organization, min_residents_invited);
+//     uint64_t regen_score = get_regen_score(organization);
+//     uint64_t valid_trxs = count_transactions(organization);
+
+//     check(bitr -> planted.amount >= planted_min, "organization has less than the required amount of seeds planted");
+//     check(regen_score >= regen_min_rank, "organization has less than the required regenerative score");
+//     check(invited_users_number >= min_invited, "organization has less than required referrals. required: " + 
+//         std::to_string(min_invited) + " actual: " + std::to_string(invited_users_number));
+//     check(valid_trxs >= min_trx, 
+//         "organization has exchanged less than the required transactions with other Reputable/Regenerative organizations or Citizens");
+// }
+
+void organization::update_status (name organization, uint64_t status) {
   auto oitr = organizations.find(organization.value);
-
   check(oitr != organizations.end(), "the organization does not exist");
-  check(status == regenerative_org || status == reputable_org, "invalid organization status");
-
   organizations.modify(oitr, _self, [&](auto& org) {
     org.status = status;
   });
 }
 
-void organization::history_add_regenerative(name organization) {
-    action(
-        permission_level{contracts::history, "active"_n},
-        contracts::history, "addregen"_n,
-        std::make_tuple(organization)
-    ).send();
+void organization::history_update_org_status (name organization, uint64_t status) {
+    // action(
+    //     permission_level(contracts::history, "active"_n),
+    //     contracts::history,
+    //     ""
+    // ).send();
 }
 
-void organization::history_add_reputable(name organization) {
-    action(
-        permission_level{contracts::history, "active"_n},
-        contracts::history, "addreputable"_n,
-        std::make_tuple(organization)
-    ).send();
+// void organization::history_add_regenerative(name organization) {
+//     action(
+//         permission_level{contracts::history, "active"_n},
+//         contracts::history, "addregen"_n,
+//         std::make_tuple(organization)
+//     ).send();
+// }
+
+// void organization::history_add_reputable(name organization) {
+//     action(
+//         permission_level{contracts::history, "active"_n},
+//         contracts::history, "addreputable"_n,
+//         std::make_tuple(organization)
+//     ).send();
+// }
+
+ACTION organization::makethrivble (name organization) {
+    check_status_requirements(organization, status_thrivable);
+    update_status(organization, status_thrivable);
+    history_update_org_status(organization, status_thrivable);
 }
+
 
 ACTION organization::makeregen(name organization) {
     check_can_make_regen(organization);
-    update_status(organization, regenerative_org);
+    update_status(organization, status_sustainable);
     history_add_regenerative(organization);
 }
 
 ACTION organization::makereptable(name organization) {
     check_can_make_reputable(organization);
-    update_status(organization, reputable_org);
+    update_status(organization, status_reputable);
     history_add_reputable(organization);
 }
 
 ACTION organization::testregen(name organization) {
     require_auth(get_self());
-    update_status(organization, regenerative_org);
+    update_status(organization, status_sustainable);
     history_add_regenerative(organization);
 }
 
 ACTION organization::testreptable(name organization) {
     require_auth(get_self());
-    update_status(organization, reputable_org);
+    update_status(organization, status_reputable);
     history_add_reputable(organization);
 }
 

--- a/src/seeds.settings.cpp
+++ b/src/seeds.settings.cpp
@@ -71,35 +71,75 @@ void settings::reset() {
   confwithdesc(name("hrvst.orgs"), 200000, "Percentage of the harvest that Organizations will receive (4 decimals of precision)", high_impact);
   confwithdesc(name("hrvst.global"), 200000, "Percentage of the harvest that Global G-DHO will receive (4 decimals of precision)", high_impact);
   
-  // Organizations
-  confwithdesc(name("org.minplant"), 200 * 10000, "Minimum amount to create an organization (in Seeds)", high_impact);
-  
-  confwithdesc(name("org.minsub"), 7, "Minimum amount of rating points a user can take from an org", high_impact);
-  confwithdesc(name("org.maxadd"), 7, "Maximum amount of rating points a user can give to an org", high_impact);
 
-  // replace this single rating with the below
-  // confwithdesc(name("org.rgen.min"), 1000, "Minimum regen points an organization must have to be ranked", high_impact);
+
+
+  // =====================================
+  // organizations 
+  // =====================================
+
+  confwithdesc(name("orgminplnt.5"), 2000 * 10000, "Minimum planted Seeds to become a Thrivable organization (in Seeds)", medium_impact);
+  confwithdesc(name("orgminplnt.4"), 1000 * 10000, "Minimum planted Seeds to become a Regenerative organization (in Seeds)", medium_impact);
+  confwithdesc(name("orgminplnt.3"), 800 * 10000, "Minimum planted Seeds to become a Sustainable organization (in Seeds)", medium_impact);
+  confwithdesc(name("orgminplnt.2"), 400 * 10000, "Minimum planted Seeds to become a Reputable organization (in Seeds)", medium_impact);
+  confwithdesc(name("orgminplnt.1"), 200 * 10000, "Minimum planted Seeds to create a Regular organization (in Seeds)", medium_impact);
   
+  confwithdesc(name("orgminrank.5"), 90, "Minimum reputation score to become a Thrivable organization", medium_impact);
+  confwithdesc(name("orgminrank.4"), 75, "Minimum reputation score to become a Regenerative organization", medium_impact);
+  confwithdesc(name("orgminrank.3"), 50, "Minimum reputation score to become a Sustainable organization", medium_impact);
+  confwithdesc(name("orgminrank.2"), 20, "Minimum reputation score to become a Reputable organization", medium_impact);
+
   // user rating threshold when an org can become a (reputable/sustainable/regenerative/thrivable) org
   confwithdesc(name("org.rated.5"), 1000, "Thrivable organization rating threshold", low_impact);
   confwithdesc(name("org.rated.4"), 200, "Regenerative organization rating threshold", low_impact);
   confwithdesc(name("org.rated.3"), 100, "Sustainable organization rating threshold", low_impact);
   confwithdesc(name("org.rated.2"), 50, "Reputable organization rating threshold", low_impact);
 
+  confwithdesc(name("org.visref.5"), 100, "Minimum of visitors invited to become a Thrivable organization", medium_impact);
+  confwithdesc(name("org.visref.4"), 50, "Minimum of visitors invited to become a Regenerative organization", medium_impact);
+  confwithdesc(name("org.visref.3"), 10, "Minimum of visitors invited to become a Sustainable organization", medium_impact);
+  confwithdesc(name("org.visref.2"), 1, "Minimum of visitors invited to become a Reputable organization", medium_impact);
 
-  // Resident orgs
-  confwithdesc(name("rep.minplnt"), 400 * 10000, "Minimum amount planted to become a Reputable Organization (in Seeds)", high_impact);
-  confwithdesc(name("rep.minrank"), 50, "Minimum rank an organization must have to become a Reputable Organization", high_impact);
-  confwithdesc(name("rep.refrred"), 10, "Minimum number of referrals to become a Reputable Organization", high_impact);
-  confwithdesc(name("rep.resref"), 5, "Minimum number of residents or citizens referred to become a Reputable Organization", high_impact);
-  confwithdesc(name("rep.mintrx"), 5, "Minimum number of exchanged transactions with Reputable/Regenerative organizations or Citizens to become a Reputable Organization", high_impact);
+  confwithdesc(name("org.resref.5"), 50, "Minimum of residents invited to become a Thrivable organization", medium_impact);
+  confwithdesc(name("org.resref.4"), 25, "Minimum of residents invited to become a Regenerative organization", medium_impact);
+  confwithdesc(name("org.resref.3"), 5, "Minimum of residents invited to become a Sustainable organization", medium_impact);
+  confwithdesc(name("org.resref.2"), 0, "Minimum of residents invited to become a Reputable organization", medium_impact);
 
-  // Regenerative orgs
-  confwithdesc(name("rgen.minplnt"), 400 * 10000, "Minimum amount planted to become a Regenerative Organization (in Seeds)", high_impact);
-  confwithdesc(name("rgen.minrank"), 50, "Minimum rank an organization must have to become a Regenerative Organization", high_impact);
-  confwithdesc(name("rgen.refrred"), 10, "Minimum number of referrals to become a Regenerative Organization", high_impact);
-  confwithdesc(name("rgen.resref"), 5, "Minimum number of residents or citizens referred to become a Regenerative Organization", high_impact);
-  confwithdesc(name("rgen.mintrx"), 5, "Minimum number of exchanged transactions with Reputable/Regenerative organizations or Citizens to become a Regenerative Organization", high_impact);
+  // Organizations
+  // confwithdesc(name("org.minplant"), 200 * 10000, "Minimum amount to create an organization (in Seeds)", high_impact);
+  
+  confwithdesc(name("org.minsub"), 7, "Minimum amount of rating points a user can take from an org", high_impact);
+  confwithdesc(name("org.maxadd"), 7, "Maximum amount of rating points a user can give to an org", high_impact);
+
+  // replace this single rating with the below
+  // confwithdesc(name("org.rgen.min"), 1000, "Minimum regen points an organization must have to be ranked", high_impact);
+
+
+
+  // // Resident orgs
+  // confwithdesc(name("rep.minplnt"), 400 * 10000, "Minimum amount planted to become a Reputable Organization (in Seeds)", high_impact);
+  // confwithdesc(name("rep.minrank"), 50, "Minimum rank an organization must have to become a Reputable Organization", high_impact);
+  // confwithdesc(name("rep.refrred"), 10, "Minimum number of referrals to become a Reputable Organization", high_impact);
+  // confwithdesc(name("rep.resref"), 5, "Minimum number of residents or citizens referred to become a Reputable Organization", high_impact);
+  // confwithdesc(name("rep.mintrx"), 5, "Minimum number of exchanged transactions with Reputable/Regenerative organizations or Citizens to become a Reputable Organization", high_impact);
+
+  // // Regenerative orgs
+  // confwithdesc(name("rgen.minplnt"), 400 * 10000, "Minimum amount planted to become a Regenerative Organization (in Seeds)", high_impact);
+  // confwithdesc(name("rgen.minrank"), 50, "Minimum rank an organization must have to become a Regenerative Organization", high_impact);
+  // confwithdesc(name("rgen.refrred"), 10, "Minimum number of referrals to become a Regenerative Organization", high_impact);
+  // confwithdesc(name("rgen.resref"), 5, "Minimum number of residents or citizens referred to become a Regenerative Organization", high_impact);
+  // confwithdesc(name("rgen.mintrx"), 5, "Minimum number of exchanged transactions with Reputable/Regenerative organizations or Citizens to become a Regenerative Organization", high_impact);
+
+
+
+
+
+
+
+
+
+
+
 
   // Scheduler cycle
   confwithdesc(name("secndstoexec"), 60, "Seconds to execute", high_impact);

--- a/src/seeds.settings.cpp
+++ b/src/seeds.settings.cpp
@@ -72,8 +72,6 @@ void settings::reset() {
   confwithdesc(name("hrvst.global"), 200000, "Percentage of the harvest that Global G-DHO will receive (4 decimals of precision)", high_impact);
   
 
-
-
   // =====================================
   // organizations 
   // =====================================
@@ -105,41 +103,15 @@ void settings::reset() {
   confwithdesc(name("org.resref.3"), 5, "Minimum of residents invited to become a Sustainable organization", medium_impact);
   confwithdesc(name("org.resref.2"), 0, "Minimum of residents invited to become a Reputable organization", medium_impact);
 
-  // Organizations
-  // confwithdesc(name("org.minplant"), 200 * 10000, "Minimum amount to create an organization (in Seeds)", high_impact);
+  conffloatdsc(name("org5trx.mul"), 2.0, "Multiplier received when exchanging with a Thrivable organization", medium_impact);
+  conffloatdsc(name("org4trx.mul"), 1.7, "Multiplier received when exchanging with a Regeneraitve organization", medium_impact);
+  conffloatdsc(name("org3trx.mul"), 1.3, "Multiplier received when exchanging with a Sustainable organization", medium_impact);
+  conffloatdsc(name("org2trx.mul"), 1.0, "Multiplier received when exchanging with a Reputable organization", medium_impact);
+  conffloatdsc(name("org1trx.mul"), 1.0, "Multiplier received when exchanging with a Regular organization", medium_impact);
   
   confwithdesc(name("org.minsub"), 7, "Minimum amount of rating points a user can take from an org", high_impact);
   confwithdesc(name("org.maxadd"), 7, "Maximum amount of rating points a user can give to an org", high_impact);
-
-  // replace this single rating with the below
-  // confwithdesc(name("org.rgen.min"), 1000, "Minimum regen points an organization must have to be ranked", high_impact);
-
-
-
-  // // Resident orgs
-  // confwithdesc(name("rep.minplnt"), 400 * 10000, "Minimum amount planted to become a Reputable Organization (in Seeds)", high_impact);
-  // confwithdesc(name("rep.minrank"), 50, "Minimum rank an organization must have to become a Reputable Organization", high_impact);
-  // confwithdesc(name("rep.refrred"), 10, "Minimum number of referrals to become a Reputable Organization", high_impact);
-  // confwithdesc(name("rep.resref"), 5, "Minimum number of residents or citizens referred to become a Reputable Organization", high_impact);
-  // confwithdesc(name("rep.mintrx"), 5, "Minimum number of exchanged transactions with Reputable/Regenerative organizations or Citizens to become a Reputable Organization", high_impact);
-
-  // // Regenerative orgs
-  // confwithdesc(name("rgen.minplnt"), 400 * 10000, "Minimum amount planted to become a Regenerative Organization (in Seeds)", high_impact);
-  // confwithdesc(name("rgen.minrank"), 50, "Minimum rank an organization must have to become a Regenerative Organization", high_impact);
-  // confwithdesc(name("rgen.refrred"), 10, "Minimum number of referrals to become a Regenerative Organization", high_impact);
-  // confwithdesc(name("rgen.resref"), 5, "Minimum number of residents or citizens referred to become a Regenerative Organization", high_impact);
-  // confwithdesc(name("rgen.mintrx"), 5, "Minimum number of exchanged transactions with Reputable/Regenerative organizations or Citizens to become a Regenerative Organization", high_impact);
-
-
-
-
-
-
-
-
-
-
-
+  confwithdesc(name("orgratethrsh"), 100, "Minimum rating points an organization needs to earn to start being ranked", medium_impact);
 
   // Scheduler cycle
   confwithdesc(name("secndstoexec"), 60, "Seconds to execute", high_impact);

--- a/test/history.test.js
+++ b/test/history.test.js
@@ -814,7 +814,7 @@ describe('individual transactions', async assert => {
   await contracts.organization.create(seconduser, secondorg, "Org Number 2", eosDevKey, { authorization: `${seconduser}@active` })
   await contracts.accounts.testsetrs(firstorg, 49, { authorization: `${accounts}@active` })
   await contracts.accounts.testsetrs(secondorg, 49, { authorization: `${accounts}@active` })
-  await contracts.organization.testregen(firstorg, { authorization: `${organization}@active` })
+  await contracts.organization.teststatus(firstorg, 4, { authorization: `${organization}@active` })
     
   console.log('add bioregions')
   const keypair = await createKeypair();

--- a/test/organization.test.js
+++ b/test/organization.test.js
@@ -1,8 +1,8 @@
 const { describe } = require("riteway")
-const { eos, encodeName, getBalance, getBalanceFloat, names, getTableRows, isLocal, initContracts } = require("../scripts/helper")
-const { equals } = require("ramda")
+const { eos, encodeName, getBalance, getBalanceFloat, names, getTableRows, isLocal, initContracts, ramdom64ByteHexString, sha256, fromHexString } = require("../scripts/helper")
+const { equals, any, or } = require("ramda")
 
-const { organization, accounts, token, firstuser, seconduser, thirduser, bank, settings, harvest, history, exchange } = names
+const { organization, accounts, token, firstuser, seconduser, thirduser, fourthuser, fifthuser, bank, settings, harvest, history, exchange, onboarding } = names
 
 let eosDevKey = "EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV"
 
@@ -13,7 +13,18 @@ function getBeginningOfDayInSeconds () {
 
 function sleep(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
-}  
+}
+
+const randomAccountName = () => {
+    let length = 12
+    var result           = '';
+    var characters       = 'abcdefghijklmnopqrstuvwxyz1234';
+    var charactersLength = characters.length;
+    for ( var i = 0; i < length; i++ ) {
+       result += characters.charAt(Math.floor(Math.random() * charactersLength));
+    }
+    return result;
+}
 
 describe('organization', async assert => {
 
@@ -54,8 +65,8 @@ describe('organization', async assert => {
     await contracts.accounts.adduser(seconduser, 'second user', 'individual', { authorization: `${accounts}@active` })
 
     console.log('add rep')
-    await contracts.accounts.addrep(firstuser, 10000, { authorization: `${accounts}@active` })
-    await contracts.accounts.addrep(seconduser, 13000, { authorization: `${accounts}@active` })
+    await contracts.accounts.testsetrs(firstuser, 49, { authorization: `${accounts}@active` })
+    await contracts.accounts.testsetrs(seconduser, 99, { authorization: `${accounts}@active` })
 
     console.log('create balance')
     await contracts.token.transfer(firstuser, organization, "400.0000 SEEDS", "Initial supply", { authorization: `${firstuser}@active` })
@@ -141,8 +152,8 @@ describe('organization', async assert => {
     })
 
     console.log('add regen')
-    // await contracts.organization.addregen('testorg1', firstuser, 1, { authorization: `${firstuser}@active` })
-    // await contracts.organization.subregen('testorg3', seconduser, 1, { authorization: `${seconduser}@active` })
+    await contracts.organization.addregen('testorg1', firstuser, 15, { authorization: `${firstuser}@active` })
+    await contracts.organization.subregen('testorg3', seconduser, 1, { authorization: `${seconduser}@active` })
     
     const regen = await getTableRows({
         code: organization,
@@ -339,7 +350,7 @@ describe('organization', async assert => {
                 org_name: 'testorg1',
                 owner: 'seedsuseraaa',
                 status: 0,
-                regen: 10000,
+                regen: 6,
                 reputation: 0,
                 voice: 0,
                 planted: "200.0000 SEEDS"
@@ -348,7 +359,7 @@ describe('organization', async assert => {
                 org_name: 'testorg3',
                 owner: 'seedsuseraaa',
                 status: 0,
-                regen: -13000,
+                regen: -2,
                 reputation: 0,
                 voice: 0,
                 planted: "200.0000 SEEDS"
@@ -623,7 +634,8 @@ describe('organization scores', async assert => {
     }))
     
     console.log('settings reset')
-    //await contracts.settings.reset({ authorization: `${settings}@active` })
+    await contracts.settings.reset({ authorization: `${settings}@active` })
+    await contracts.settings.configure('orgratethrsh', 0, { authorization: `${settings}@active` })
 
     console.log('reset organization')
     await contracts.organization.reset({ authorization: `${organization}@active` })
@@ -658,13 +670,9 @@ describe('organization scores', async assert => {
     await contracts.accounts.adduser(thirduser, 'third user', 'individual', { authorization: `${accounts}@active` })
 
     console.log('add rep')
-    await contracts.accounts.addrep(firstuser, 20000, { authorization: `${accounts}@active` })
-    await contracts.accounts.addrep(seconduser, 13000, { authorization: `${accounts}@active` })
-    await contracts.accounts.addrep(thirduser, 1000, { authorization: `${accounts}@active` })
-
-    await contracts.accounts.testsetrs(firstuser, 66, { authorization: `${accounts}@active` })
-    await contracts.accounts.testsetrs(seconduser, 33, { authorization: `${accounts}@active` })
-    await contracts.accounts.testsetrs(thirduser, 0, { authorization: `${accounts}@active` })
+    await contracts.accounts.testsetrs(firstuser, 99, { authorization: `${accounts}@active` })
+    await contracts.accounts.testsetrs(seconduser, 66, { authorization: `${accounts}@active` })
+    await contracts.accounts.testsetrs(thirduser, 33, { authorization: `${accounts}@active` })
     
     console.log('create balance')
     await contracts.token.transfer(firstuser, organization, "400.0000 SEEDS", "Initial supply", { authorization: `${firstuser}@active` })
@@ -678,27 +686,29 @@ describe('organization scores', async assert => {
     await contracts.organization.create(seconduser, org5, "Org 5 - Test, Inc.", eosDevKey, { authorization: `${seconduser}@active` })
 
     console.log('modify regen')
-    // await contracts.organization.subregen(org1, firstuser, 2, { authorization: `${firstuser}@active` })
-    // await contracts.organization.subregen(org1, seconduser, 3, { authorization: `${seconduser}@active` })
+    await contracts.organization.subregen(org1, firstuser, 1, { authorization: `${firstuser}@active` })
+    await contracts.organization.subregen(org1, seconduser, 1, { authorization: `${seconduser}@active` })
 
-    // await contracts.organization.addregen(org2, firstuser, 4, { authorization: `${firstuser}@active` })
-    // await contracts.organization.addregen(org2, seconduser, 4, { authorization: `${seconduser}@active` })
+    await contracts.organization.addregen(org2, firstuser, 4, { authorization: `${firstuser}@active` })
+    await contracts.organization.addregen(org2, seconduser, 3, { authorization: `${seconduser}@active` })
 
-    // await contracts.organization.addregen(org3, firstuser, 1, { authorization: `${firstuser}@active` })
-    // await contracts.organization.subregen(org3, seconduser, 1, { authorization: `${seconduser}@active` })
-    // await contracts.organization.subregen(org3, thirduser, 1, { authorization: `${thirduser}@active` })
+    await contracts.organization.addregen(org3, firstuser, 6, { authorization: `${firstuser}@active` })
+    await contracts.organization.subregen(org3, seconduser, 6, { authorization: `${seconduser}@active` })
+    await contracts.organization.subregen(org3, thirduser, 6, { authorization: `${thirduser}@active` })
 
-    // await contracts.organization.addregen(org4, firstuser, 2, { authorization: `${firstuser}@active` })
-    // await contracts.organization.addregen(org4, seconduser, 2, { authorization: `${seconduser}@active` })
+    await contracts.organization.addregen(org4, firstuser, 7, { authorization: `${firstuser}@active` })
+    await contracts.organization.addregen(org4, seconduser, 5, { authorization: `${seconduser}@active` })
 
-    // await contracts.organization.addregen(org5, firstuser, 7, { authorization: `${firstuser}@active` })
-    // await contracts.organization.addregen(org5, seconduser, 7, { authorization: `${seconduser}@active` })
+    await contracts.organization.addregen(org5, firstuser, 12, { authorization: `${firstuser}@active` })
+    await contracts.organization.addregen(org5, seconduser, 12, { authorization: `${seconduser}@active` })
     
     await contracts.accounts.testsetcbs(org1, 100, { authorization: `${accounts}@active` })
     await contracts.accounts.testsetcbs(org2, 75, { authorization: `${accounts}@active` })
     await contracts.accounts.testsetcbs(org3, 50, { authorization: `${accounts}@active` })
     await contracts.accounts.testsetcbs(org4, 25, { authorization: `${accounts}@active` })
     await contracts.accounts.testsetcbs(org5, 1, { authorization: `${accounts}@active` })
+
+    Promise.all(orgs.map(org => contracts.accounts.testsetrs(org, 49, { authorization: `${accounts}@active` })))
 
     await contracts.accounts.rankorgreps({ authorization: `${accounts}@active` })
     await sleep(200)
@@ -734,7 +744,6 @@ describe('organization scores', async assert => {
     await transfer(org5, seconduser, 200)
     await transfer(org5, thirduser, 200)
 
-    // let txt = await contracts.organization.scoreorgs("", { authorization: `${organization}@active` })
     await contracts.harvest.calctrxpts({ authorization: `${harvest}@active` })
     await sleep(100)
 
@@ -750,7 +759,15 @@ describe('organization scores', async assert => {
         table: 'txpoints',
         json: true
     })
-    console.log('prro:', orgTxScore)
+    console.log('orgTxScore:', orgTxScore)
+
+    const orgsTable = await getTableRows({
+        code: organization,
+        scope: organization,
+        table: 'organization',
+        json: true
+    })
+    console.log(orgsTable)
 
     const regenScores = await getTableRows({
         code: organization,
@@ -758,6 +775,7 @@ describe('organization scores', async assert => {
         table: 'regenscores',
         json: true
     })
+    console.log('Regen Scores:', regenScores)
 
     const cbsRanks = await getTableRows({
         code: accounts,
@@ -780,7 +798,7 @@ describe('organization scores', async assert => {
         json: true
     })
 
-    // await contracts.organization.addregen(org1, firstuser, 10, { authorization: `${firstuser}@active` })
+    await contracts.organization.addregen(org1, firstuser, 10, { authorization: `${firstuser}@active` })
     
     const avgsAfter = await getTableRows({
         code: organization,
@@ -811,10 +829,10 @@ describe('organization scores', async assert => {
         should: 'rank the orgs properly',
         actual: regenScores.rows,
         expected: [
-            { org_name: org2, regen_avg: 66000, rank: 50 },
-            { org_name: org3, regen_avg: 2000, rank: 0 },
-            { org_name: org4, regen_avg: 33000, rank: 25 },
-            { org_name: org5, regen_avg: 115500, rank: 75 }
+            { org_name: org2, regen_avg: 6, rank: 25 },
+            { org_name: org3, regen_avg: 0, rank: 0 },
+            { org_name: org4, regen_avg: 10, rank: 50 },
+            { org_name: org5, regen_avg: 11, rank: 75 }
         ]
     })
 
@@ -823,26 +841,26 @@ describe('organization scores', async assert => {
         should: 'rank the orgs properly',
         actual: cbsRanks.rows,
         expected: [
-            { org_name: org1, community_building_score: 100, rank: 80 },
-            { org_name: org2, community_building_score: 75, rank: 60 },
-            { org_name: org3, community_building_score: 50, rank: 40 },
-            { org_name: org4, community_building_score: 25, rank: 20 },
-            { org_name: org5, community_building_score: 1, rank: 0 }
+            { account: org1, community_building_score: 100, rank: 80 },
+            { account: org2, community_building_score: 75, rank: 60 },
+            { account: org3, community_building_score: 50, rank: 40 },
+            { account: org4, community_building_score: 25, rank: 20 },
+            { account: org5, community_building_score: 1, rank: 0 }
         ]
     })
 
-    console.log('cbs', cbsRanks.rows)
+    // console.log('cbs', cbsRanks.rows)
 
     assert({
         given: 'txs calculated',
         should: 'rank thr orgs properly',
         actual: txRanks.rows,
         expected: [
-            { account: org1, points: 301, rank: 0 },
-            { account: org2, points: 601, rank: 20 },
-            { account: org3, points: 1201, rank: 40 },
-            { account: org4, points: 1534, rank: 60 },
-            { account: org5, points: 1601, rank: 80 }
+            { account: org1, points: 501, rank: 0 },
+            { account: org2, points: 1001, rank: 20 },
+            { account: org3, points: 2001, rank: 40 },
+            { account: org4, points: 2600, rank: 60 },
+            { account: org5, points: 2935, rank: 80 }      
         ]
     })
     console.log('trxs', txRanks.rows)
@@ -853,34 +871,34 @@ describe('organization scores', async assert => {
         actual: avgsBefore.rows,
         expected: [
             {
-                org_name: 'testorg1',
-                total_sum: -79000,
+                org_name: org1,
+                total_sum: -3,
                 num_votes: 2,
-                average: -39500
+                average: -1
             },
             {
-                org_name: 'testorg2',
-                total_sum: 132000,
+                org_name: org2,
+                total_sum: 12,
                 num_votes: 2,
-                average: 66000
+                average: 6
             },
             {
-                org_name: 'testorg3',
-                total_sum: 6000,
+                org_name: org3,
+                total_sum: 0,
                 num_votes: 3,
-                average: 2000
+                average: 0
             },
             {
-                org_name: 'testorg4',
-                total_sum: 66000,
+                org_name: org4,
+                total_sum: 20,
                 num_votes: 2,
-                average: 33000
+                average: 10
             },
             {
-                org_name: 'testorg5',
-                total_sum: 231000,
+                org_name: org5,
+                total_sum: 23,
                 num_votes: 2,
-                average: 115500
+                average: 11
             }
         ]
     })
@@ -891,34 +909,34 @@ describe('organization scores', async assert => {
         actual: avgsAfter.rows,
         expected: [
             {
-                org_name: 'testorg1',
-                total_sum: 101000,
+                org_name: org1,
+                total_sum: 13,
                 num_votes: 2,
-                average: 50500
+                average: 6
             },
             {
-                org_name: 'testorg2',
-                total_sum: 132000,
+                org_name: org2,
+                total_sum: 12,
                 num_votes: 2,
-                average: 66000
+                average: 6
             },
             {
-                org_name: 'testorg3',
-                total_sum: 6000,
+                org_name: org3,
+                total_sum: 0,
                 num_votes: 3,
-                average: 2000
+                average: 0
             },
             {
-                org_name: 'testorg4',
-                total_sum: 66000,
+                org_name: org4,
+                total_sum: 20,
                 num_votes: 2,
-                average: 33000
+                average: 10
             },
             {
-                org_name: 'testorg5',
-                total_sum: 231000,
+                org_name: org5,
+                total_sum: 23,
                 num_votes: 2,
-                average: 115500
+                average: 11
             }
         ]
     })
@@ -926,22 +944,171 @@ describe('organization scores', async assert => {
 })
 
 describe('organization status', async assert => {
+
     if (!isLocal()) {
         console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
         return
     }
 
-    const contracts = await Promise.all([
-        eos.contract(organization),
-        eos.contract(token),
-        eos.contract(accounts),
-        eos.contract(settings),
-        eos.contract(harvest),
-        eos.contract(history),
-        eos.contract(exchange)
-    ]).then(([organization, token, accounts, settings, harvest, history, exchange]) => ({
-        organization, token, accounts, settings, harvest, history, exchange
-    }))
+    const contracts = await initContracts({ organization, settings, harvest, accounts, token, exchange, onboarding, history })
+
+    const checkOrgStatus = async (expectedStatus, n=null) => {
+        const orgTable = await getTableRows({
+            code: organization,
+            scope: organization,
+            table: 'organization',
+            json: true
+        })
+        assert({
+            given: 'orgs changed status' + (n==null ? '' : ` (index ${n})`),
+            should: 'have the correct status',
+            actual: orgTable.rows.map(r => r.status),
+            expected: expectedStatus
+        })
+    }
+
+    const minPlanted = 'orgminplnt.'
+    const minRepRank = 'orgminrank.'
+    const minRegenScore = 'org.rated.'
+    const minVisitor = 'org.visref.'
+    const minResidents = 'org.resref.'
+
+    const org1 = 'testorg1'
+    const org2 = 'testorg2'
+    const org3 = 'testorg3'
+    const org4 = 'testorg4'
+    const org5 = 'testorg5'
+
+    const regular = 0
+    const reputable = 1
+    const sustainable = 2
+    const regenerative = 3
+    const thrivable = 4
+
+    const statusStrings = ['regular', 'reputable', 'sustainable', 'regenerative', 'thrivable']
+
+    const orgs = [ org1, org2, org3, org4, org5 ]
+
+    const users = [firstuser, seconduser, thirduser, fourthuser, fifthuser]
+
+    const getSetting = async (key) => {
+        const sttgs = await getTableRows({
+            code: settings,
+            scope: settings,
+            table: 'config',
+            json: true,
+            limit: 10000
+        })
+        const param = sttgs.rows.filter(r => r.param == key)
+        return param[0].value
+    }
+
+    const makeStatus = async (org, status, ignore=[]) => {
+        if (!ignore.includes(minPlanted)) {
+            const mPlanted = (await getSetting(minPlanted + (status+1))) / 10000
+            await contracts.token.transfer(firstuser, org, `${mPlanted}.0000 SEEDS`, "for harvest", { authorization: `${firstuser}@active` })
+            await contracts.token.transfer(org, harvest, `${mPlanted}.0000 SEEDS`, `sow ${org}`, { authorization: `${org}@active` })
+        }
+        if (!ignore.includes(minRepRank)) {
+            const mRepRank = await getSetting(minRepRank + (status+1))
+            await contracts.accounts.testsetrs(org, mRepRank, { authorization: `${accounts}@active` })
+        }
+        if (!ignore.includes(minRegenScore)) {
+            const mRegenScore = await getSetting(minRegenScore + (status+1))
+            await contracts.organization.testregensc(org, mRegenScore, { authorization: `${organization}@active` })
+        }
+        if (!ignore.includes(minVisitor)) {
+            const mVisitor = await getSetting(minVisitor + (status+1))
+            const refsTable = await getTableRows({
+                code: settings,
+                scope: settings,
+                table: 'config',
+                json: true
+            })
+            const orgRefs = refsTable.rows.filter(r => r.referrer == org)
+
+            for (let i = orgRefs.length; i < mVisitor; i++) {
+                const inviteSecret = await ramdom64ByteHexString()
+                const inviteHash = sha256(fromHexString(inviteSecret)).toString('hex')
+                const newAccount = randomAccountName()
+                await contracts.token.transfer(seconduser, org, '15.0000 SEEDS', '', { authorization: `${seconduser}@active` })
+                await contracts.token.transfer(org, onboarding, '15.0000 SEEDS', '', { authorization: `${org}@active` })
+                await contracts.onboarding.invite(org, '10.0000 SEEDS', '5.0000 SEEDS', inviteHash, { authorization: `${org}@active` })
+                await contracts.onboarding.accept(newAccount, inviteSecret, eosDevKey, { authorization: `${onboarding}@active` })
+            }
+        }
+        if (!ignore.includes(minResidents)) {
+            const mResidents = await getSetting(minResidents + (status+1))
+            const refsTable = await getTableRows({
+                code: accounts,
+                scope: accounts,
+                table: 'refs',
+                json: true,
+                limit: 10000
+            })
+            const orgRefs = refsTable.rows.filter(r => r.referrer == org).map(r => r.invited)
+            const usersTable = await getTableRows({
+                code: accounts,
+                scope: accounts,
+                table: 'users',
+                json: true,
+                limit: 10000
+            })
+            const usrs = usersTable.rows.filter(r => orgRefs.includes(r.account))
+            usrs.sort((a, b) => {
+                if (a.status == 'visitor') {
+                    return 1
+                }
+                return -1
+            })
+            for (let i=0, j=0; i < usrs.length; i++) {
+                if (usrs[i].status == 'visitor') {
+                    if (j < mResidents) {
+                        await contracts.accounts.testresident(usrs[i].account, { authorization: `${accounts}@active` })
+                    }
+                }
+                j += 1
+            }
+        }
+    }
+
+    const handleError = (wrapped) => {
+        return async function() {
+            try {
+                await wrapped.apply(this, arguments);
+                return false
+            } catch (err) {
+                console.log(err.json.error.details[0])
+                return true
+            }
+        }
+    }
+
+    const assertFailure = async ({ given, should, actual }) => {
+        assert({
+            given,
+            should,
+            actual,
+            expected: true
+        })
+    }
+
+    const checkHistoryRecords = async (scope, expected) => {
+        const historyTables = await getTableRows({
+            code: history,
+            scope: scope,
+            table: 'acctstatus',
+            json: true,
+            limit: 10000
+        })
+        const entries = historyTables.rows.map(r => r.account)
+        assert({
+            given: 'orgs updated status',
+            should: 'be in the entries',
+            actual: entries,
+            expected
+        })
+    }
 
     console.log('reset token stats')
     await contracts.token.resetweekly({ authorization: `${token}@active` })
@@ -950,152 +1117,160 @@ describe('organization status', async assert => {
     await contracts.exchange.reset({ authorization: `${exchange}@active` })
     await contracts.exchange.initrounds( 10 * 10000, "90.9091 SEEDS", { authorization: `${exchange}@active` })
 
-    console.log('configure')
-    //await contracts.settings.reset({ authorization: `${settings}@active` })
+    console.log('reset settings')
+    await contracts.settings.reset({ authorization: `${settings}@active` })
+    await contracts.settings.configure('txlimit.min', 1000, { authorization: `${settings}@active` })
 
-    const org1 = 'testorg1'
-    const org2 = 'testorg2'
-    const org3 = 'testorg3'
+    console.log('reset accounts')
+    await contracts.accounts.reset({ authorization: `${accounts}@active` })
 
-    let hasLessInvitationsResidents
-    try {
-        await contracts.organization.makeregen(org2, { authorization: `${organization}@active` })
-        hasLessInvitationsResidents = false
-    } catch (err) {
-        hasLessInvitationsResidents = true
+    console.log('reset harvest')
+    await contracts.harvest.reset({ authorization: `${harvest}@active` })
+
+    console.log('reset organization')
+    await contracts.organization.reset({ authorization: `${organization}@active` })
+
+    console.log('reset onboarding')
+    await contracts.onboarding.reset({ authorization: `${onboarding}@active` })
+
+
+    orgs.map(async org => { await contracts.history.reset(org, { authorization: `${history}@active` }) })
+    users.map( async user => { await contracts.history.reset(user, { authorization: `${history}@active` }) })
+
+    const day = getBeginningOfDayInSeconds()
+    await contracts.history.deldailytrx(day, { authorization: `${history}@active` })
+
+    console.log('join users')
+    await Promise.all(users.map(user => contracts.accounts.adduser(user, user, 'individual', { authorization: `${accounts}@active` })))
+
+    console.log('create organizations')
+    for (let index = 0; index < orgs.length; index++) {
+        const user = users[index%2]
+        const org = orgs[index]
+        await contracts.token.transfer(user, organization, "200.0000 SEEDS", "Initial supply", { authorization: `${user}@active` })
+        await contracts.organization.create(user, org, `Org Number ${index}`, eosDevKey, { authorization: `${user}@active` })
     }
 
-    await contracts.settings.configure('rep.resref', 1, { authorization: `${settings}@active` })
+    await checkOrgStatus([regular, regular, regular, regular, regular])
 
-    await contracts.accounts.addref(org2, firstuser, { authorization: `${accounts}@api` })
-    await contracts.accounts.addref(org2, seconduser, { authorization: `${accounts}@api` })
-    await contracts.accounts.addref(org2, thirduser, { authorization: `${accounts}@api` })
-    await contracts.accounts.testcitizen(seconduser, { authorization: `${accounts}@active` })
+    const makereptableWithError = handleError(contracts.organization.makereptable)
+    const makesustnbleWithError = handleError(contracts.organization.makesustnble)
+    const makeregenWithError = handleError(contracts.organization.makeregen)
+    const makethrivbleWithError = handleError(contracts.organization.makethrivble)
 
-    let hasLessSeeds
-    try {
-        await contracts.organization.makereptable(org2, { authorization: `${organization}@active` })
-        hasLessSeeds = false
-    } catch (err) {
-        hasLessSeeds = true
+    const ignore = [minPlanted, minRepRank, minRegenScore, minVisitor, minResidents]
+
+    console.log('trying to update status without meeting the requirements')
+    for (let i = 0; i < ignore.length-1; i++) {
+        await makeStatus(org1, reputable, ignore.slice(i))
+        await assertFailure({
+            given: `${org1} trying to upgrade to ${statusStrings[reputable]}`,
+            should: 'fail',
+            actual: await makereptableWithError(org1, { authorization: `${org1}@active` })
+        })
     }
 
-    await contracts.token.transfer(seconduser, org2, "200.0000 SEEDS", "Regen supply", { authorization: `${seconduser}@active` })
-    await contracts.token.transfer(org2, harvest, "200.0000 SEEDS", `sow ${org2}`, { authorization: `${org2}@active` })
+    console.log(`make ${org1} ${statusStrings[reputable]}`)
+    await makeStatus(org1, reputable)
+    await makereptableWithError(org1, { authorization: `${org1}@active` })
+    await checkOrgStatus([reputable, regular, regular, regular, regular])
+    await checkHistoryRecords(statusStrings[reputable], [org1])
 
-    let hasLessInvitations
-    try {
-        await contracts.organization.makereptable(org2, { authorization: `${organization}@active` })
-        hasLessInvitations = false
-    } catch (err) {
-        hasLessInvitations = true
+    console.log(`make ${org1} regenerative`)
+    await makeStatus(org1, regenerative)
+    await assertFailure({
+        given: `${org1} trying to upgrade to ${statusStrings[regenerative]}`,
+        should: `fail because ${org1} is not ${statusStrings[sustainable]}`,
+        actual: await makeregenWithError(org1, { authorization: `${org1}@active` })
+    })
+    await makesustnbleWithError(org1, { authorization: `${org1}@active` })
+    await checkOrgStatus([sustainable, regular, regular, regular, regular])
+    await checkHistoryRecords(statusStrings[sustainable], [org1])
+
+    await contracts.organization.makeregen(org1, { authorization: `${org1}@active` })
+    await checkOrgStatus([regenerative, regular, regular, regular, regular])
+    await checkHistoryRecords(statusStrings[regenerative], [org1])
+
+    console.log()
+    for (let i = 0; i < ignore.length-1; i++) {
+        await makeStatus(org2, thrivable, ignore.slice(i))
+        await assertFailure({
+            given: `${org2} trying to upgrade to ${statusStrings[thrivable]}`,
+            should: 'fail',
+            actual: await makereptableWithError(org2, { authorization: `${org2}@active` })
+        })
+    }
+    await makeStatus(org2, thrivable)
+    
+    await contracts.organization.makereptable(org2, { authorization: `${org2}@active` })
+    await checkHistoryRecords(statusStrings[reputable], [org1, org2])
+
+    await contracts.organization.makesustnble(org2, { authorization: `${org2}@active` })
+    await checkHistoryRecords(statusStrings[sustainable], [org1, org2])
+
+    await contracts.organization.makeregen(org2, { authorization: `${org2}@active` })
+    await checkHistoryRecords(statusStrings[regenerative], [org1, org2])
+
+    await contracts.organization.makethrivble(org2, { authorization: `${org2}@active` })
+    await checkHistoryRecords(statusStrings[thrivable], [org2])
+
+    await checkOrgStatus([regenerative, thrivable, regular, regular, regular])
+
+    const checkTrxpoints = async (user, expectedValue) => {
+        const trxtables = await getTableRows({
+            code: history,
+            scope: day,
+            table: 'dailytrxs',
+            json: true,
+            limit: 10000
+        })
+        const orgTrx = trxtables.rows.filter(r => r.from == user)
+        assert({
+            given: 'org with status',
+            should: 'use its multiplier',
+            actual: orgTrx[orgTrx.length-1].from_points,
+            expected: parseInt(Math.ceil(expectedValue))
+        })
     }
 
-    await contracts.settings.configure('rep.refrred', 3, { authorization: `${settings}@active` })
+    console.log('transfer to org')
+    await contracts.accounts.testsetrs(fourthuser, 49, { authorization: `${accounts}@active` })
+    await makeStatus(org5, thrivable)
 
-    let hasLessTransactions
-    try {
-        await contracts.organization.makereptable(org2, { authorization: `${organization}@active` })
-        hasLessTransactions = false
-    } catch (err) {
-        hasLessTransactions = true
-    }
+    const multiplier = 0.98989898989899
 
-    console.log('test reputable')
+    await contracts.accounts.testsetrs(org5, 49, { authorization: `${accounts}@active` })
+    await contracts.token.transfer(fourthuser, org5, "100.0000 SEEDS", "Initial supply 1", { authorization: `${fourthuser}@active` })
+    await sleep(3000)
+    await checkTrxpoints(fourthuser, 100 * multiplier * 1.0)
 
-    await contracts.organization.testregen(org1, { authorization: `${organization}@active` })
-    await contracts.organization.testreptable(org3, { authorization: `${organization}@active` })
+    await makeStatus(org5, reputable)
+    await contracts.organization.makereptable(org5, { authorization: `${org5}@active` })
+    await contracts.accounts.testsetrs(org5, 49, { authorization: `${accounts}@active` })
+    await contracts.token.transfer(fourthuser, org5, "110.0000 SEEDS", "Initial supply 2", { authorization: `${fourthuser}@active` })
+    await sleep(3000)
+    await checkTrxpoints(fourthuser, 110 * multiplier * 1.0)
 
-    await contracts.token.transfer(seconduser, org2, "10.0000 SEEDS", "Regen supply", { authorization: `${seconduser}@active` })
-    await contracts.token.transfer(org2, seconduser, "2.0000 SEEDS", '', { authorization: `${org2}@active` })
-    await sleep(300)
-    await contracts.token.transfer(org2, seconduser, "2.0000 SEEDS", '', { authorization: `${org2}@active` })
-    await sleep(300)
-    await contracts.token.transfer(org2, seconduser, "2.0000 SEEDS", '', { authorization: `${org2}@active` })
-    await sleep(300)
-    await contracts.token.transfer(org2, org1, "2.0000 SEEDS", '', { authorization: `${org2}@active` })
-    await sleep(300)
-    await contracts.token.transfer(org2, org3, "2.0000 SEEDS", '', { authorization: `${org2}@active` })
-    await sleep(300)
+    await makeStatus(org5, sustainable)
+    await contracts.organization.makesustnble(org5, { authorization: `${org5}@active` })
+    await contracts.accounts.testsetrs(org5, 49, { authorization: `${accounts}@active` })
+    await contracts.token.transfer(fourthuser, org5, "120.0000 SEEDS", "Initial supply 3", { authorization: `${fourthuser}@active` })
+    await sleep(3000)
+    await checkTrxpoints(fourthuser, 120 * multiplier * 1.3)
 
-    console.log('make reputable')
+    await makeStatus(org5, regenerative)
+    await contracts.organization.makeregen(org5, { authorization: `${org5}@active` })
+    await contracts.accounts.testsetrs(org5, 49, { authorization: `${accounts}@active` })
+    await contracts.token.transfer(fourthuser, org5, "130.0000 SEEDS", "Initial supply 4", { authorization: `${fourthuser}@active` })
+    await sleep(3000)
+    await checkTrxpoints(fourthuser, 130 * multiplier * 1.7)
 
-    await contracts.organization.makereptable(org2, { authorization: `${organization}@active` })
-
-    const organizationsReputable = await getTableRows({
-        code: organization,
-        scope: organization,
-        table: 'organization',
-        json: true
-    })
-
-    await contracts.settings.configure('rgen.resref', 1, { authorization: `${settings}@active` })
-    await contracts.settings.configure('rgen.refrred', 3, { authorization: `${settings}@active` })
-
-    console.log('make regen')
-
-    await contracts.organization.makeregen(org2, { authorization: `${organization}@active` })
-
-    const organizationsRegen = await getTableRows({
-        code: organization,
-        scope: organization,
-        table: 'organization',
-        json: true
-    })
-
-    assert({
-        given: 'makereptable called without enough invitations for citizens/residents',
-        should: 'fail',
-        actual: hasLessInvitationsResidents,
-        expected: true
-    })
-
-    assert({
-        given: 'makereptable called without enough seeds',
-        should: 'fail',
-        actual: hasLessSeeds,
-        expected: true
-    })
-
-    assert({
-        given: 'makereptable called without enough invitations',
-        should: 'fail',
-        actual: hasLessInvitations,
-        expected: true
-    })
-
-    assert({
-        given: 'makereptable called without enough transactions',
-        should: 'fail',
-        actual: hasLessTransactions,
-        expected: true
-    })
-
-    assert({
-        given: 'makereptable called',
-        should: 'give reputable status',
-        actual: organizationsReputable.rows.map(org => org.status),
-        expected: [
-            2,
-            1,
-            1,
-            0,
-            0
-        ]
-    })
-
-    assert({
-        given: 'makeregen called',
-        should: 'give regenerative status',
-        actual: organizationsRegen.rows.map(org => org.status),
-        expected: [
-            2,
-            2,
-            1,
-            0,
-            0
-        ]
-    })
+    await makeStatus(org5, thrivable)
+    await contracts.organization.makethrivble(org5, { authorization: `${org5}@active` })
+    await contracts.accounts.testsetrs(org5, 49, { authorization: `${accounts}@active` })
+    await contracts.token.transfer(fourthuser, org5, "140.0000 SEEDS", "Initial supply 5", { authorization: `${fourthuser}@active` })
+    await sleep(3000)
+    await checkTrxpoints(fourthuser, 140 * multiplier * 2.0)
 
 })
 


### PR DESCRIPTION
- Added new methods for orgs to update their status
- Changed the way validations were made for org status
- Added new settings
- Added new table to history contract and deleting `reputable` and `regen` tables, migration is not needed since those tables were empty
- Changed transactions multiplier in history
- Fixed rep multiplier in `addregen` and `subregen` actions
- Added tests for orgs

#242 

## Deployment

**Contracts**
- [ ] Accounts
- [ ] Organization
- [ ] History
- [ ] Settings

updateSettings (yes)

updateScheduler, not needed
migration, not needed