### PR TITLE
Bugfix/alliance and campaign quorum

### DIFF
--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -111,6 +111,7 @@ CONTRACT proposals : public contract {
       ACTION testevalprop(uint64_t proposal_id, uint64_t prop_cycle);
 
       ACTION initcycstats();
+      ACTION migvotepow(uint64_t cycle);
 
   private:
       symbol seeds_symbol = symbol("SEEDS", 4);
@@ -132,6 +133,16 @@ CONTRACT proposals : public contract {
       name stage_staged = name("staged"); // 1 staged: can be cancelled, edited
       name stage_active = name("active"); // 2 active: can be voted on, can't be edited; open or evaluate status
       name stage_done = name("done");     // 3 done: can't be edited or voted on
+
+
+      // cycle stats numbers - size table scoped by cycle
+      name campaign_votes_cast = "cmp.votes.sz"_n; 
+      name alliance_votes_cast = "all.votes.sz"_n; 
+      name campaign_number = "cmp.num.sz"_n; 
+      name alliance_number = "all.num.sz"_n; 
+      name campaign_votes_needed = "cmp.vote.nd"_n;
+      name alliance_votes_needed = "all.vote.nd"_n;
+
 
       std::vector<uint64_t> default_step_distribution = {
         25,  // initial payout
@@ -169,7 +180,9 @@ CONTRACT proposals : public contract {
       void change_rep(name beneficiary, bool passed);
       uint64_t get_size(name id);
       void size_change(name id, int64_t delta);
+      void size_change_s(name id, int64_t delta, uint64_t scope);
       void size_set(name id, int64_t value);
+      void size_set_s(name id, int64_t value, uint64_t scope);
 
       uint64_t get_quorum(uint64_t total_proposals);
       void recover_voice(name account);
@@ -488,6 +501,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
         (calcvotepow)(addcampaign)
         (migrtevotedp)(migrpass)(testperiod)(testevalprop)(migstats)(migcycstat)(testpropquor)
         (initcycstats)
+        (migvotepow)
         )
       }
   }

--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -109,6 +109,7 @@ CONTRACT proposals : public contract {
 
       ACTION migvotepow(uint64_t cycle);
       ACTION reevalprop (uint64_t proposal_id, uint64_t prop_cycle);
+      ACTION migeval();
 
   private:
       symbol seeds_symbol = symbol("SEEDS", 4);
@@ -425,6 +426,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
         (cleanmig)(testpropquor)
         (migvotepow)
         (reevalprop)
+        (migeval)
         )
       }
   }

--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -183,9 +183,7 @@ CONTRACT proposals : public contract {
       void change_rep(name beneficiary, bool passed);
       uint64_t get_size(name id);
       void size_change(name id, int64_t delta);
-      void size_change_s(name id, int64_t delta, uint64_t scope);
       void size_set(name id, int64_t value);
-      void size_set_s(name id, int64_t value, uint64_t scope);
 
       uint64_t get_quorum(uint64_t total_proposals);
       void recover_voice(name account);

--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -108,6 +108,7 @@ CONTRACT proposals : public contract {
       ACTION testevalprop(uint64_t proposal_id, uint64_t prop_cycle);
 
       ACTION migvotepow(uint64_t cycle);
+      ACTION reevalprop (uint64_t proposal_id, uint64_t prop_cycle);
 
   private:
       symbol seeds_symbol = symbol("SEEDS", 4);
@@ -423,6 +424,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
         (testperiod)(testevalprop)
         (cleanmig)(testpropquor)
         (migvotepow)
+        (reevalprop)
         )
       }
   }

--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -109,7 +109,6 @@ CONTRACT proposals : public contract {
 
       ACTION migvotepow(uint64_t cycle);
       ACTION reevalprop (uint64_t proposal_id, uint64_t prop_cycle);
-      ACTION migeval();
 
   private:
       symbol seeds_symbol = symbol("SEEDS", 4);
@@ -426,7 +425,6 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
         (cleanmig)(testpropquor)
         (migvotepow)
         (reevalprop)
-        (migeval)
         )
       }
   }

--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -21,7 +21,6 @@ CONTRACT proposals : public contract {
       proposals(name receiver, name code, datastream<const char*> ds)
         : contract(receiver, code, ds),
           props(receiver, receiver.value),
-          migrateprops(receiver, receiver.value),
           voice(receiver, receiver.value),
           lastprops(receiver, receiver.value),
           cycle(receiver, receiver.value),
@@ -84,8 +83,6 @@ CONTRACT proposals : public contract {
 
       ACTION testvdecay(uint64_t timestamp);
 
-      ACTION migratevoice(uint64_t start);
-
       ACTION testsetvoice(name user, uint64_t amount);
       ACTION initsz();
 
@@ -113,7 +110,6 @@ CONTRACT proposals : public contract {
       ACTION testperiod ();
       ACTION testevalprop(uint64_t proposal_id, uint64_t prop_cycle);
 
-      ACTION initcycstats();
       ACTION migvotepow(uint64_t cycle);
 
   private:
@@ -264,45 +260,6 @@ CONTRACT proposals : public contract {
           uint128_t by_campaign_type_id()const { return (uint128_t(campaign_type.value) << 64) + id; }
       };
 
-      TABLE proposal_migration_table {
-          uint64_t id;
-          name creator;
-          name recipient;
-          asset quantity;
-          asset staked;
-          bool executed;
-          uint64_t total;
-          uint64_t favour;
-          uint64_t against;
-          string title;
-          string summary;
-          string description;
-          string image;
-          string url;
-          name status;
-          name stage;
-          name fund;
-          uint64_t creation_date;
-          std::vector<uint64_t> pay_percentages;
-          uint64_t passed_cycle;
-          uint32_t age;
-          asset current_payout;
-          name campaign_type;
-          asset max_amount_per_invite;
-          asset planted;
-          asset reward;
-          uint64_t campaign_id;
-
-          uint64_t primary_key()const { return id; }
-          uint64_t by_status()const { return status.value; }
-          uint64_t by_stage()const { return stage.value; }
-          uint64_t by_campaign()const { return campaign_id; }
-          uint64_t by_creator()const { return creator.value; }
-          uint128_t by_status_id()const { return (uint128_t(status.value) << 64) + id; }
-          uint128_t by_stage_id()const { return (uint128_t(stage.value) << 64) + id; }
-          uint128_t by_campaign_type_id()const { return (uint128_t(campaign_type.value) << 64) + id; }
-      };
-
       TABLE min_stake_table {
           uint64_t prop_id;
           uint64_t min_stake;
@@ -395,30 +352,6 @@ CONTRACT proposals : public contract {
         uint64_t primary_key()const { return propcycle; }
       };
 
-
-      TABLE cycle_stats_migration_table {
-        uint64_t propcycle; 
-
-        uint64_t start_time; 
-        uint64_t end_time; 
-        uint64_t num_proposals;
-        uint64_t num_votes;
-        uint64_t total_voice_cast;
-        uint64_t total_favour;
-        uint64_t total_against; 
-        uint64_t total_citizens;
-        uint64_t quorum_vote_base;
-        uint64_t quorum_votes_needed;
-        uint64_t total_eligible_voters;
-        float unity_needed;
-
-        std::vector<uint64_t> active_props;
-        std::vector<uint64_t> eval_props;
-
-        uint64_t primary_key()const { return propcycle; }
-      };
-
-
       TABLE voted_proposals_table { // scoped by cycle
         uint64_t proposal_id;
 
@@ -442,23 +375,6 @@ CONTRACT proposals : public contract {
       const_mem_fun<proposal_table, uint128_t, &proposal_table::by_campaign_type_id>>
     > proposal_tables;
     
-    typedef eosio::multi_index<"migrateprops"_n, proposal_migration_table,
-      indexed_by<"bystatus"_n,
-      const_mem_fun<proposal_migration_table, uint64_t, &proposal_migration_table::by_status>>,
-      indexed_by<"bystage"_n,
-      const_mem_fun<proposal_migration_table, uint64_t, &proposal_migration_table::by_stage>>,
-      indexed_by<"bycampaign"_n,
-      const_mem_fun<proposal_migration_table, uint64_t, &proposal_migration_table::by_campaign>>,
-      indexed_by<"bycreator"_n,
-      const_mem_fun<proposal_migration_table, uint64_t, &proposal_migration_table::by_creator>>,
-      indexed_by<"bystatusid"_n,
-      const_mem_fun<proposal_migration_table, uint128_t, &proposal_migration_table::by_status_id>>,
-      indexed_by<"bystageid"_n,
-      const_mem_fun<proposal_migration_table, uint128_t, &proposal_migration_table::by_stage_id>>,
-      indexed_by<"bycmptypeid"_n,
-      const_mem_fun<proposal_migration_table, uint128_t, &proposal_migration_table::by_campaign_type_id>>
-    > proposal_migration_tables;
-
     typedef eosio::multi_index<"votes"_n, vote_table> votes_tables;
     typedef eosio::multi_index<"participants"_n, participant_table> participant_tables;
     typedef eosio::multi_index<"users"_n, user_table> user_tables;
@@ -475,16 +391,14 @@ CONTRACT proposals : public contract {
       const_mem_fun<delegate_trust_table, uint128_t, &delegate_trust_table::by_delegatee_delegator>>
     > delegate_trust_tables;
     typedef eosio::multi_index<"cyclestats"_n, cycle_stats_table> cycle_stats_tables;
-    typedef eosio::multi_index<"mcyclestats"_n, cycle_stats_migration_table> cycle_stats_migration_tables;
     typedef eosio::multi_index<"cycvotedprps"_n, voted_proposals_table> voted_proposals_tables;
 
-    typedef eosio::multi_index<"supportlvl"_n, support_level_table> support_level_tables;
+    typedef eosio::multi_index<"support"_n, support_level_table> support_level_tables;
 
     DEFINE_SIZE_TABLE
     DEFINE_SIZE_TABLE_MULTI_INDEX
 
     proposal_tables props;
-    proposal_migration_tables migrateprops;
     participant_tables participants;
     user_tables users;
     voice_tables voice;
@@ -504,11 +418,10 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
         EOSIO_DISPATCH_HELPER(proposals, (reset)(create)(createx)(createinvite)(update)(updatex)(addvoice)(changetrust)(favour)(against)
         (neutral)(erasepartpts)(checkstake)(onperiod)(evalproposal)(decayvoice)(cancel)(updatevoices)(updatevoice)(decayvoices)
         (addactive)(testvdecay)(initsz)(testquorum)(initnumprop)
-        (migratevoice)(testsetvoice)(delegate)(mimicvote)(undelegate)(voteonbehalf)
+        (testsetvoice)(delegate)(mimicvote)(undelegate)(voteonbehalf)
         (calcvotepow)(addcampaign)(checkprop)(doneprop)
         (migrtevotedp)(migrpass)(testperiod)(testevalprop)
         (cleanmig)(testpropquor)
-        (initcycstats)
         (migvotepow)
         )
       }

--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -185,7 +185,7 @@ CONTRACT proposals : public contract {
       bool is_active(name account, uint64_t cutoff_date);
       void send_vote_on_behalf(name voter, uint64_t id, uint64_t amount, name option);
 
-      void increase_voice_cast(name voter, uint64_t amount, name option);
+      void increase_voice_cast(uint64_t amount, name option, name prop_type);
       uint64_t calc_quorum_base(uint64_t propcycle);
       void add_voted_proposal(uint64_t proposal_id);
       void create_aux(name creator, name recipient, asset quantity, string title, string summary, string description, string image, string url, 
@@ -195,7 +195,7 @@ CONTRACT proposals : public contract {
 
       void send_eval_prop(uint64_t proposal_id, uint64_t prop_cycle);
       void init_cycle_new_stats();
-      void update_cycle_stats_from_proposal(uint64_t proposal_id, name array);
+      void update_cycle_stats_from_proposal(uint64_t proposal_id, name type, name array);
       void send_punish(name account);
       void send_update_voices();
       void send_cancel_lock(name fromfund, uint64_t campaign_id, asset quantity);
@@ -203,6 +203,9 @@ CONTRACT proposals : public contract {
 
       void send_test_eval_prop(uint64_t proposal_id, uint64_t prop_cycle);
       void set_support_level(uint64_t cycle, uint64_t num_proposals, uint64_t votes_cast, name type);
+      void add_voice_cast(uint64_t cycle, uint64_t voice_cast, name type);
+      void add_num_prop(uint64_t cycle, uint64_t num_prop, name type);
+      uint64_t calc_voice_needed(uint64_t total_voice, uint64_t num_proposals);
 
       uint64_t config_get(name key) {
         DEFINE_CONFIG_TABLE

--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -137,16 +137,6 @@ CONTRACT proposals : public contract {
       name stage_active = name("active"); // 2 active: can be voted on, can't be edited; open or evaluate status
       name stage_done = name("done");     // 3 done: can't be edited or voted on
 
-
-      // cycle stats numbers - size table scoped by cycle
-      name campaign_votes_cast = "cmp.votes.sz"_n; 
-      name alliance_votes_cast = "all.votes.sz"_n; 
-      name campaign_number = "cmp.num.sz"_n; 
-      name alliance_number = "all.num.sz"_n; 
-      name campaign_votes_needed = "cmp.vote.nd"_n;
-      name alliance_votes_needed = "all.vote.nd"_n;
-
-
       std::vector<uint64_t> default_step_distribution = {
         25,  // initial payout
         25,  // cycle 1
@@ -219,6 +209,7 @@ CONTRACT proposals : public contract {
       bool check_prop_majority(uint64_t favour, uint64_t against);
 
       void send_test_eval_prop(uint64_t proposal_id, uint64_t prop_cycle);
+      void set_support_level(uint64_t cycle, uint64_t num_proposals, uint64_t votes_cast, name type);
 
       uint64_t config_get(name key) {
         DEFINE_CONFIG_TABLE
@@ -399,11 +390,10 @@ CONTRACT proposals : public contract {
         
         uint64_t num_proposals;
         uint64_t total_voice_cast;
-        uint64_t support_level;
+        uint64_t voice_needed;
 
         uint64_t primary_key()const { return propcycle; }
       };
-
 
 
       TABLE cycle_stats_migration_table {
@@ -487,6 +477,8 @@ CONTRACT proposals : public contract {
     typedef eosio::multi_index<"cyclestats"_n, cycle_stats_table> cycle_stats_tables;
     typedef eosio::multi_index<"mcyclestats"_n, cycle_stats_migration_table> cycle_stats_migration_tables;
     typedef eosio::multi_index<"cycvotedprps"_n, voted_proposals_table> voted_proposals_tables;
+
+    typedef eosio::multi_index<"supportlvl"_n, support_level_table> support_level_tables;
 
     DEFINE_SIZE_TABLE
     DEFINE_SIZE_TABLE_MULTI_INDEX

--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -372,14 +372,14 @@ CONTRACT proposals : public contract {
         
         uint64_t start_time; 
         uint64_t end_time; 
-        uint64_t num_proposals;
+        uint64_t num_proposals;           // unused -> see support_level_table, scoped by type
         uint64_t num_votes;
         uint64_t total_voice_cast;
         uint64_t total_favour;
         uint64_t total_against; 
         uint64_t total_citizens;
-        uint64_t quorum_vote_base;
-        uint64_t quorum_votes_needed;
+        uint64_t quorum_vote_base;        // unused -> see support_level_table scoped by type
+        uint64_t quorum_votes_needed;     // unused -> see support_level_table scoped by type
         uint64_t total_eligible_voters;
         float unity_needed;
 
@@ -388,6 +388,18 @@ CONTRACT proposals : public contract {
 
         uint64_t primary_key()const { return propcycle; }
       };
+
+      TABLE support_level_table {
+        uint64_t propcycle; 
+        
+        uint64_t num_proposals;
+        uint64_t total_voice_cast;
+        uint64_t support_level;
+
+        uint64_t primary_key()const { return propcycle; }
+      };
+
+
 
       TABLE cycle_stats_migration_table {
         uint64_t propcycle; 

--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -99,12 +99,10 @@ CONTRACT proposals : public contract {
 
       ACTION addcampaign(uint64_t proposal_id, uint64_t campaign_id);
 
-
       ACTION migrtevotedp ();
       ACTION migrpass ();
 
-      ACTION migstats (uint64_t cycle);
-      ACTION migcycstat ();
+      ACTION cleanmig ();
       ACTION testpropquor(uint64_t current_cycle, uint64_t prop_id);
 
       ACTION testperiod ();
@@ -499,7 +497,8 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
         (addactive)(testvdecay)(initsz)(testquorum)(initnumprop)
         (migratevoice)(testsetvoice)(delegate)(mimicvote)(undelegate)(voteonbehalf)
         (calcvotepow)(addcampaign)
-        (migrtevotedp)(migrpass)(testperiod)(testevalprop)(migstats)(migcycstat)(testpropquor)
+        (migrtevotedp)(migrpass)(testperiod)(testevalprop)
+        (cleanmig)(testpropquor)
         (initcycstats)
         (migvotepow)
         )

--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -101,9 +101,6 @@ CONTRACT proposals : public contract {
       ACTION doneprop(uint64_t proposal_id);
 
 
-      ACTION migrtevotedp ();
-      ACTION migrpass ();
-
       ACTION cleanmig ();
       ACTION testpropquor(uint64_t current_cycle, uint64_t prop_id);
 
@@ -420,7 +417,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
         (addactive)(testvdecay)(initsz)(testquorum)(initnumprop)
         (testsetvoice)(delegate)(mimicvote)(undelegate)(voteonbehalf)
         (calcvotepow)(addcampaign)(checkprop)(doneprop)
-        (migrtevotedp)(migrpass)(testperiod)(testevalprop)
+        (testperiod)(testevalprop)
         (cleanmig)(testpropquor)
         (migvotepow)
         )

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -29,7 +29,7 @@ const endpoints = {
   local: 'http://127.0.0.1:8888',
   kylin: 'http://kylin.fn.eosbixin.com',
   telosTestnet: 'https://test.hypha.earth',
-  telosMainnet: 'https://node.hypha.earth'
+  telosMainnet: 'https://api.telosfoundation.io'
 }
 
 const ownerAccounts = {

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -1689,9 +1689,12 @@ void proposals::recover_voice(name account) {
 
 }
 
-void gratitude::size_change(name id, int delta) {
+void proposals::size_change(name id, int64_t delta) {
+  size_tables sizes(get_self(), get_self().value);
+
   auto sitr = sizes.find(id.value);
   if (sitr == sizes.end()) {
+    check(delta >= 0, "can't add negagtive size");
     sizes.emplace(_self, [&](auto& item) {
       item.id = id;
       item.size = delta;
@@ -1709,16 +1712,18 @@ void gratitude::size_change(name id, int delta) {
   }
 }
 
-void gratitude::size_set(name id, uint64_t newsize) {
+void proposals::size_set(name id, int64_t value) {
+  size_tables sizes(get_self(), get_self().value);
+
   auto sitr = sizes.find(id.value);
   if (sitr == sizes.end()) {
     sizes.emplace(_self, [&](auto& item) {
       item.id = id;
-      item.size = newsize;
+      item.size = value;
     });
   } else {
     sizes.modify(sitr, _self, [&](auto& item) {
-      item.size = newsize;
+      item.size = value;
     });
   }
 }

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -295,7 +295,7 @@ ACTION proposals::migvotepow(uint64_t cycle) {
     std::to_string(cmp_num) +
     " campaign total votes: " + 
     std::to_string(cmp_total) +
-    " alliance votes needed: " + 
+    " campaign votes needed: " + 
     std::to_string(cmp_votes_needed)
   );
 

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -1689,16 +1689,9 @@ void proposals::recover_voice(name account) {
 
 }
 
-void proposals::size_change(name id, int64_t delta) {
-  size_change_s(id, delta, get_self().value);
-}
-
-void proposals::size_change_s(name id, int64_t delta, uint64_t scope) {
-  size_tables sizes(get_self(), scope);
-
+void gratitude::size_change(name id, int delta) {
   auto sitr = sizes.find(id.value);
   if (sitr == sizes.end()) {
-    check(delta >= 0, "can't add negagtive size");
     sizes.emplace(_self, [&](auto& item) {
       item.id = id;
       item.size = delta;
@@ -1716,22 +1709,16 @@ void proposals::size_change_s(name id, int64_t delta, uint64_t scope) {
   }
 }
 
-void proposals::size_set(name id, int64_t value) {
-  size_set_s(id, value, get_self().value);
-}
-
-void proposals::size_set_s(name id, int64_t value, uint64_t scope) {
-  size_tables sizes(get_self(), scope);
-
+void gratitude::size_set(name id, uint64_t newsize) {
   auto sitr = sizes.find(id.value);
   if (sitr == sizes.end()) {
     sizes.emplace(_self, [&](auto& item) {
       item.id = id;
-      item.size = value;
+      item.size = newsize;
     });
   } else {
     sizes.modify(sitr, _self, [&](auto& item) {
-      item.size = value;
+      item.size = newsize;
     });
   }
 }

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -2097,11 +2097,8 @@ void proposals::reevalprop (uint64_t proposal_id, uint64_t prop_cycle) {
     if (passed && valid_quorum) {
 
       print(" re-eval : CHANGED STATUS TO PASSED");
-
   
       // refund_staked(pitr->creator, pitr->staked);
-
-      /**
        
       change_rep(pitr->creator, true);
 
@@ -2128,7 +2125,6 @@ void proposals::reevalprop (uint64_t proposal_id, uint64_t prop_cycle) {
         proposal.status = status_evaluate;
         proposal.current_payout += payout_amount;
       });
-      **/
 
     } else {
       print(" prop still failed ");

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -2141,23 +2141,3 @@ void proposals::reevalprop (uint64_t proposal_id, uint64_t prop_cycle) {
   }
 
 }
-
-void proposals::migeval() {
-  auto citr = cyclestats.get(32, "error");
-  for(const uint64_t value: citr.active_props) {
-    print(" prop " + std::to_string(value) +" ");
-
-    auto pitr = props.find(value);
-
-    check(pitr != props.end(), "unknown prop id ");
-
-    if (pitr->status == status_evaluate && pitr->stage == stage_done) {
-      // fix it
-      print(" FIXGING stage " + std::to_string(value) +" to -> active");
-
-      props.modify(pitr, _self, [&](auto & item){
-        item.stage = stage_active;
-      });
-    }
-  }
-}

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -2129,6 +2129,7 @@ void proposals::reevalprop (uint64_t proposal_id, uint64_t prop_cycle) {
         proposal.age = 0;
         proposal.staked = asset(0, seeds_symbol);
         proposal.status = status_evaluate;
+        proposal.stage = stage_active;
         proposal.current_payout += payout_amount;
       });
 
@@ -2139,4 +2140,24 @@ void proposals::reevalprop (uint64_t proposal_id, uint64_t prop_cycle) {
     print(" not re-evaluating proposals that passed ");
   }
 
+}
+
+void proposals::migeval() {
+  auto citr = cyclestats.get(32, "error");
+  for(const uint64_t value: citr.active_props) {
+    print(" prop " + std::to_string(value) +" ");
+
+    auto pitr = props.find(value);
+
+    check(pitr != props.end(), "unknown prop id ");
+
+    if (pitr->status == status_evaluate && pitr->stage == stage_done) {
+      // fix it
+      print(" FIXGING stage " + std::to_string(value) +" to -> active");
+
+      props.modify(pitr, _self, [&](auto & item){
+        item.stage = stage_active;
+      });
+    }
+  }
 }

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -265,21 +265,27 @@ void proposals::calcvotepow() {
 ACTION proposals::migvotepow(uint64_t cycle) {
   require_auth(_self);
 
-  auto pitr = props.find(131);// NOTE migration method from cycle 32 onward
+  //auto pitr = props.find(131);// NOTE migration method from cycle 32 onward
   uint64_t all_total = 0;
   uint64_t cmp_total = 0;
   uint64_t cmp_num = 0;
   uint64_t all_num = 0;
-  while( pitr != props.end() && pitr -> passed_cycle == cycle) {
-    name prop_type = get_type(pitr->fund);
-    if (prop_type == alliance_type) {
-      all_total += pitr -> total;
+
+
+  auto citr = cyclestats.get(cycle, "unknown cycle");
+
+  for(const uint64_t value: citr.active_props) {
+    print(" prop " + std::to_string(value) +" ");
+
+    auto pitr = props.get(value, "unknown prop id ");
+
+    if (get_type(pitr.fund) == alliance_type) {
+      all_total += pitr.total;
       all_num += 1;
     } else {
-      cmp_total += pitr -> total; 
+      cmp_total += pitr.total; 
       cmp_num += 1;
     }
-    pitr++;
   }
 
   set_support_level(cycle, cmp_num, cmp_total, campaign_type);
@@ -306,7 +312,7 @@ void proposals::set_support_level(uint64_t cycle, uint64_t num_proposals, uint64
 
   support_level_tables support(get_self(), type.value);
   auto sitr = support.find(cycle);
-  
+
   if (sitr != support.end()) {
     support.modify(sitr, _self, [&](auto & item){
       item.num_proposals = num_proposals;

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -1977,66 +1977,6 @@ void proposals::add_voted_proposal (uint64_t proposal_id) {
 
 }
 
-ACTION proposals::migrtevotedp () {
-  require_auth(get_self());
-
-  auto pitr = props.begin();
-  
-  while (pitr != props.end()) {
-    if (pitr -> passed_cycle != 0) {
-      voted_proposals_tables votedprops(get_self(), pitr -> passed_cycle);
-      auto vpitr = votedprops.find(pitr -> id);
-      if (vpitr == votedprops.end()) {
-        votedprops.emplace(_self, [&](auto & item){
-          item.proposal_id = pitr -> id;
-        });
-      }
-    }
-    pitr++;
-  }
-
-}
-
-ACTION proposals::migrpass () {
-  require_auth(get_self());
-  // fix passed for rejected proposla in the range from cycle 25 
-
-  // Manual review results: 
-
-  // 72 - 25
-  // 80 - 26 
-  // 90 - 27
-  // 95 - 28
-  // 100 - 28 <-- current cycle
-
-  auto pitr = props.find(72);
-
-  while(pitr != props.end() && pitr->id <= 100) {
-    if (pitr->status == status_rejected && pitr->passed_cycle == 0) {
-
-      uint64_t cycle = 25;
-
-      if (pitr->id >= 80) {
-        cycle = 26;
-      }
-
-      if (pitr->id >= 90) {
-        cycle = 27;
-      }
-      
-      if (pitr->id >= 95) {
-        cycle = 28;
-      }
-
-      props.modify(pitr, _self, [&](auto& proposal) {
-        proposal.passed_cycle = cycle;
-      });
-
-    }
-    pitr++;
-  }
-}
-
 ACTION proposals::addcampaign (uint64_t proposal_id, uint64_t campaign_id) {
   require_auth(get_self());
 

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -2081,6 +2081,8 @@ void proposals::reevalprop (uint64_t proposal_id, uint64_t prop_cycle) {
   // re-evaluate only proposals which have been rejected
   if (pitr -> stage == stage_done && pitr -> status == status_rejected) {
 
+    check(pitr -> passed_cycle == prop_cycle, "invalid cycle");
+
     bool passed = check_prop_majority(pitr->favour, pitr->against);
     bool is_alliance_type = prop_type == alliance_type;
     bool is_campaign_type = prop_type == campaign_type;
@@ -2092,14 +2094,18 @@ void proposals::reevalprop (uint64_t proposal_id, uint64_t prop_cycle) {
 
     print(" re-eval "+std::to_string(proposal_id) + 
       " passed:  " + (passed ? "YES" : "NO") + 
-      " quorum: " + (valid_quorum ? "YES" : "NO")  + " ");
+      " quorum: " + (valid_quorum ? "YES" : "NO") +
+      " votes in favor: " + std::to_string(pitr->favour) +
+      " votes needed: " + std::to_string(quorum_votes_needed) +
+      " votes against: " + std::to_string(pitr->against) +
+
+      + " ");
 
     if (passed && valid_quorum) {
 
       print(" re-eval : CHANGED STATUS TO PASSED");
   
       // refund_staked(pitr->creator, pitr->staked);
-       
       change_rep(pitr->creator, true);
 
       asset payout_amount;


### PR DESCRIPTION
# Code Changes and Cleanup

## Cleanup
Removed various migration data structures and actions, added a clean action, which I already ran on mainnet - clean removed the data from mainnet already. 

## Quorum / Support Level fix for alliances and campaigns

New table: support, scoped by alliance and campaign

This table contains number of proposals, number of votes, and resulting support level needed - all this used to be in cycle stats. 

Cycle stats are not scoped and now have 0 for these values - I wonder if we can remove them without migration? Not sure so leaving them there, will also prevent apps from crashing.

Using support table when adding proposals, adding votes, and when doing the evaluation

## Unit Tests
Cleaned up unit tests and added some for the new support table

```
  passed: 101,  failed: 0  of 101 tests  (3m 15.7s)
```