### PR TITLE
Use buckets to distribute dSeeds and planted bonus alongside harvest #224

### DIFF
--- a/include/contracts.hpp
+++ b/include/contracts.hpp
@@ -25,6 +25,7 @@ namespace contracts {
   name region = "region.seeds"_n;
   name gratitude = "gratz.seeds"_n;
   name pouch = "pouch.seeds"_n;
+  name pool = "pool.seeds"_n;
 }
 namespace bankaccts {
   name milestone = "milest.seeds"_n;

--- a/include/seeds.escrow.hpp
+++ b/include/seeds.escrow.hpp
@@ -3,6 +3,8 @@
 #include <eosio/asset.hpp>
 #include <seeds.token.hpp>
 #include <contracts.hpp>
+#include <utils.hpp>
+#include <tables/config_table.hpp>
 
 using namespace eosio;
 using std::string;
@@ -13,7 +15,8 @@ CONTRACT escrow : public contract {
         escrow(name receiver, name code, datastream<const char*> ds)
         : contract(receiver, code, ds),
         locks(receiver, receiver.value),
-        sponsors(receiver, receiver.value)
+        sponsors(receiver, receiver.value),
+        config(contracts::settings, contracts::settings.value)
         {}
 
         ACTION reset();
@@ -31,6 +34,10 @@ CONTRACT escrow : public contract {
                         const name&     event_name,
                         const string&   notes);
 
+        ACTION sendtopool(uint64_t start, uint64_t chunksize);
+
+        ACTION miglock(uint64_t lock_id);
+
         ACTION cancellock (const uint64_t& lock_id);
 
         ACTION claim(name beneficiary);
@@ -47,7 +54,12 @@ CONTRACT escrow : public contract {
         void ontransfer(name from, name to, asset quantity, string memo);
 
     private:
-        symbol seeds_symbol = symbol("SEEDS", 4);
+        const name trigger_source_hypha_dao = "dao.hypha"_n;
+        const name trigger_event_golive = "golive"_n;
+
+        DEFINE_CONFIG_TABLE
+        DEFINE_CONFIG_TABLE_MULTI_INDEX
+        DEFINE_CONFIG_GET
 
         // events scoped by trigger_source
         TABLE event {
@@ -113,8 +125,9 @@ CONTRACT escrow : public contract {
         
         token_lock_table locks;
         sponsors_tables sponsors;
+        config_tables config;
 
         void check_asset(asset quantity);
-        void init_balance(name user);
-        void deduct_from_sponsor (name sponsor, asset locked_quantity);
+        void deduct_from_sponsor(name sponsor, asset locked_quantity);
+        void send_transfer(const name & beneficiary, const asset & quantity, const string & memo);
 };

--- a/include/seeds.harvest.hpp
+++ b/include/seeds.harvest.hpp
@@ -152,6 +152,7 @@ CONTRACT harvest : public contract {
     double config_float_get(name key);
     void send_distribute_harvest (name key, asset amount);
     void withdraw_aux(name sender, name beneficiary, asset quantity, string memo);
+    void send_pool_payout(asset quantity);
 
     // Contract Tables
 

--- a/include/seeds.pool.hpp
+++ b/include/seeds.pool.hpp
@@ -1,0 +1,77 @@
+#include <eosio/eosio.hpp>
+#include <eosio/asset.hpp>
+#include <eosio/transaction.hpp>
+#include <contracts.hpp>
+#include <utils.hpp>
+#include <tables/config_table.hpp>
+#include <tables/size_table.hpp>
+
+using namespace eosio;
+using std::string;
+
+CONTRACT pool : public contract {
+
+  public:
+
+    using contract::contract;
+    pool(name receiver, name code, datastream<const char*> ds)
+      : contract(receiver, code, ds),
+        balances(receiver, receiver.value),
+        sizes(receiver, receiver.value),
+        config(contracts::settings, contracts::settings.value)
+        {}
+
+    ACTION reset();
+
+    ACTION ontransfer(name from, name to, asset quantity, string memo);
+
+    ACTION payouts(asset quantity);
+
+    ACTION payout(asset quantity, uint64_t start, uint64_t chunksize, uint64_t accumulated_balance);
+
+
+  private:
+
+    const name total_balance_size = "total.sz"_n;
+
+    void send_transfer(const name & to, const asset & quantity, const string & memo);
+
+    DEFINE_CONFIG_TABLE
+    DEFINE_CONFIG_TABLE_MULTI_INDEX
+    DEFINE_CONFIG_GET
+
+    DEFINE_SIZE_TABLE
+    DEFINE_SIZE_TABLE_MULTI_INDEX
+    DEFINE_SIZE_GET
+    DEFINE_SIZE_CHANGE
+    DEFINE_SIZE_SET
+
+    TABLE balances_table {
+      name account;
+      asset balance;
+
+      uint64_t primary_key () const { return account.value; }
+    };
+
+    typedef eosio::multi_index<"balances"_n, balances_table> balances_tables;
+
+    balances_tables balances;
+    size_tables sizes;
+
+    // external tables
+    config_tables config;
+
+};
+
+extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
+  if (action == name("transfer").value && code == contracts::token.value) {
+      execute_action<pool>(name(receiver), name(code), &pool::ontransfer);
+  } else if (code == receiver) {
+      switch (action) {
+        EOSIO_DISPATCH_HELPER(pool, 
+          (reset)
+          (payouts)(payout)
+        )
+      }
+  }
+}

--- a/include/seeds.pool.hpp
+++ b/include/seeds.pool.hpp
@@ -27,7 +27,7 @@ CONTRACT pool : public contract {
 
     ACTION payouts(asset quantity);
 
-    ACTION payout(asset quantity, uint64_t start, uint64_t chunksize, uint64_t accumulated_balance);
+    ACTION payout(asset quantity, uint64_t start, uint64_t chunksize, int64_t old_total_balance);
 
 
   private:

--- a/include/tables/config_table.hpp
+++ b/include/tables/config_table.hpp
@@ -12,3 +12,12 @@ using eosio::name;
       }; 
 
 #define DEFINE_CONFIG_TABLE_MULTI_INDEX typedef eosio::multi_index<"config"_n, config_table> config_tables; 
+
+#define DEFINE_CONFIG_GET \
+        uint64_t config_get (name key) { \
+            auto citr = config.find(key.value);\
+            if (citr == config.end()) { \
+                eosio::check(false, ("settings: the "+key.to_string()+" parameter has not been initialized").c_str());\
+            }\
+            return citr->value;\
+        } \

--- a/include/tables/size_table.hpp
+++ b/include/tables/size_table.hpp
@@ -9,3 +9,49 @@ using eosio::name;
       };
 
 #define DEFINE_SIZE_TABLE_MULTI_INDEX typedef eosio::multi_index<"sizes"_n, size_table> size_tables;
+
+#define DEFINE_SIZE_CHANGE \
+      void size_change(name id, int delta) { \
+        auto sitr = sizes.find(id.value); \
+        if (sitr == sizes.end()) { \
+          sizes.emplace(_self, [&](auto& item) { \
+            item.id = id; \
+            item.size = delta; \
+          }); \
+        } else { \
+          uint64_t newsize = sitr->size + delta; \ 
+          if (delta < 0) { \
+            if (sitr->size < -delta) { \
+              newsize = 0; \
+            } \
+          } \
+          sizes.modify(sitr, _self, [&](auto& item) { \
+            item.size = newsize; \
+          }); \
+        } \
+      }
+
+#define DEFINE_SIZE_SET \ 
+      void size_set(name id, uint64_t newsize) { \
+        auto sitr = sizes.find(id.value); \
+        if (sitr == sizes.end()) { \
+          sizes.emplace(_self, [&](auto& item) { \
+            item.id = id; \
+            item.size = newsize; \
+          }); \
+        } else { \
+          sizes.modify(sitr, _self, [&](auto& item) { \
+            item.size = newsize; \
+          }); \
+        } \
+      } 
+
+#define DEFINE_SIZE_GET \
+      uint64_t get_size(name id) { \
+        auto sitr = sizes.find(id.value); \
+        if (sitr == sizes.end()) { \
+          return 0; \
+        } else { \
+          return sitr->size; \
+        } \
+      } 

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -11,7 +11,8 @@ const networks = {
   mainnet: 'aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906',
   jungle: 'e70aaab8997e1dfce58fbfac80cbbb8fecec7b99cf982a9444273cbc64c41473',
   kylin: '5fff1dae8dc8e2fc4d5b23b2c7665c97f9e9d8edf2b6485a86ba311c25639191',
-  local: process.env.COMPILER === 'local' ? eosioLocalChainID : dockerLocalChainID,
+  // local: process.env.COMPILER === 'local' ? eosioLocalChainID : dockerLocalChainID,
+  local: 'cf057bbfb72640471fd910bcb67639c22df9f92470936cddc1ade0e2f2e7dc4f',
   telosTestnet: '1eaa0824707c8c16bd25145493bf062aecddfeb56c736f6ba6397f3195f33c9f',
   telosMainnet: '4667b205c6838ef70ff7988f6e8257e8be0e1284a2f59699054a018f743b1d11'
 }
@@ -84,7 +85,7 @@ const payForCPUKeys = {
 const payForCPUPublicKey = payForCPUKeys[chainId]
 
 const applicationKeys = {
-  [networks.local]: 'EOS7HXZn1yhQJAiHbUXeEnPTVHoZLgAScNNELAyvWxoqQJzcLbbjq',
+  [networks.local]: 'EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV', // 'EOS7HXZn1yhQJAiHbUXeEnPTVHoZLgAScNNELAyvWxoqQJzcLbbjq',
   [networks.telosMainnet]: 'EOS7HXZn1yhQJAiHbUXeEnPTVHoZLgAScNNELAyvWxoqQJzcLbbjq',
   [networks.telosTestnet]: 'EOS7HXZn1yhQJAiHbUXeEnPTVHoZLgAScNNELAyvWxoqQJzcLbbjq'
 }
@@ -179,6 +180,7 @@ const accountsMetadata = (network) => {
       gratitude: contract('gratz.seeds', 'gratitude'),
       pouch: contract('pouch.seeds', 'pouch'),
       service: contract('hello.seeds', 'service'),
+      pool: contract('pool.seeds', 'pool')
     }
   } else if (network == networks.telosMainnet) {
     return {
@@ -667,6 +669,9 @@ var permissions = [{
 }, {
   target: `${accounts.accounts.account}@addcbs`,
   action: 'addcbs'
+}, {
+  target: `${accounts.pool.account}@active`,
+  actor: `${accounts.pool.account}@eosio.code`
 }]
 
 const isTestnet = chainId == networks.telosTestnet

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -806,7 +806,7 @@ function asset (quantity) {
     if (quantity.symbol) {
       return quantity
     }
-    return {}
+    return null
   }
   const [amount, symbol] = quantity.split(' ')
   const indexDecimal = amount.indexOf('.')

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -216,6 +216,7 @@ const accountsMetadata = (network) => {
       gratitude: contract('gratz.seeds', 'gratitude'),
       pouch: contract('pouch.seeds', 'pouch'),
       service: contract('hello.seeds', 'service'),
+      pool: contract('pool.seeds', 'pool')
     }
   } else if (network == networks.telosTestnet) {
     return {

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -792,9 +792,27 @@ const sleep = async (ms) => {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+function asset (quantity) {
+  if (typeof quantity == 'object') {
+    if (quantity.symbol) {
+      return quantity
+    }
+    return {}
+  }
+  const [amount, symbol] = quantity.split(' ')
+  const indexDecimal = amount.indexOf('.')
+  const precision = amount.substring(indexDecimal + 1).length
+  return {
+    amount: parseFloat(amount),
+    symbol,
+    precision,
+    toString: quantity
+  }
+}
+
 module.exports = {
   eos, getEOSWithEndpoint, encodeName, decodeName, getBalance, getBalanceFloat, getTableRows, initContracts,
   accounts, names, ownerPublicKey, activePublicKey, apiPublicKey, permissions, sha256, isLocal, ramdom64ByteHexString, createKeypair,
-  testnetUserPubkey, getTelosBalance, fromHexString, allContractNames, allContracts, allBankAccountNames, sleep
+  testnetUserPubkey, getTelosBalance, fromHexString, allContractNames, allContracts, allBankAccountNames, sleep, asset
 }
 

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -11,8 +11,7 @@ const networks = {
   mainnet: 'aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906',
   jungle: 'e70aaab8997e1dfce58fbfac80cbbb8fecec7b99cf982a9444273cbc64c41473',
   kylin: '5fff1dae8dc8e2fc4d5b23b2c7665c97f9e9d8edf2b6485a86ba311c25639191',
-  // local: process.env.COMPILER === 'local' ? eosioLocalChainID : dockerLocalChainID,
-  local: 'cf057bbfb72640471fd910bcb67639c22df9f92470936cddc1ade0e2f2e7dc4f',
+  local: process.env.COMPILER === 'local' ? eosioLocalChainID : dockerLocalChainID,
   telosTestnet: '1eaa0824707c8c16bd25145493bf062aecddfeb56c736f6ba6397f3195f33c9f',
   telosMainnet: '4667b205c6838ef70ff7988f6e8257e8be0e1284a2f59699054a018f743b1d11'
 }
@@ -85,7 +84,7 @@ const payForCPUKeys = {
 const payForCPUPublicKey = payForCPUKeys[chainId]
 
 const applicationKeys = {
-  [networks.local]: 'EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV', // 'EOS7HXZn1yhQJAiHbUXeEnPTVHoZLgAScNNELAyvWxoqQJzcLbbjq',
+  [networks.local]: 'EOS7HXZn1yhQJAiHbUXeEnPTVHoZLgAScNNELAyvWxoqQJzcLbbjq',
   [networks.telosMainnet]: 'EOS7HXZn1yhQJAiHbUXeEnPTVHoZLgAScNNELAyvWxoqQJzcLbbjq',
   [networks.telosTestnet]: 'EOS7HXZn1yhQJAiHbUXeEnPTVHoZLgAScNNELAyvWxoqQJzcLbbjq'
 }
@@ -261,6 +260,7 @@ const accountsMetadata = (network) => {
       gratitude: contract('gratz.seeds', 'gratitude'),
       pouch: contract('pouch.seeds', 'pouch'),
       service: contract('hello.seeds', 'service'),
+      pool: contract('pool.seeds', 'pool')
     }
   } else if (network == networks.kylin) {
     throw new Error('Kylin deployment currently disabled')
@@ -672,6 +672,14 @@ var permissions = [{
 }, {
   target: `${accounts.pool.account}@active`,
   actor: `${accounts.pool.account}@eosio.code`
+}, {
+  target: `${accounts.pool.account}@hrvst.pool`,
+  actor: `${accounts.harvest.account}@eosio.code`,
+  parent: 'active',
+  type: 'createActorPermission'
+}, {
+  target: `${accounts.pool.account}@hrvst.pool`,
+  action: 'payouts'
 }]
 
 const isTestnet = chainId == networks.telosTestnet

--- a/src/seeds.harvest.cpp
+++ b/src/seeds.harvest.cpp
@@ -1259,16 +1259,18 @@ void harvest::runharvest() {
   size_tables pool_sizes_t(contracts::pool, contracts::pool.value);
 
   auto total_pool_balance_itr = pool_sizes_t.find(name("total.sz").value);
+  int64_t pool_payout = 0;
+
   if (total_pool_balance_itr != pool_sizes_t.end() && total_pool_balance_itr->size > 0) {
-    quantity = asset(mitr->mint_rate * 0.5, test_symbol);
-    send_pool_payout(asset(mitr->mint_rate * 0.5, utils::seeds_symbol));
-  } else {
-    quantity = asset(mitr->mint_rate, test_symbol);
+    pool_payout = std::min(int64_t(mitr->mint_rate * 0.5), int64_t(total_pool_balance_itr->size));
+    send_pool_payout(asset(pool_payout, utils::seeds_symbol));
   }
+
+  quantity = asset(mitr->mint_rate - pool_payout, test_symbol);
 
   string memo = "harvest";
 
-  print("mint rate:", quantity, "\n");
+  print("minted:", quantity, "\n");
 
   token::issue_action_test t_issue{contracts::token, { contracts::token, "minthrvst"_n }};
   t_issue.send(get_self(), quantity, memo);

--- a/src/seeds.pool.cpp
+++ b/src/seeds.pool.cpp
@@ -23,6 +23,7 @@ ACTION pool::ontransfer (name from, name to, asset quantity, string memo) {
       quantity.symbol == utils::seeds_symbol) {        // SEEDS symbol
 
     utils::check_asset(quantity);
+    check(from == contracts::escrow, "the sender is not an allowed account");
 
     name account = name(memo);
     check(is_account(account), account.to_string() + " is not an account");

--- a/src/seeds.pool.cpp
+++ b/src/seeds.pool.cpp
@@ -1,0 +1,119 @@
+#include <seeds.pool.hpp>
+
+
+ACTION pool::reset () {
+  require_auth(get_self());
+
+  auto bitr = balances.begin();
+  while (bitr != balances.end()) {
+    bitr = balances.erase(bitr);
+  }
+
+  auto sitr = sizes.begin();
+  while (sitr != sizes.end()) {
+    sitr = sizes.erase(sitr);
+  }
+}
+
+
+ACTION pool::ontransfer (name from, name to, asset quantity, string memo) {
+
+  if (get_first_receiver() == contracts::token  &&  // from SEEDS token account
+      to  ==  get_self() &&                     // to here
+      quantity.symbol == utils::seeds_symbol) {        // SEEDS symbol
+
+    utils::check_asset(quantity);
+
+    name account = name(memo);
+    check(is_account(account), account.to_string() + " is not an account");
+
+    auto bitr = balances.find(account.value);
+
+    if (bitr == balances.end()) {
+      balances.emplace(_self, [&](auto & item){
+        item.account = account;
+        item.balance = quantity;
+      });
+    } else {
+      balances.modify(bitr, _self, [&](auto & item){
+        item.balance += quantity;
+      });
+    }
+    
+    size_change(total_balance_size, quantity.amount);
+  }
+
+}
+
+
+ACTION pool::payouts (asset quantity) {
+
+  require_auth(get_self());
+
+  uint64_t batch_size = config_get("batchsize"_n);
+  payout(quantity, uint64_t(0), batch_size, uint64_t(0));
+
+}
+
+
+ACTION pool::payout (asset quantity, uint64_t start, uint64_t chunksize, uint64_t accumulated_balance) {
+
+  require_auth(get_self());
+
+  auto bitr = start == 0 ? balances.begin() : balances.lower_bound(start);
+  uint64_t current = 0;
+
+  double total_balance = double(get_size(total_balance_size));
+
+  string memo("pool distribution");
+
+  while (bitr != balances.end() && current < chunksize) {
+
+    double percentage = bitr->balance.amount / total_balance;
+    asset amount_to_payout = asset(std::min(bitr->balance.amount, int64_t(percentage * quantity.amount)), utils::seeds_symbol);
+    
+    send_transfer(bitr->account, amount_to_payout, memo);
+
+    accumulated_balance += amount_to_payout.amount;
+
+    if (bitr->balance == amount_to_payout) {
+      bitr = balances.erase(bitr);
+    } else {
+      balances.modify(bitr, _self, [&](auto & item){
+        item.balance -= amount_to_payout;
+      });
+      bitr++;
+    }
+
+    current += 8;
+  }
+
+  if (bitr != balances.end()) {
+    action next_execution(
+      permission_level(get_self(), "active"_n),
+      get_self(),
+      "payout"_n,
+      std::make_tuple(quantity, bitr->account.value, chunksize, accumulated_balance)
+    );
+
+    transaction tx;
+    tx.actions.emplace_back(next_execution);
+    tx.delay_sec = 1;
+    tx.send(bitr->account.value, _self);
+  } else {
+    size_change(total_balance_size, -1 * accumulated_balance);
+  }
+
+}
+
+void pool::send_transfer (const name & to, const asset & quantity, const string & memo) {
+
+  action(
+    permission_level(get_self(), "active"_n),
+    contracts::token,
+    "transfer"_n,
+    std::make_tuple(get_self(), to, quantity, memo)
+  ).send();
+
+}
+

--- a/test/pool.test.js
+++ b/test/pool.test.js
@@ -1,0 +1,126 @@
+const { describe } = require("riteway")
+const { names, getTableRows, isLocal, initContracts, sleep, asset, getBalanceFloat } = require("../scripts/helper")
+
+const { firstuser, seconduser, thirduser, pool, accounts, settings, token } = names
+
+
+describe('Pool transfer and payout', async assert => {
+
+  if (!isLocal()) {
+    console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
+    return
+  }
+
+  const contracts = await initContracts({ pool, accounts, settings, token })
+
+  const users = [firstuser, seconduser, thirduser]
+
+  const checkBalances = async ({ expected, given, should }) => {
+    const balanceTable = await getTableRows({
+      code: pool,
+      scope: pool,
+      table: 'balances',
+      json: true
+    })
+    const sizesTable = await getTableRows({
+      code: pool,
+      scope: pool,
+      table: 'sizes',
+      json: true
+    })
+    assert({
+      given,
+      should,
+      actual: balanceTable.rows,
+      expected
+    })
+    assert({
+      given,
+      should,
+      actual: (sizesTable.rows.filter(r => r.id === 'total.sz')[0].size / 10000).toFixed(4),
+      expected: balanceTable.rows.length > 0 ? 
+        balanceTable.rows.map(r => asset(r.balance).amount).reduce((acc, curr) => acc + curr).toFixed(4) : 
+        '0.0000'
+    })
+  }
+
+  console.log('reset pool')
+  await contracts.pool.reset({ authorization: `${pool}@active` })
+
+  console.log('reset accounts')
+  await contracts.accounts.reset({ authorization: `${accounts}@active` })
+
+  console.log('reset settings')
+  await contracts.settings.reset({ authorization: `${settings}@active` })
+
+  console.log('reset token')
+  await contracts.token.resetweekly({ authorization: `${token}@active` })
+
+  console.log('get initial balances')
+  const balancesBefore = await Promise.all(users.map(user => getBalanceFloat(user)))
+
+  console.log(`transfer to ${pool}`)
+  await Promise.all(users.map((user, index) => contracts.token.transfer(user, pool, `${10 * (index+1)}.0000 SEEDS`, user, { authorization: `${user}@active` })))
+
+  await checkBalances({
+    expected: [
+      { account: firstuser, balance: '10.0000 SEEDS' },
+      { account: seconduser, balance: '20.0000 SEEDS' },
+      { account: thirduser, balance: '30.0000 SEEDS' }
+    ],
+    given: 'transfered SEEDS',
+    should: 'have the correct balances'
+  })
+
+  console.log('set batchsize to 2')
+  await contracts.settings.configure('batchsize', 2, { authorization: `${settings}@active` })
+
+  console.log('payout Seeds')
+  await contracts.pool.payouts('10.0000 SEEDS', { authorization: `${pool}@active` })
+  await sleep(2000)
+
+  await checkBalances({
+    expected: [
+      { account: firstuser, balance: '8.3334 SEEDS' },
+      { account: seconduser, balance: '16.6667 SEEDS' },
+      { account: thirduser, balance: '25.0000 SEEDS' }
+    ],
+    given: 'payout SEEDS',
+    should: 'have the correct balances'
+  })
+
+  console.log('payout more Seeds')
+  await contracts.pool.payouts('20.0000 SEEDS', { authorization: `${pool}@active` })
+  await sleep(2000)
+
+  await checkBalances({
+    expected: [
+      { account: firstuser, balance: '5.0001 SEEDS' },
+      { account: seconduser, balance: '10.0001 SEEDS' },
+      { account: thirduser, balance: '15.0001 SEEDS' }
+    ],
+    given: 'payout more SEEDS',
+    should: 'have the correct balances'
+  })
+
+  console.log('payout all the Seeds')
+  await contracts.pool.payouts('2000.0000 SEEDS', { authorization: `${pool}@active` })
+  await sleep(2000)
+
+  await checkBalances({
+    expected: [],
+    given: 'payout all SEEDS',
+    should: 'have the correct balances'
+  })
+
+  console.log('get balances after')
+  const balancesAfter = await Promise.all(users.map(user => getBalanceFloat(user)))
+
+  assert({
+    given: 'all the payouts completed',
+    should: 'have the correct Seeds balance',
+    actual: balancesAfter.map((balanceAfter, index) => balanceAfter - balancesBefore[index]).reduce((acc, curr) => acc + curr),
+    expected: 0
+  })
+
+})

--- a/test/pool.test.js
+++ b/test/pool.test.js
@@ -1,7 +1,7 @@
 const { describe } = require("riteway")
 const { names, getTableRows, isLocal, initContracts, sleep, asset, getBalanceFloat } = require("../scripts/helper")
 
-const { firstuser, seconduser, thirduser, pool, accounts, settings, token } = names
+const { firstuser, seconduser, thirduser, pool, accounts, settings, token, escrow } = names
 
 
 describe('Pool transfer and payout', async assert => {
@@ -60,7 +60,8 @@ describe('Pool transfer and payout', async assert => {
   const balancesBefore = await Promise.all(users.map(user => getBalanceFloat(user)))
 
   console.log(`transfer to ${pool}`)
-  await Promise.all(users.map((user, index) => contracts.token.transfer(user, pool, `${10 * (index+1)}.0000 SEEDS`, user, { authorization: `${user}@active` })))
+  await Promise.all(users.map((user, index) => contracts.token.transfer(user, escrow, `${10 * (index+1)}.0000 SEEDS`, '', { authorization: `${user}@active` })))
+  await Promise.all(users.map((user, index) => contracts.token.transfer(escrow, pool, `${10 * (index+1)}.0000 SEEDS`, user, { authorization: `${escrow}@active` })))
 
   await checkBalances({
     expected: [
@@ -91,7 +92,7 @@ describe('Pool transfer and payout', async assert => {
 
   console.log('payout more Seeds')
   await contracts.pool.payouts('20.0000 SEEDS', { authorization: `${pool}@active` })
-  await sleep(2000)
+  await sleep(4000)
 
   await checkBalances({
     expected: [
@@ -104,7 +105,7 @@ describe('Pool transfer and payout', async assert => {
   })
 
   console.log('payout all the Seeds')
-  await contracts.pool.payouts('2000.0000 SEEDS', { authorization: `${pool}@active` })
+  await contracts.pool.payouts('30.0003 SEEDS', { authorization: `${pool}@active` })
   await sleep(2000)
 
   await checkBalances({

--- a/test/proposals.test.js
+++ b/test/proposals.test.js
@@ -1829,7 +1829,7 @@ describe('Active count and vote power', async assert => {
 })
 
 
-describe.only('Voice decay', async assert => {
+describe('Voice decay', async assert => {
 
   if (!isLocal()) {
     console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")


### PR DESCRIPTION
Fixes #224 

- Added new contract call pool.seeds. I added the contract to local and testnet configuration in helper.js but not in main net.
- Changed escrow contract to send the dSeeds as soon as go live is triggerd. It also sends the dSeeds when the locks are claimed.
- Changed harvest so they mint 50% less in case dSeeds > 0, and distribute the other 50% as dSeeds
- Added tests for pool, harvest, escrow and proposals

## Deployment

#### Contracts that need to be deployed:
- [ ] Pool (new contract)
- [ ] Harvest
- [ ] Escrow

#### Other considerations:
- [ ] Permissions need to be updated


