### PR TITLE
organizations can create a proposal

### DIFF
--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -1539,8 +1539,9 @@ void proposals::check_resident(name account)
   check(uitr != users.end(), "no user");
   check(
     uitr->status == name("citizen") || 
-    uitr->status == name("resident"), 
-    "user is not a resident or citizen");
+    uitr->status == name("resident") ||
+    uitr->type == "organisation"_n, 
+    "user is not a resident or citizen or an organization");
 }
 
 void proposals::addactive(name account) {


### PR DESCRIPTION
due to resident / citizen requirement, organizations - who are not residents or citizens - cannot create proposals

Modified to allow orgs to create proposals.

We may want to check the owner of the org? Under discussion. Meanwhile allow orgs to create proposals as a quick fix for user needs at the moment. 