### PR TITLE
Migrate user accounts to limit String size #318

### DIFF
--- a/include/seeds.accounts.hpp
+++ b/include/seeds.accounts.hpp
@@ -96,6 +96,9 @@ CONTRACT accounts : public contract {
       ACTION delcbsreporg(uint64_t start_org);
       ACTION testmigscope(name account, uint64_t amount);
 
+      ACTION migusersizes(uint64_t start, uint64_t chunksize);
+      ACTION migusrsize(name account);
+
   private:
       symbol seeds_symbol = symbol("SEEDS", 4);
       symbol network_symbol = symbol("TLOS", 4);
@@ -381,4 +384,5 @@ EOSIO_DISPATCH(accounts, (reset)(adduser)(canresident)(makeresident)(cancitizen)
 (testmvouch)(migratevouch)
 (migorgs)(delcbsreporg)(testmigscope)
 (addcbs)
+(migusersizes)(migusrsize)
 );

--- a/src/seeds.accounts.cpp
+++ b/src/seeds.accounts.cpp
@@ -1723,3 +1723,57 @@ void accounts::migrate_calc_vouch_rep (name account) {
     });
   }
 }
+
+ACTION accounts::migusersizes (uint64_t start, uint64_t chunksize) {
+
+  require_auth(get_self());
+
+  auto uitr = start == 0 ? users.begin() : users.lower_bound(start);
+  uint64_t count = 0;
+
+  string none = "";
+
+  while (uitr != users.end() && count < chunksize) {
+    users.modify(uitr, _self, [&](auto & user){
+      user.nickname = user.nickname.size() <= 64 ? user.nickname : none;
+      user.image = user.image.size() <= 512 ? user.image : none;
+      user.roles = user.roles.size() <= 512 ? user.roles : none;
+      user.skills = user.skills.size() <= 512 ? user.skills : none;
+      user.interests = user.interests.size() <= 512 ? user.interests : none;
+    });
+    uitr++;
+  }
+
+  if (uitr != users.end()) {
+    action next_execution(
+      permission_level{get_self(), "active"_n},
+      get_self(),
+      "migusersizes"_n,
+      std::make_tuple(uitr->account.value, chunksize)
+    );
+
+    transaction tx;
+    tx.actions.emplace_back(next_execution);
+    tx.delay_sec = 1;
+    tx.send(uitr->account.value + 1, _self);
+  }
+}
+
+ACTION accounts::migusrsize (name account) {
+
+  require_auth(get_self());
+
+  auto uitr = users.find(account.value);
+  string none = "";
+
+  if (uitr != users.end()) {
+    users.modify(uitr, _self, [&](auto & user){
+      user.nickname = user.nickname.size() <= 64 ? user.nickname : none;
+      user.image = user.image.size() <= 512 ? user.image : none;
+      user.roles = user.roles.size() <= 512 ? user.roles : none;
+      user.skills = user.skills.size() <= 512 ? user.skills : none;
+      user.interests = user.interests.size() <= 512 ? user.interests : none;
+    });
+  }
+
+}

--- a/test/accounts.test.js
+++ b/test/accounts.test.js
@@ -1848,3 +1848,109 @@ describe('Migrate cbs and rep for orgs', async assert => {
   await printHarvestTables('org')
 
 })
+
+
+describe('Enforce accounts', async assert => {
+
+  if (!isLocal()) {
+    console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
+    return
+  }
+
+  const eosDevKey = 'EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV'
+
+  const contracts = await initContracts({ accounts, settings })
+
+  console.log('reset accounts')
+  await contracts.accounts.reset({ authorization: `${accounts}@active` })
+
+  console.log('reset settings')
+  await contracts.settings.reset({ authorization: `${settings}@active` })
+
+  const generateString = (length) => {
+    var result = ''
+    var characters = 'abcdefghijklmnopqrstuvwxyz1234'
+    var charactersLength = characters.length
+    for ( var i = 0; i < length; i++ ) {
+      result += characters.charAt(Math.floor(Math.random() * charactersLength))
+    }
+    return result
+  }
+
+  const string8000 = generateString(8000)
+  const string600 = generateString(600)
+  const string512 = generateString(512)
+
+  await contracts.accounts.adduser(firstuser, 'firstuser', 'individual', { authorization: `${accounts}@active` })
+  await contracts.accounts.adduser(seconduser, 'seconduser', 'individual', { authorization: `${accounts}@active` })
+  await contracts.accounts.adduser(thirduser, 'thirduser', 'individual', { authorization: `${accounts}@active` })
+  await contracts.accounts.adduser(fourthuser, 'fourthuser', 'individual', { authorization: `${accounts}@active` })
+
+  await contracts.accounts.update(
+    firstuser, 
+    "individual", 
+    string512,
+    string512,
+    string512,
+    string512,
+    string512,
+    string512,
+    { authorization: `${firstuser}@active` })
+
+  await contracts.accounts.update(
+    seconduser, 
+    "individual", 
+    seconduser,
+    string600,
+    string600,
+    string512,
+    string512,
+    string512,
+    { authorization: `${seconduser}@active` })
+
+  await contracts.accounts.update(
+    thirduser, 
+    "individual", 
+    thirduser,
+    string600,
+    string600,
+    string600,
+    string600,
+    string600,
+    { authorization: `${thirduser}@active` })
+
+  await contracts.accounts.migusersizes(0, 2, { authorization: `${accounts}@active` })
+  await sleep(2000)
+
+  const users = await getTableRows({
+    code: accounts,
+    scope: accounts,
+    table: 'users',
+    json: true
+  })
+  console.log(users)
+
+  await contracts.accounts.update(
+    fourthuser, 
+    "individual", 
+    fourthuser,
+    string512,
+    string512,
+    string512,
+    generateString(132000),
+    string512,
+    { authorization: `${fourthuser}@active` })
+
+  await contracts.accounts.migusrsize(fourthuser, { authorization: `${accounts}@active` })
+
+  const users2 = await getTableRows({
+    code: accounts,
+    scope: accounts,
+    table: 'users',
+    json: true
+  })
+  console.log(users2)
+
+})
+
+


### PR DESCRIPTION
Fixes #318 

- This one includes two functions to migrate the users table and force it  to use the new string limits: 
  - migusersizes: traverse all the users table enforcing the new limits
  - migusrsize: finds one user and enforce the new limits for that user

I added the migusrsize because I don't know if the user with 132 kB in a string will cause problems in the other function so maybe it's a good idea to process that user apart from the rest.

Both functions don't check for the story limits because according to @n13 the longest string for the `story` is 6000 characters long and the limit is 7000