### PR TITLE
Feature/spline ranks rebased

### DIFF
--- a/include/seeds.forum.hpp
+++ b/include/seeds.forum.hpp
@@ -59,6 +59,7 @@ CONTRACT forum : public contract {
 
         ACTION testapoints ();
         ACTION testsize (name id, uint64_t size);
+        ACTION testrank (uint64_t rnk);
 
     private:
         TABLE postcomment_table {
@@ -194,5 +195,5 @@ CONTRACT forum : public contract {
 EOSIO_DISPATCH(forum, 
     (createpost)(createcomt)(upvotepost)(upvotecomt)(downvotepost)(downvotecomt)(reset)(onperiod)(newday)
     (rankforums)(rankforum)(givereps)(giverep)(delteactives)(deleteactive)
-    (testapoints)(testsize)
+    (testapoints)(testsize)(testrank)
 );

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -19,7 +19,7 @@ namespace utils {
 
   symbol seeds_symbol = symbol("SEEDS", 4);
 
-  inline uint64_t rank(uint64_t current, uint64_t total) { 
+  inline uint64_t linear_rank(uint64_t current, uint64_t total) { 
     /**
      * TODO - Table Locks
      * 
@@ -36,14 +36,123 @@ namespace utils {
      * lock but applying reputation we would have to store changes in a secondary table rep_delta, apply all changes there while rep ranking is happening
      * and apply the delta back to the full table once rep ranking is finished.
      * 
-     * The count rebalances the next time we go over it, it's a dynamic system. 
      * 
+     * The count rebalances the next time we go over it, it's a dynamic system. 
+
      * The cheap way to fix it is to limit rank to 99
     */
-
     uint64_t r = (current * 100) / total; 
     if (r > 99) return 99;
     return r;
+  }
+
+  inline uint64_t spline_rank(uint64_t current, uint64_t total) {
+    // Spline rank table coeficients
+    const float rank_coefs[100] = { 0.00,
+                            0.00,
+                            0.01,
+                            0.03,
+                            0.06,
+                            0.09,
+                            0.14,
+                            0.19,
+                            0.26,
+                            0.34,
+                            0.44,
+                            0.55,
+                            0.67,
+                            0.81,
+                            0.97,
+                            1.15,
+                            1.34,
+                            1.56,
+                            1.80,
+                            2.06,
+                            2.34,
+                            2.65,
+                            2.98,
+                            3.34,
+                            3.72,
+                            4.14,
+                            4.58,
+                            5.06,
+                            5.57,
+                            6.11,
+                            6.68,
+                            7.30,
+                            7.94,
+                            8.63,
+                            9.35,
+                            10.12,
+                            10.92,
+                            11.77,
+                            12.66,
+                            13.60,
+                            14.59,
+                            15.62,
+                            16.70,
+                            17.83,
+                            19.02,
+                            20.26,
+                            21.55,
+                            22.90,
+                            24.30,
+                            25.77,
+                            27.23,
+                            28.70,
+                            30.16,
+                            31.63,
+                            33.09,
+                            34.56,
+                            36.02,
+                            37.49,
+                            38.95,
+                            40.41,
+                            41.88,
+                            43.34,
+                            44.81,
+                            46.27,
+                            47.74,
+                            49.20,
+                            50.67,
+                            52.13,
+                            53.60,
+                            55.06,
+                            56.53,
+                            57.99,
+                            59.45,
+                            60.92,
+                            62.38,
+                            63.85,
+                            65.31,
+                            66.78,
+                            68.24,
+                            69.71,
+                            71.17,
+                            72.64,
+                            74.10,
+                            75.57,
+                            77.03,
+                            78.50,
+                            79.96,
+                            81.42,
+                            82.89,
+                            84.35,
+                            85.82,
+                            87.28,
+                            88.75,
+                            90.21,
+                            91.68,
+                            93.14,
+                            94.61,
+                            96.07,
+                            97.54,
+                            99.00
+    };
+    uint64_t calc = (current * 100) / total;
+    if (calc > 99) calc = 99;
+
+    return (uint64_t)rank_coefs[calc];
   }
 
   inline bool is_valid_majority(uint64_t favour, uint64_t against, uint64_t majority) {

--- a/src/seeds.accounts.cpp
+++ b/src/seeds.accounts.cpp
@@ -850,7 +850,7 @@ void accounts::rankrep(uint64_t start_val, uint64_t chunk, uint64_t chunksize, n
 
   while (ritr != rep_by_rep.end() && count < chunksize) {
 
-    uint64_t rank = utils::rank(current, total);
+    uint64_t rank = utils::spline_rank(current, total);
 
     rep_by_rep.modify(ritr, _self, [&](auto& item) {
       item.rank = rank;
@@ -911,7 +911,7 @@ void accounts::rankcbs(uint64_t start_val, uint64_t chunk, uint64_t chunksize, n
 
   while (citr != cbs_by_cbs.end() && count < chunksize) {
 
-    uint64_t rank = utils::rank(current, total);
+    uint64_t rank = utils::spline_rank(current, total);
 
     cbs_by_cbs.modify(citr, _self, [&](auto& item) {
       item.rank = rank;
@@ -1374,7 +1374,7 @@ void accounts::evaldemote (name to, uint64_t start_val, uint64_t chunk, uint64_t
   while (ritr != rep_by_rep.end() && count < chunksize) {
 
     if (ritr->account == to) {
-      uint64_t rank = utils::rank(current, total);
+      uint64_t rank = utils::spline_rank(current, total);
 
       rep_by_rep.modify(ritr, _self, [&](auto& item) {
         item.rank = rank;

--- a/src/seeds.forum.cpp
+++ b/src/seeds.forum.cpp
@@ -409,7 +409,7 @@ ACTION forum::rankforum(uint64_t start, uint64_t chunksize, uint64_t chunk) {
 
     while (fitr != forum_rep_by_points.end() && count < chunksize) {
 
-        uint64_t rank = utils::rank(current, total);
+        uint64_t rank = utils::spline_rank(current, total);
 
         forum_rep_by_points.modify(fitr, _self, [&](auto& item) {
             item.rank = rank;
@@ -537,3 +537,8 @@ ACTION forum::testapoints () {
     check(false, std::to_string(get_available_points()));
 }
 
+ACTION forum::testrank (uint64_t rnk) {
+    require_auth(get_self());
+    auto r = utils::spline_rank(rnk, 100);
+    print("rank "+std::to_string(r));
+}

--- a/src/seeds.harvest.cpp
+++ b/src/seeds.harvest.cpp
@@ -484,7 +484,7 @@ void harvest::ranktx(uint64_t start_val, uint64_t chunk, uint64_t chunksize, nam
 
   while (titr != txpt_by_points.end() && count < chunksize) {
 
-    uint64_t rank = utils::rank(current, total);
+    uint64_t rank = utils::spline_rank(current, total);
 
     txpt_by_points.modify(titr, _self, [&](auto& item) {
       item.rank = rank;
@@ -533,7 +533,7 @@ void harvest::rankplanted(uint128_t start_val, uint64_t chunk, uint64_t chunksiz
 
   while (pitr != planted_by_planted.end() && count < chunksize) {
 
-    uint64_t rank = utils::rank(current, total);
+    uint64_t rank = utils::spline_rank(current, total);
 
     planted_by_planted.modify(pitr, _self, [&](auto& item) {
       item.rank = rank;
@@ -741,7 +741,7 @@ void harvest::rankcs(uint64_t start_val, uint64_t chunk, uint64_t chunksize, nam
 
   while (citr != cs_by_points.end() && count < chunksize) {
 
-    uint64_t rank = utils::rank(current, total);
+    uint64_t rank = utils::linear_rank(current, total);
 
     cs_by_points.modify(citr, _self, [&](auto& item) {
       item.rank = rank;
@@ -808,7 +808,7 @@ void harvest::rankrgncs(uint64_t start, uint64_t chunk, uint64_t chunksize) {
 
   while (bitr != rgns_by_points.end() && count < chunksize) {
 
-    uint64_t rank = utils::rank(current, total);
+    uint64_t rank = utils::linear_rank(current, total);
 
     auto csitr = rgncspoints.find(bitr -> region.value);
     if (csitr == rgncspoints.end()) {

--- a/src/seeds.organization.cpp
+++ b/src/seeds.organization.cpp
@@ -468,7 +468,7 @@ ACTION organization::rankregen(uint64_t start, uint64_t chunk, uint64_t chunksiz
 
     while (rsitr != regen_score_by_avg_regen.end() && count < chunksize) {
 
-        uint64_t rank = utils::rank(current, total);
+        uint64_t rank = utils::spline_rank(current, total);
 
         regen_score_by_avg_regen.modify(rsitr, _self, [&](auto & item) {
             item.rank = rank;

--- a/test/accounts.test.js
+++ b/test/accounts.test.js
@@ -1183,7 +1183,7 @@ describe('reputation & cbs ranking', async assert => {
     given: '4 users with cbs',
     should: 'have entries in cbs table',
     actual: cbsAfter.rows.map(({rank})=>rank),
-    expected: [0,25,50,75]
+    expected: [0,4,27,63]
   })
 
   assert({

--- a/test/accounts.test.js
+++ b/test/accounts.test.js
@@ -1630,7 +1630,7 @@ describe('Punishment', async assert => {
   }
 
   console.log('change resident threshold')
-  await contracts.settings.configure('res.rep.pt', 10, { authorization: `${settings}@active` })
+  await contracts.settings.configure('res.rep.pt', 2, { authorization: `${settings}@active` })
 
   console.log('join users')
   await contracts.accounts.adduser(firstuser, `user`, 'individual', { authorization: `${accounts}@active` })

--- a/test/forum.test.js
+++ b/test/forum.test.js
@@ -314,12 +314,11 @@ describe('forum reputation', async assert => {
         try {
             await contracts.forum.testapoints({ authorization: `${forum}@active` })
         } catch (e) {
-            const error = JSON.parse(e)
             assert({
                 given: 'test points called',
                 should: 'return the correct amount of points',
                 expected: `assertion failure with message: ${parseInt(expectedValue)}`,
-                actual: error.error.details[0].message
+                actual: e.json.error.details[0].message
             })
         }
     }
@@ -364,15 +363,16 @@ describe('forum reputation', async assert => {
     await testGetPoints(parseInt(0.5 * 1000), 1000)
     await testGetPoints(parseInt(0.2 * 20000), 20000)
     await testGetPoints(parseInt(0.1 * 100001), 100001)
-    
+
+    ranktest = await contracts.forum.testrank(50, { authorization: `${forum}@active` });
 
     assert({
         given: 'rankforums called',
         should: 'rank all the users in the forum correctly',
         expected: [
             { account: firstuser, reputation: -70000, rank: 0 },
-            { account: seconduser, reputation: 70000, rank: 66 },
-            { account: thirduser, reputation: 35000, rank: 33 }
+            { account: seconduser, reputation: 70000, rank: 50 },
+            { account: thirduser, reputation: 35000, rank: 8 }
         ],
         actual: forumReputation.rows
     })
@@ -387,8 +387,15 @@ describe('forum reputation', async assert => {
     assert({
         given: 'reputation distributed',
         should: 'give users correct reputation',
-        expected: [10000, 5006, 10003],
+        expected: [10000, 5005, 10000],
         actual: users.rows.map(u => u.reputation)
+    })
+
+    assert({
+        given: 'ranking using spline coeficients',
+        should: 'return expected value',
+        expected: 'rank 27',
+        actual: ranktest.processed.action_traces[0].console
     })
 })
 

--- a/test/harvest.test.js
+++ b/test/harvest.test.js
@@ -892,7 +892,7 @@ describe('contribution score', async assert => {
   for (const org of orgs) { orgScores.push(await calcCSPoints(org, 'org')) }
   orgScores = orgScores.filter(s => s > 0)
 
-  await checkCSScores(individualHarvestScope, userScores, [0, 0, 0])
+  await checkCSScores(individualHarvestScope, userScores, [0, 0, 0, 0])
   await checkCSScores(organizationScope, orgScores, [0, 0])
 
   console.log('rank contribution score for orgs')
@@ -900,7 +900,7 @@ describe('contribution score', async assert => {
   await contracts.harvest.rankorgcss({ authorization: `${harvest}@active` })
   await sleep(2000)
 
-  await checkCSScores(individualHarvestScope, userScores, [0, 33, 66])
+  await checkCSScores(individualHarvestScope, userScores, [25, 0, 50, 75])
   await checkCSScores(organizationScope, orgScores, [0, 50])
 
 })

--- a/test/harvest.test.js
+++ b/test/harvest.test.js
@@ -384,7 +384,7 @@ describe("Harvest General", async assert => {
     })),
     expected: [{
       account: firstuser,
-      score: 50
+      score: 27
     }, {
       account: seconduser,
       score: 0
@@ -457,9 +457,9 @@ describe("harvest planted score", async assert => {
 
   assert({
     given: 'planted calculation',
-    should: 'have valies',
+    should: 'have values',
     actual: planted.rows.map(({ rank }) => rank),
-    expected: [50, 0]
+    expected: [27, 0]
   })
 
 })
@@ -553,7 +553,7 @@ describe("harvest transaction score", async assert => {
   await contracts.accounts.testsetrs(thirduser, 75, { authorization: `${accounts}@active` })
   await transfer(seconduser, thirduser, 10, '0'+memoprefix)
 
-  await checkScores([10, 16], [0, 50], "2 reputation, 2 tx", "0, 50 score")
+  await checkScores([10, 16], [0, 27], "2 reputation, 2 tx", "0, 27 score")
 
   let expectedScore = 15 + 25 * (1 * 1.5) // 52.5
   console.log("More than 26 transactions. Expected tx points: "+ expectedScore)
@@ -565,13 +565,13 @@ describe("harvest transaction score", async assert => {
     // score from before was 15
     await transfer(firstuser, seconduser, 9, memoprefix+" tx "+i)
   }
-  await checkScores([19, 16], [50, 0], "2 reputation, 2 tx", "50, 0 score")
+  await checkScores([19, 16], [27, 0], "2 reputation, 2 tx", "27, 0 score")
 
   // test tx exceeds volume limit
   let tx_max_points = 1777
   let third_user_rep_multiplier = 2 * 0.7575
   await transfer(seconduser, thirduser, 3000, memoprefix+" tx max pt")
-  await checkScores([19, parseInt(Math.ceil(16 + tx_max_points * third_user_rep_multiplier))], [0, 50], "large tx", "100, 75 score")
+  await checkScores([19, parseInt(Math.ceil(16 + tx_max_points * third_user_rep_multiplier))], [0, 27], "large tx", "100, 27 score")
   
   // send back 
   await transfer(thirduser, seconduser, 3000, memoprefix+" tx max pt")
@@ -607,7 +607,7 @@ describe("harvest transaction score", async assert => {
     given: 'contribution score points',
     should: 'have contribution points',
     actual: cspoints.rows.map(({ contribution_points }) => contribution_points), 
-    expected: [49]
+    expected: [26]
   })
 
   assert({
@@ -694,7 +694,7 @@ describe("harvest community building score", async assert => {
   await contracts.accounts.testsetcbs(fourthuser, 0, { authorization: `${accounts}@active` })
 
   await contracts.accounts.rankcbss({ authorization: `${accounts}@active` })
-  await checkScores([1, 2, 3, 0], [25, 50, 75, 0], "cbs distribution", "correct")
+  await checkScores([1, 2, 3, 0], [4, 27, 63, 0], "cbs distribution", "correct")
 })
 
 describe('contribution score', async assert => {
@@ -891,7 +891,7 @@ describe('contribution score', async assert => {
   for (const org of orgs) { orgScores.push(await calcCSPoints(org, 'org')) }
   orgScores = orgScores.filter(s => s > 0)
 
-  await checkCSScores(individualHarvestScope, userScores, [0, 0, 0, 0])
+  await checkCSScores(individualHarvestScope, userScores, [0, 0, 0])
   await checkCSScores(organizationScope, orgScores, [0, 0])
 
   console.log('rank contribution score for orgs')
@@ -899,7 +899,7 @@ describe('contribution score', async assert => {
   await contracts.harvest.rankorgcss({ authorization: `${harvest}@active` })
   await sleep(2000)
 
-  await checkCSScores(individualHarvestScope, userScores, [0, 25, 50, 75])
+  await checkCSScores(individualHarvestScope, userScores, [0, 33, 66])
   await checkCSScores(organizationScope, orgScores, [0, 50])
 
 })
@@ -1497,8 +1497,8 @@ describe('regions contribution score', async assert => {
     should: 'have the correct ranks',
     actual: cspointsrgns.rows,
     expected: [
-      { account: 'rgn2.rgn', contribution_points: 77, rank: 0 },
-      { account: 'rgn3.rgn', contribution_points: 117, rank: 50 }
+      { account: 'rgn2.rgn', contribution_points: 41, rank: 0 },
+      { account: 'rgn3.rgn', contribution_points: 82, rank: 50 }
     ]
   })
 

--- a/test/organization.test.js
+++ b/test/organization.test.js
@@ -841,10 +841,10 @@ describe('organization scores', async assert => {
         should: 'rank the orgs properly',
         actual: cbsRanks.rows,
         expected: [
-            { account: org1, community_building_score: 100, rank: 80 },
-            { account: org2, community_building_score: 75, rank: 60 },
-            { account: org3, community_building_score: 50, rank: 40 },
-            { account: org4, community_building_score: 25, rank: 20 },
+            { account: org1, community_building_score: 100, rank: 71 },
+            { account: org2, community_building_score: 75, rank: 41 },
+            { account: org3, community_building_score: 50, rank: 14 },
+            { account: org4, community_building_score: 25, rank: 2 },
             { account: org5, community_building_score: 1, rank: 0 }
         ]
     })
@@ -857,10 +857,10 @@ describe('organization scores', async assert => {
         actual: txRanks.rows,
         expected: [
             { account: org1, points: 501, rank: 0 },
-            { account: org2, points: 1001, rank: 20 },
-            { account: org3, points: 2001, rank: 40 },
-            { account: org4, points: 2600, rank: 60 },
-            { account: org5, points: 2935, rank: 80 }      
+            { account: org2, points: 1001, rank: 2 },
+            { account: org3, points: 2001, rank: 14 },
+            { account: org4, points: 2600, rank: 41 },
+            { account: org5, points: 2935, rank: 71 }      
         ]
     })
     console.log('trxs', txRanks.rows)

--- a/test/organization.test.js
+++ b/test/organization.test.js
@@ -829,10 +829,10 @@ describe('organization scores', async assert => {
         should: 'rank the orgs properly',
         actual: regenScores.rows,
         expected: [
-            { org_name: org2, regen_avg: 6, rank: 25 },
+            { org_name: org2, regen_avg: 6, rank: 4 },
             { org_name: org3, regen_avg: 0, rank: 0 },
-            { org_name: org4, regen_avg: 10, rank: 50 },
-            { org_name: org5, regen_avg: 11, rank: 75 }
+            { org_name: org4, regen_avg: 10, rank: 27 },
+            { org_name: org5, regen_avg: 11, rank: 63 }
         ]
     })
 


### PR DESCRIPTION
Changed utils::rank so that it allows both linear and spline curve (using mapped points) for ranks.
Includes reviewed tests for accounts, forum, harvest and organization contracts to match the new distribution.

## Edit

See constitution / game guide page 38 - "individual Accounts Total Contribution Scores"
Also page 50 same thing for orgs

There's been a change of spec, we need both linear and spline curves. 

The final contribution score for orgs and individuals should use the linear curve.

All other instances should use the spline curve.

## Spec
Add the linear rank back in, create 2 methods, rank_spline and rank_linear, change the code so the right one is used in the right places. 

## Deployment

- Accounts
- Harvest
- Forum
- Organization