### PR TITLE
Bugfix/token transfer cpu time

### DIFF
--- a/include/seeds.harvest.hpp
+++ b/include/seeds.harvest.hpp
@@ -16,6 +16,7 @@
 #include <tables/cbs_table.hpp>
 #include <tables/cspoints_table.hpp>
 #include <tables/organization_table.hpp>
+#include <tables/planted_table.hpp>
 #include <eosio/singleton.hpp>
 #include <cmath> 
 
@@ -175,21 +176,9 @@ CONTRACT harvest : public contract {
       uint64_t primary_key()const { return refund_id; }
     };
 
-    TABLE planted_table {
-      name account;
-      asset planted;
-      uint64_t rank;  
+    DEFINE_PLANTED_TABLE
 
-      uint64_t primary_key()const { return account.value; }
-      uint128_t by_planted() const { return (uint128_t(planted.amount) << 64) + account.value; } 
-      uint64_t by_rank() const { return rank; } 
-
-    };
-
-    typedef eosio::multi_index<"planted"_n, planted_table,
-      indexed_by<"byplanted"_n,const_mem_fun<planted_table, uint128_t, &planted_table::by_planted>>,
-      indexed_by<"byrank"_n,const_mem_fun<planted_table, uint64_t, &planted_table::by_rank>>
-    > planted_tables;
+    DEFINE_PLANTED_TABLE_MULTI_INDEX
 
     TABLE tx_points_table {
       name account;

--- a/include/seeds.harvest.hpp
+++ b/include/seeds.harvest.hpp
@@ -93,8 +93,6 @@ CONTRACT harvest : public contract {
     ACTION testupdatecs(name account, uint64_t contribution_score);
     ACTION testcspoints(name account, uint64_t contribution_points);
     
-    ACTION updtotal(); // MIGRATION ACTION
-
     ACTION setorgtxpt(name organization, uint64_t tx_points);
 
     ACTION calcmqevs();
@@ -414,7 +412,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
           (payforcpu)(reset)
           (unplant)(claimrefund)(cancelrefund)(sow)
           (ranktx)(calctrxpt)(calctrxpts)(rankplanted)(rankplanteds)(calccss)(calccs)(rankcss)(rankorgcss)(rankcs)(ranktxs)(rankorgtxs)(updatecs)(rankrgncss)(rankrgncs)
-          (updatetxpt)(updtotal)(calctotal)
+          (updatetxpt)(calctotal)
           (setorgtxpt)
           (testclaim)(testupdatecs)(testcalcmqev)(testcspoints)
           (calcmqevs)(calcmintrate)

--- a/include/seeds.organization.hpp
+++ b/include/seeds.organization.hpp
@@ -7,6 +7,7 @@
 #include <tables/config_table.hpp>
 #include <tables/rep_table.hpp>
 #include <tables/organization_table.hpp>
+#include <tables/planted_table.hpp>
 #include <cmath> 
 
 using namespace eosio;
@@ -113,6 +114,10 @@ CONTRACT organization : public contract {
         DEFINE_ORGANIZATION_TABLE
 
         DEFINE_ORGANIZATION_TABLE_MULTI_INDEX
+
+        DEFINE_PLANTED_TABLE
+
+        DEFINE_PLANTED_TABLE_MULTI_INDEX
 
         TABLE members_table {
             name account;
@@ -261,16 +266,6 @@ CONTRACT organization : public contract {
             uint64_t by_date() const { return date; }
         };
 
-        TABLE planted_table { // from harvest
-            name account;
-            asset planted;
-            uint64_t rank;  
-
-            uint64_t primary_key()const { return account.value; }
-            uint128_t by_planted() const { return (uint128_t(planted.amount) << 64) + account.value; } 
-            uint64_t by_rank() const { return rank; } 
-        };
-
         typedef eosio::multi_index<"balances"_n, tables::balance_table,
             indexed_by<"byplanted"_n,
             const_mem_fun<tables::balance_table, uint64_t, &tables::balance_table::by_planted>>
@@ -320,11 +315,6 @@ CONTRACT organization : public contract {
             indexed_by<"byrank"_n,
             const_mem_fun<cbs_organization_table, uint64_t, &cbs_organization_table::by_rank>>
         > cbs_organization_tables;
-
-        typedef eosio::multi_index<"planted"_n, planted_table,
-            indexed_by<"byplanted"_n,const_mem_fun<planted_table, uint128_t, &planted_table::by_planted>>,
-            indexed_by<"byrank"_n,const_mem_fun<planted_table, uint64_t, &planted_table::by_rank>>
-        > planted_tables;
 
         organization_tables organizations;
         sponsors_tables sponsors;

--- a/include/seeds.token.hpp
+++ b/include/seeds.token.hpp
@@ -10,6 +10,8 @@
 #include <contracts.hpp>
 #include <tables.hpp>
 #include <tables/config_table.hpp>
+#include <tables/planted_table.hpp>
+#include <tables/organization_table.hpp>
 #include <eosio/singleton.hpp>
 
 #include <string>
@@ -195,8 +197,6 @@ namespace eosio {
           symbol seeds_symbol = symbol("SEEDS", 4);
           symbol test_symbol = symbol("TESTS", 4);
 
-         DEFINE_CONFIG_TABLE
-
          struct [[eosio::table]] account {
             asset    balance;
 
@@ -229,18 +229,12 @@ namespace eosio {
             const_mem_fun<transaction_stats, uint64_t, &transaction_stats::by_transaction_volume>>
          > transaction_tables;
 
-          typedef eosio::multi_index<"users"_n, tables::user_table,
-            indexed_by<"byreputation"_n,
-            const_mem_fun<tables::user_table, uint64_t, &tables::user_table::by_reputation>>
-          > user_tables;
-
          void sub_balance( const name& owner, const asset& value );
          void add_balance( const name& owner, const asset& value, const name& ram_payer );
-         void update_stats( const name& from, const name& to, const asset& quantity );
+         void update_stats( name from, name to, asset quantity );
          void save_transaction(name from, name to, asset quantity);
-         void check_limit( const name& from );
          uint64_t balance_for( const name& owner );
-         void check_limit_transactions(name from);
+         void check_limit_transactions(name from, name to, asset quantity);
          void reset_weekly_aux(uint64_t begin);
 
          TABLE circulating_supply_table {
@@ -255,11 +249,20 @@ namespace eosio {
 
          circulating_supply_tables circulating;
 
-         typedef eosio::multi_index<"config"_n, config_table> config_tables;
-         typedef eosio::multi_index<"balances"_n, tables::balance_table,
-         indexed_by<"byplanted"_n,
-            const_mem_fun<tables::balance_table, uint64_t, &tables::balance_table::by_planted>>
-         > balance_tables;
+
+         // Seeds specific tables for transaction limits
+
+         DEFINE_CONFIG_TABLE
+         
+         DEFINE_CONFIG_TABLE_MULTI_INDEX
+
+         DEFINE_PLANTED_TABLE
+
+         DEFINE_PLANTED_TABLE_MULTI_INDEX
+
+         DEFINE_ORGANIZATION_TABLE
+
+         DEFINE_ORGANIZATION_TABLE_MULTI_INDEX
 
    };
    /** @}*/ // end of @defgroup eosiotoken eosio.token

--- a/include/tables/planted_table.hpp
+++ b/include/tables/planted_table.hpp
@@ -1,0 +1,19 @@
+#include <eosio/eosio.hpp>
+
+using eosio::name;
+
+#define DEFINE_PLANTED_TABLE TABLE planted_table { \
+      name account; \
+      asset planted; \
+      uint64_t rank; \
+\
+      uint64_t primary_key()const { return account.value; } \
+      uint128_t by_planted() const { return (uint128_t(planted.amount) << 64) + account.value; } \
+      uint64_t by_rank() const { return rank; } \
+    }; \
+
+#define DEFINE_PLANTED_TABLE_MULTI_INDEX \
+    typedef eosio::multi_index<"planted"_n, planted_table, \
+      indexed_by<"byplanted"_n,const_mem_fun<planted_table, uint128_t, &planted_table::by_planted>>, \
+      indexed_by<"byrank"_n,const_mem_fun<planted_table, uint64_t, &planted_table::by_rank>> \
+    > planted_tables; \

--- a/src/seeds.harvest.cpp
+++ b/src/seeds.harvest.cpp
@@ -332,48 +332,6 @@ ACTION harvest::calctotal(uint64_t startval) {
   } 
 }
 
-// copy everything to harvest table
-// ACTION harvest::updharvest(uint64_t startval) {
-
-//   total_table tt = total.get_or_create(get_self(), total_table());
-//   tt.total_planted = asset(0, seeds_symbol);
-//   total.set(tt, get_self());
-
-//   uint64_t limit = 50;
-
-//   auto bitr = startval == 0 ? balances.begin() : balances.find(startval);
-
-//   while (bitr != balances.end() && limit > 0) {
-//     if (bitr->planted.amount > 0 && bitr->account != _self) {
-//       planted.emplace(_self, [&](auto& entry) {
-//         entry.account = bitr->account;
-//         entry.planted = bitr->planted;
-//       });
-//       size_change(planted_size, 1);
-//       change_total(true, bitr->planted);
-//     }
-//     bitr++;
-//     limit--;
-//   }
-
-//   if (bitr != balances.end()) {
-
-//     uint64_t next_value = bitr->account.value;
-//     action next_execution(
-//         permission_level{get_self(), "active"_n},
-//         get_self(),
-//         "updharvest"_n,
-//         std::make_tuple(next_value)
-//     );
-
-//     transaction tx;
-//     tx.actions.emplace_back(next_execution);
-//     tx.delay_sec = 1;
-//     tx.send(next_value, _self);
-
-//   } 
-// }
-
 // Calculate Transaction Points for a single account
 // Returns count of iterations
 uint32_t harvest::calc_transaction_points(name account, name type) {

--- a/src/seeds.harvest.cpp
+++ b/src/seeds.harvest.cpp
@@ -859,7 +859,7 @@ void harvest::_withdraw(name beneficiary, asset quantity)
   auto bank_account = contracts::bank;
 
   token::transfer_action action{contracts::token, {contracts::bank, "active"_n}};
-  action.send(contracts::bank, beneficiary, quantity, "");sub_planted
+  action.send(contracts::bank, beneficiary, quantity, "");
 }
 
 void harvest::testclaim(name from, uint64_t request_id, uint64_t sec_rewind) {

--- a/src/seeds.harvest.cpp
+++ b/src/seeds.harvest.cpp
@@ -210,7 +210,6 @@ void harvest::cancelrefund(name from, uint64_t request_id) {
       uint32_t refund_time = ritr->request_time + ONE_WEEK * ritr->weeks_delay;
 
       if (refund_time > eosio::current_time_point().sec_since_epoch()) {
-        auto bitr = balances.find(from.value);
 
         add_planted(from, ritr->amount);
 


### PR DESCRIPTION
Fix for #315 

Reduce access to users table

Added access to org and planted tables: This is the minimal data we need to figure out if someone is within their limit.

If we wanted to do this in 1 table access, we would need a new planted table.

We need the info on org vs user downstream so we could just add it as parameters to the trx entry, so we don't have to look it up again in history. 

## Update: 4 table lookups is as good as it gets!

Talking with Ian, the history action needs to know the organization's level and also the region, to figure out the multiplier for the transaction points. 


Will look into it more, to add it as delayed action is possible, but Ian ran into some issues with it not always executing. 

We may just pass along the data from org and planted tables to history, so it doesn't need to look it up again. 

It's becoming more clear why transfers are expensive, they do a lot. 
