### PR TITLE
Feature/gratitude acknowledge

### DIFF
--- a/include/seeds.gratitude.hpp
+++ b/include/seeds.gratitude.hpp
@@ -123,5 +123,5 @@ CONTRACT gratitude : public contract {
 };
 
 EOSIO_DISPATCH(gratitude, 
-  (reset)(give)(acknowledge)(newround)
+  (reset)(give)(acknowledge)(newround)(testacks)
 );

--- a/include/seeds.gratitude.hpp
+++ b/include/seeds.gratitude.hpp
@@ -40,6 +40,8 @@ CONTRACT gratitude : public contract {
     // Generates a new gratitude round, regenerating gratitude and splitting stored SEEDS
     ACTION newround();
 
+    ACTION testacks();
+
   private:
 
     void check_user(name account);

--- a/include/seeds.gratitude.hpp
+++ b/include/seeds.gratitude.hpp
@@ -44,6 +44,7 @@ CONTRACT gratitude : public contract {
 
     void check_user(name account);
     void init_balances(name account);
+    void calc_acks(name account);
     void add_gratitude(name account, asset quantity);
     void sub_gratitude(name account, asset quantity);
     uint64_t get_current_volume();
@@ -82,10 +83,10 @@ CONTRACT gratitude : public contract {
     };
 
     TABLE acks_table {
-      name receiver;
-      vector<name> donors; // can have duplicates
+      name donor;
+      vector<name> receivers; // can have duplicates
 
-      uint64_t primary_key() const { return receiver.value; }
+      uint64_t primary_key() const { return donor.value; }
     };
 
     TABLE stats_table {
@@ -116,6 +117,7 @@ CONTRACT gratitude : public contract {
 
     const name gratzgen_res = "gratz1.gen"_n; // Gratitude generated per cycle for residents
     const name gratzgen_cit = "gratz2.gen"_n; // Gratitude generated per cycle for citizens
+    const name gratz_acks = "gratz.acks"_n; // Gratitude generated per cycle for citizens
 };
 
 EOSIO_DISPATCH(gratitude, 

--- a/include/seeds.gratitude.hpp
+++ b/include/seeds.gratitude.hpp
@@ -114,7 +114,8 @@ CONTRACT gratitude : public contract {
     config_tables config;
     size_tables sizes;
 
-    const name gratzgen = "gratz.gen"_n; // Gratitude generated per cycle setting
+    const name gratzgen_res = "gratz1.gen"_n; // Gratitude generated per cycle for residents
+    const name gratzgen_cit = "gratz2.gen"_n; // Gratitude generated per cycle for citizens
 };
 
 EOSIO_DISPATCH(gratitude, 

--- a/src/seeds.gratitude.cpp
+++ b/src/seeds.gratitude.cpp
@@ -36,10 +36,11 @@ ACTION gratitude::reset () {
 ACTION gratitude::give (name from, name to, asset quantity, string memo) {
   require_auth(from);
 
-  check( from != to, "gratitude: cannot give to self" );
-  check( is_account( to ), "gratitude: to account does not exist");
+  check(from != to, "gratitude: cannot give to self");
+  check(is_account(to), "gratitude: to account does not exist");
+  check_user(to);
   check_asset(quantity);
-  check( quantity.amount > 0, "gratitude: must give positive quantity" );
+  check(quantity.amount > 0, "gratitude: must give positive quantity");
 
   // Should create balances if not there yet
   init_balances(to);
@@ -54,8 +55,9 @@ ACTION gratitude::give (name from, name to, asset quantity, string memo) {
 ACTION gratitude::acknowledge (name from, name to, string memo) {
   require_auth(from);
 
-  check( from != to, "gratitude: cannot give to self" );
-  check( is_account( to ), "gratitude: to account does not exist");
+  check(from != to, "gratitude: cannot give to self");
+  check(is_account(to), "gratitude: to account does not exist");
+  check_user(to);
 
   auto actr = acks.find(from.value);
   if (actr == acks.end()) {

--- a/src/seeds.gratitude.cpp
+++ b/src/seeds.gratitude.cpp
@@ -70,6 +70,23 @@ ACTION gratitude::acknowledge (name from, name to, string memo) {
   }
 }
 
+ACTION gratitude::testacks() {
+  require_auth(get_self());
+
+  check(false, "DEBUG: !!!!");
+
+  auto actr = acks.begin();
+  while (actr != acks.end()) {
+    calc_acks(actr->donor);
+    actr++;
+  }
+
+  auto actr2 = acks.begin();
+  while (actr2 != acks.end()) {
+    actr2 = acks.erase(actr2);
+  }
+}
+
 ACTION gratitude::newround() {
   require_auth(get_self());
 
@@ -77,11 +94,11 @@ ACTION gratitude::newround() {
   uint64_t tot_accounts = get_size("balances.sz"_n);
   uint64_t volume = get_current_volume();
 
-  auto actr = acks.begin();
-  while (actr != acks.end()) {
-    calc_acks(actr->donor);
-    actr = acks.erase(actr);
-  }
+  // auto actr = acks.begin();
+  // while (actr != acks.end()) {
+  //   calc_acks(actr->donor);
+  //   actr = acks.erase(actr);
+  // }
 
   auto bitr = balances.begin();
   while (bitr != balances.end()) {

--- a/src/seeds.gratitude.cpp
+++ b/src/seeds.gratitude.cpp
@@ -73,17 +73,10 @@ ACTION gratitude::acknowledge (name from, name to, string memo) {
 ACTION gratitude::testacks() {
   require_auth(get_self());
 
-  check(false, "DEBUG: !!!!");
-
   auto actr = acks.begin();
   while (actr != acks.end()) {
     calc_acks(actr->donor);
-    actr++;
-  }
-
-  auto actr2 = acks.begin();
-  while (actr2 != acks.end()) {
-    actr2 = acks.erase(actr2);
+    actr = acks.erase(actr);
   }
 }
 
@@ -94,11 +87,11 @@ ACTION gratitude::newround() {
   uint64_t tot_accounts = get_size("balances.sz"_n);
   uint64_t volume = get_current_volume();
 
-  // auto actr = acks.begin();
-  // while (actr != acks.end()) {
-  //   calc_acks(actr->donor);
-  //   actr = acks.erase(actr);
-  // }
+  auto actr = acks.begin();
+  while (actr != acks.end()) {
+    calc_acks(actr->donor);
+    actr = acks.erase(actr);
+  }
 
   auto bitr = balances.begin();
   while (bitr != balances.end()) {

--- a/src/seeds.gratitude.cpp
+++ b/src/seeds.gratitude.cpp
@@ -46,6 +46,26 @@ ACTION gratitude::give (name from, name to, asset quantity, string memo) {
   update_stats(from, to, quantity);
 }
 
+ACTION gratitude::acknowledge (name from, name to, string memo) {
+  require_auth(from);
+
+  check( from != to, "gratitude: cannot give to self" );
+  check( is_account( to ), "gratitude: to account does not exist");
+
+  auto actr = acks.find(to.value);
+  if (actr == acks.end()) {
+    acks.emplace(_self, [&](auto& item) {
+      item.receiver = to;
+      item.donors = vector{from};
+    });
+  } else {
+    acks.modify(actr, get_self(), [&](auto &item) {
+        item.donors.push_back(from);
+    });
+  }
+}
+
+
 ACTION gratitude::newround() {
   require_auth(get_self());
   auto generated_gratz = config_get(gratzgen);

--- a/src/seeds.gratitude.cpp
+++ b/src/seeds.gratitude.cpp
@@ -57,15 +57,15 @@ ACTION gratitude::acknowledge (name from, name to, string memo) {
   check( from != to, "gratitude: cannot give to self" );
   check( is_account( to ), "gratitude: to account does not exist");
 
-  auto actr = acks.find(to.value);
+  auto actr = acks.find(from.value);
   if (actr == acks.end()) {
     acks.emplace(_self, [&](auto& item) {
-      item.receiver = to;
-      item.donors = vector{from};
+      item.donor = from;
+      item.receivers = vector{to};
     });
   } else {
     acks.modify(actr, get_self(), [&](auto &item) {
-        item.donors.push_back(from);
+        item.receivers.push_back(to);
     });
   }
 }
@@ -77,7 +77,6 @@ ACTION gratitude::newround() {
   uint64_t tot_accounts = get_size("balances.sz"_n);
   uint64_t volume = get_current_volume();
 
-  // TODO: calculate acks, redistribute then reset them
   auto actr = acks.begin();
   while (actr != acks.end()) {
     calc_acks(actr->donor);

--- a/src/seeds.settings.cpp
+++ b/src/seeds.settings.cpp
@@ -267,7 +267,8 @@ void settings::reset() {
   // =====================================
   // gratitude 
   // =====================================
-  confwithdesc(name("gratz.gen"), 100 * 10000, "Base quantity of gratitude tokens received per cycle", high_impact);
+  confwithdesc(name("gratz1.gen"), 100 * 10000, "Base quantity of gratitude tokens received for residents per cycle", medium_impact);
+  confwithdesc(name("gratz2.gen"), 200 * 10000, "Base quantity of gratitude tokens received for citizens per cycle", medium_impact);
 
   // contracts
   setcontract(name("accounts"), "accts.seeds"_n);

--- a/src/seeds.settings.cpp
+++ b/src/seeds.settings.cpp
@@ -269,6 +269,7 @@ void settings::reset() {
   // =====================================
   confwithdesc(name("gratz1.gen"), 100 * 10000, "Base quantity of gratitude tokens received for residents per cycle", medium_impact);
   confwithdesc(name("gratz2.gen"), 200 * 10000, "Base quantity of gratitude tokens received for citizens per cycle", medium_impact);
+  confwithdesc(name("gratz.acks"), 10, "Minumum number of gratitude acks to fully use your tokens", medium_impact);
 
   // contracts
   setcontract(name("accounts"), "accts.seeds"_n);

--- a/test/gratitude.test.js
+++ b/test/gratitude.test.js
@@ -101,8 +101,26 @@ describe('gratitude general', async assert => {
   checkRemainingGratitude(firstuser, initialGratitude-transferAmount)
   checkReceivedGratitude(seconduser, transferAmount)
 
-  // console.log('acknowledge')
-  // await contracts.gratitude.acknowledge(firstuser, seconduser, 'Thanks!', { authorization: `${firstuser}@active` })
+  console.log('test acknowledge')
+  await contracts.gratitude.acknowledge(seconduser, firstuser, 'Thanks!', { authorization: `${seconduser}@active` })
+
+  console.log('calc acks')
+  await contracts.gratitude.testacks({ authorization: `${gratitude}@active` })
+
+  console.log("DEBUG: acks should have been processed!")
+
+  const acksTable = await getTableRows({
+    code: gratitude,
+    scope: gratitude,
+    table: 'acks',
+    json: true
+  })
+  console.log(acksTable)
+
+  const gratzAcks = await get_settings("gratz.acks")
+  const transferPerAckAmount = initialGratitude / gratzAcks
+  checkRemainingGratitude(seconduser, initialGratitude-transferPerAckAmount)
+  checkReceivedGratitude(firstuser, transferPerAckAmount)
 
   console.log('restart gratitude round')
 
@@ -125,5 +143,6 @@ describe('gratitude general', async assert => {
     actual: secondBalanceAfter,
     expected: secondBalanceBefore + amount
   })
+
 
 })

--- a/test/gratitude.test.js
+++ b/test/gratitude.test.js
@@ -107,15 +107,13 @@ describe('gratitude general', async assert => {
   console.log('calc acks')
   await contracts.gratitude.testacks({ authorization: `${gratitude}@active` })
 
-  console.log("DEBUG: acks should have been processed!")
-
   const acksTable = await getTableRows({
     code: gratitude,
     scope: gratitude,
     table: 'acks',
     json: true
   })
-  console.log(acksTable)
+  //console.log(acksTable)
 
   const gratzAcks = await get_settings("gratz.acks")
   const transferPerAckAmount = initialGratitude / gratzAcks
@@ -124,24 +122,33 @@ describe('gratitude general', async assert => {
 
   console.log('restart gratitude round')
 
+  const firstBalanceBefore = await getBalance(firstuser)  
   const secondBalanceBefore = await getBalance(seconduser)  
   await contracts.gratitude.newround({ authorization: `${gratitude}@active` })
   const contractBalanceAfter = await getBalance(gratitude)
-
+  const firstBalanceAfter = await getBalance(firstuser)
   const secondBalanceAfter = await getBalance(seconduser)
+
 
   assert({
     given: 'gratitude round finished',
-    should: 'contract balance',
+    should: 'reset contract balance',
     actual: contractBalanceAfter,
     expected: contractBalanceBefore
   })
 
   assert({
     given: 'gratitude round finished',
-    should: 'second user received seeds',
+    should: 'second user received seeds because of direct direct gratz received',
     actual: secondBalanceAfter,
-    expected: secondBalanceBefore + amount
+    expected: secondBalanceBefore + amount/2
+  })
+
+  assert({
+    given: 'gratitude round finished',
+    should: 'first user received seeds because of acknowledge',
+    actual: firstBalanceAfter,
+    expected: firstBalanceBefore + amount/2
   })
 
 


### PR DESCRIPTION
This implements the `acknowledge` ACTION to the contract, that allows gratitude users to mark someone to receive a percentage of their tokens without specifying exactly how much (will be decided only when the round ends, based on the number of people they acknowledged).

There's a new setting called `gratz.acks` to indicate how many acknowledges an account has to send before they start diving the remaining tokens by the amount of acks. Default value is 10, so it means if an account does less than 10 acks they will not use up all their tokens for that round, as each ack will use 1/10 of the tokens. If they do more than 10, for example 12, each ack will receive 1/12 of the tokens.