### PR TITLE
Make Token transfer more efficient #315 (History part)

### DIFF
--- a/include/seeds.history.hpp
+++ b/include/seeds.history.hpp
@@ -244,9 +244,6 @@ CONTRACT history : public contract {
 
       TABLE deferred_trx_id_table {
         uint64_t id;
-        uint64_t value;
-
-        uint64_t primary_key() const { return id; }
       };
 
       TABLE planted_table { // harvest contract
@@ -316,7 +313,9 @@ CONTRACT history : public contract {
         const_mem_fun<trx_cbp_rewards_table, uint128_t, &trx_cbp_rewards_table::by_account_key>>
       > trx_cbp_rewards_tables;
 
-      typedef eosio::multi_index<"dtrxid"_n, deferred_trx_id_table> deferred_trx_id_tables;
+
+      typedef singleton<"dtrxid"_n, deferred_trx_id_table> deferred_trx_id_tables;
+      typedef eosio::multi_index<"dtrxid"_n, deferred_trx_id_table> dump_for_deferred_trx_id_tables;
 
       DEFINE_USER_TABLE
       

--- a/src/seeds.history.cpp
+++ b/src/seeds.history.cpp
@@ -216,8 +216,6 @@ void history::trxentry(name from, name to, asset quantity) {
 void history::savepoints (name from, name to, asset quantity, uint64_t trx_id) {
   require_auth(get_self());
 
-  print("SAVEPOINTS: from=", from, ", to=", to, ", quantity=", quantity, "\n");
-
   uint64_t day = utils::get_beginning_of_day_in_seconds();
   daily_transactions_tables transactions(get_self(), day);
 
@@ -810,23 +808,12 @@ void history::adjust_transactions (uint64_t id, uint64_t timestamp) {
 
 uint64_t history::get_deferred_id () {
   deferred_trx_id_tables deferred_t(get_self(), get_self().value);
+  deferred_trx_id_table d_t = deferred_t.get_or_create(get_self(), deferred_trx_id_table());
 
-  auto ditr = deferred_t.begin();
+  d_t.id += 1;
 
-  if (ditr == deferred_t.end()) {
-    deferred_t.emplace(_self, [&](auto & item){
-      item.id = 0;
-      item.value = 1;
-    });
-    return 1;
-  }
+  deferred_t.set(d_t, get_self());
 
-  uint64_t value = ditr->value + 1;
-
-  deferred_t.modify(ditr, _self, [&](auto & item){
-    item.value = value;
-  });
-
-  return value;
+  return d_t.id;
 }
 

--- a/test/accounts.test.js
+++ b/test/accounts.test.js
@@ -845,6 +845,8 @@ describe('make resident', async assert => {
   await contracts.accounts.adduser(firstuser, 'First user', "individual", { authorization: `${accounts}@active` })
   await contracts.accounts.adduser(seconduser, 'Second user', "individual", { authorization: `${accounts}@active` })
 
+  await contracts.token.transfer(seconduser, harvest, '1.0000 SEEDS', 'sow ' + seconduser, { authorization: `${seconduser}@active` })
+
   console.log('make resident - fail')
   try {
     await contracts.accounts.makeresident(firstuser, { authorization: `${firstuser}@active` })
@@ -931,6 +933,11 @@ describe('make citizen test', async assert => {
   await contracts.accounts.adduser(seconduser, 'Second user', "individual", { authorization: `${accounts}@active` })
   await contracts.accounts.adduser(thirduser, '3 user', "individual", { authorization: `${accounts}@active` })
   await contracts.accounts.adduser(fourthuser, '4 user', "individual", { authorization: `${accounts}@active` })
+
+  await contracts.token.transfer(firstuser, harvest, '1.0000 SEEDS', 'sow ' + firstuser, { authorization: `${firstuser}@active` })
+  await contracts.token.transfer(seconduser, harvest, '1.0000 SEEDS', 'sow ' + seconduser, { authorization: `${seconduser}@active` })
+  await contracts.token.transfer(thirduser, harvest, '1.0000 SEEDS', 'sow ' + thirduser, { authorization: `${thirduser}@active` })
+  await contracts.token.transfer(fourthuser, harvest, '1.0000 SEEDS', 'sow ' + fourthuser, { authorization: `${fourthuser}@active` })
 
   console.log('make citizen - fail')
   try {

--- a/test/harvest.test.js
+++ b/test/harvest.test.js
@@ -497,6 +497,10 @@ describe("harvest transaction score", async assert => {
   let users = [firstuser, seconduser, thirduser, fourthuser]
   users.forEach( async (user, index) => await contracts.accounts.adduser(user, index+' user', 'individual', { authorization: `${accounts}@active` }))
   users.forEach( async (user, index) => await contracts.history.reset(user, { authorization: `${history}@active` }))
+
+  await contracts.token.transfer(firstuser, harvest, '1.0000 SEEDS', 'sow ' + firstuser, { authorization: `${firstuser}@active` })
+  await contracts.token.transfer(seconduser, harvest, '1.0000 SEEDS', 'sow ' + seconduser, { authorization: `${seconduser}@active` })
+  await contracts.token.transfer(thirduser, harvest, '1.0000 SEEDS', 'sow ' + thirduser, { authorization: `${thirduser}@active` })
   
   await contracts.history.deldailytrx(day, { authorization: `${history}@active` })
   await sleep(100)
@@ -826,6 +830,7 @@ describe('contribution score', async assert => {
   
   await contracts.accounts.adduser(fifthuser, fifthuser, 'individual', { authorization: `${accounts}@active` })
   await contracts.accounts.testsetrs(fifthuser, 10, { authorization: `${accounts}@active` })
+  await contracts.token.transfer(fifthuser, harvest, '1.0000 SEEDS', `sow ${fifthuser}`, { authorization: `${fifthuser}@active` })
 
   for (let i = 0; i < users.length; i++) {
     const user = users[i]
@@ -1430,6 +1435,7 @@ describe('regions contribution score', async assert => {
     await contracts.accounts.adduser(user, i + ' user', 'individual', { authorization: `${accounts}@active` })
     await contracts.accounts.testsetrs(user, 49, { authorization: `${accounts}@active` })
     await contracts.history.reset(user, { authorization: `${history}@active` })
+    await contracts.token.transfer(user, harvest, '0.0001 SEEDS', 'sow ' + user, { authorization: `${user}@active` })
   }
 
   console.log('add regions')

--- a/test/history.test.js
+++ b/test/history.test.js
@@ -2,7 +2,7 @@ const { describe } = require("riteway")
 const { names, getTableRows, isLocal, initContracts, createKeypair } = require("../scripts/helper")
 const eosDevKey = "EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV"
 
-const { firstuser, seconduser, thirduser, fourthuser, history, accounts, organization, token, settings, region } = names
+const { firstuser, seconduser, thirduser, fourthuser, history, accounts, organization, token, settings, region, harvest } = names
 
 function getBeginningOfDayInSeconds () {
   const now = new Date()
@@ -19,9 +19,12 @@ describe('make a transaction entry', async assert => {
     console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
     return
   }
-  const contracts = await initContracts({ history, accounts, settings })
+  const contracts = await initContracts({ history, accounts, settings, token })
 
   const day = getBeginningOfDayInSeconds()
+
+  console.log('reset token')
+  await contracts.token.resetweekly({ authorization: `${token}@active` })
 
   console.log('settings reset')
   await contracts.settings.reset({ authorization: `${settings}@active` })
@@ -44,6 +47,9 @@ describe('make a transaction entry', async assert => {
   const seconduserRep = 49
   await contracts.accounts.testsetrs(firstuser, firstuserRep, { authorization: `${accounts}@active` })
   await contracts.accounts.testsetrs(seconduser, seconduserRep, { authorization: `${accounts}@active` })
+
+  await contracts.token.transfer(firstuser, harvest, '1.0000 SEEDS', 'sow ' + firstuser, { authorization: `${firstuser}@active` })
+  await contracts.token.transfer(seconduser, harvest, '1.0000 SEEDS', 'sow ' + seconduser, { authorization: `${seconduser}@active` })
 
   console.log('add transaction entry')
   await contracts.history.trxentry(firstuser, seconduser, '10.0000 SEEDS', { authorization: `${history}@active` })
@@ -292,9 +298,13 @@ describe('individual transactions', async assert => {
   await contracts.accounts.testsetrs(seconduser, seconduserRep, { authorization: `${accounts}@active` })
   await contracts.accounts.testsetrs(thirduser, thirduserRep, { authorization: `${accounts}@active` })
 
+  await contracts.token.transfer(firstuser, harvest, '1.0000 SEEDS', 'sow ' + firstuser, { authorization: `${firstuser}@active` })
+  await contracts.token.transfer(seconduser, harvest, '1.0000 SEEDS', 'sow ' + seconduser, { authorization: `${seconduser}@active` })
+  await contracts.token.transfer(thirduser, harvest, '1.0000 SEEDS', 'sow ' + thirduser, { authorization: `${thirduser}@active` })
+
   const transfer = async (from, to, quantity) => {
     await contracts.token.transfer(from, to, `${quantity}.0000 SEEDS`, 'test', { authorization: `${from}@active` })
-    await sleep(2000)
+    await sleep(1000)
   }
 
   const getTransactionEntries = async (user) => {
@@ -346,7 +356,10 @@ describe('individual transactions', async assert => {
 
   await transfer(thirduser, firstuser, 10)
 
+  await sleep(1000)
+
   const infoFirstUser = await getTransactionEntries(firstuser)
+
   const infoSecondUser = await getTransactionEntries(seconduser)
   const infoThirdUser = await getTransactionEntries(thirduser)
   const historyTotal = await getTransactionEntries(history)
@@ -655,7 +668,7 @@ describe('org transaction entry', async assert => {
         to_points: 0
       },
       {
-        id: 7,
+        id: 6,
         from: firstorg,
         to: firstuser,
         volume: 10000,
@@ -664,7 +677,7 @@ describe('org transaction entry', async assert => {
         to_points: 0
       },
       {
-        id: 8,
+        id: 7,
         from: firstorg,
         to: firstuser,
         volume: 50000,
@@ -673,7 +686,7 @@ describe('org transaction entry', async assert => {
         to_points: 0
       },
       {
-        id: 9,
+        id: 8,
         from: firstorg,
         to: secondorg,
         volume: 10000,
@@ -682,7 +695,7 @@ describe('org transaction entry', async assert => {
         to_points: 2
       },
       {
-        id: 10,
+        id: 9,
         from: seconduser,
         to: firstorg,
         volume: 10000,

--- a/test/organization.test.js
+++ b/test/organization.test.js
@@ -673,6 +673,8 @@ describe('organization scores', async assert => {
     await contracts.accounts.testsetrs(firstuser, 99, { authorization: `${accounts}@active` })
     await contracts.accounts.testsetrs(seconduser, 66, { authorization: `${accounts}@active` })
     await contracts.accounts.testsetrs(thirduser, 33, { authorization: `${accounts}@active` })
+
+    await Promise.all(users1.map(user => contracts.token.transfer(user, harvest, '0.0001 SEEDS', 'sow ' + user, { authorization: `${user}@active` })))
     
     console.log('create balance')
     await contracts.token.transfer(firstuser, organization, "400.0000 SEEDS", "Initial supply", { authorization: `${firstuser}@active` })
@@ -1142,6 +1144,7 @@ describe('organization status', async assert => {
 
     console.log('join users')
     await Promise.all(users.map(user => contracts.accounts.adduser(user, user, 'individual', { authorization: `${accounts}@active` })))
+    await Promise.all(users.map(user => { contracts.token.transfer(user, harvest, '0.0001 SEEDS', 'sow ' + user, { authorization: `${user}@active` }) }))
 
     console.log('create organizations')
     for (let index = 0; index < orgs.length; index++) {


### PR DESCRIPTION
- Removed the trx points calculation from the main token::transfer action.
- Added new table (singleton) to store the ids for deferred transactions.
- Modified tests for harvest, accounts, organizations and history

Considerations:
- The trxentry method now relies on the fact that all the users and orgs have an entry in the planted table from harvest
- Although the deferred transaction for saving the trx points is unique know, it is not ready to process several of calls for the same `from` and the same `to` in the same second, maybe due to the new size of the function. It means this PR doesn't implements a solution for #316 

__Contracts changed__:
- [ ] History

There aren't any other deployment considerations.
