### PR TITLE
Add moon phase to scheduler #239

### DIFF
--- a/include/seeds.scheduler.hpp
+++ b/include/seeds.scheduler.hpp
@@ -30,11 +30,11 @@ CONTRACT scheduler : public contract {
         // specify start time any time in the future, or use 0 for "now"
         ACTION configop(name id, name action, name contract, uint64_t period, uint64_t starttime);
 
+        ACTION configmoonop(name id, name action, name contract, uint64_t quarter_moon_cycles, uint64_t starttime);
+
         ACTION removeop(name id);
 
         ACTION pauseop(name id, uint8_t pause);
-
-        ACTION confirm(name operation);
         
         ACTION stop();
         
@@ -111,7 +111,7 @@ CONTRACT scheduler : public contract {
 
         typedef eosio::multi_index <"moonops"_n, moon_ops_table,
             indexed_by<"bylastcycle"_n,
-            const_mem_fun<moon_ops_table, uint64_t, &moon_ops_table::by_last_cycle>
+            const_mem_fun<moon_ops_table, uint64_t, &moon_ops_table::by_last_cycle>>
         > moon_ops_tables;
 
         typedef eosio::multi_index <"test"_n, test_table> test_tables;
@@ -124,5 +124,5 @@ CONTRACT scheduler : public contract {
         moon_phases_tables moonphases;
         moon_ops_tables moonops;
 
-        bool is_ready_to_execute(name operation);
+        uint64_t is_ready_to_execute(const name & operation, const name & optype, const uint64_t & timestamp);
 };

--- a/include/seeds.scheduler.hpp
+++ b/include/seeds.scheduler.hpp
@@ -17,6 +17,7 @@ CONTRACT scheduler : public contract {
         operations(receiver, receiver.value),
         moonphases(receiver, receiver.value),
         test(receiver, receiver.value),
+        moonops(receiver, receiver.value),
         config(contracts::settings, contracts::settings.value)
         {}
 
@@ -78,6 +79,19 @@ CONTRACT scheduler : public contract {
             uint64_t primary_key() const { return timestamp; }
         };
 
+        TABLE moon_ops_table {
+            name id;
+            name action;
+            name contract;
+            uint64_t quarter_moon_cycles;
+            uint64_t start_time;
+            uint64_t last_moon_cycle_id;
+            uint8_t pause;
+
+            uint64_t primary_key() const { return id.value; }
+            uint64_t by_last_cycle() const { return last_moon_cycle_id; }
+        };
+
         TABLE test_table {
             name param;
             uint64_t value;
@@ -89,10 +103,16 @@ CONTRACT scheduler : public contract {
         DEFINE_CONFIG_TABLE_MULTI_INDEX
 
         typedef eosio::multi_index < "operations"_n, operations_table,
-            indexed_by<"bytimestamp"_n, const_mem_fun<operations_table, uint64_t, &operations_table::by_timestamp>>
+            indexed_by<"bytimestamp"_n, 
+            const_mem_fun<operations_table, uint64_t, &operations_table::by_timestamp>>
         > operations_tables;
 
         typedef eosio::multi_index <"moonphases"_n, moon_phases_table> moon_phases_tables;
+
+        typedef eosio::multi_index <"moonops"_n, moon_ops_table,
+            indexed_by<"bylastcycle"_n,
+            const_mem_fun<moon_ops_table, uint64_t, &moon_ops_table::by_last_cycle>
+        > moon_ops_tables;
 
         typedef eosio::multi_index <"test"_n, test_table> test_tables;
 
@@ -102,6 +122,7 @@ CONTRACT scheduler : public contract {
         config_tables config;
         test_tables test;
         moon_phases_tables moonphases;
+        moon_ops_tables moonops;
 
         bool is_ready_to_execute(name operation);
 };

--- a/include/seeds.scheduler.hpp
+++ b/include/seeds.scheduler.hpp
@@ -124,5 +124,6 @@ CONTRACT scheduler : public contract {
         moon_phases_tables moonphases;
         moon_ops_tables moonops;
 
-        uint64_t is_ready_to_execute(const name & operation, const name & optype, const uint64_t & timestamp);
+        uint64_t is_ready_op(const name & operation, const uint64_t & timestamp);
+        uint64_t is_ready_moon_op(const name & operation, const uint64_t & timestamp);
 };

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -11,8 +11,7 @@ const networks = {
   mainnet: 'aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906',
   jungle: 'e70aaab8997e1dfce58fbfac80cbbb8fecec7b99cf982a9444273cbc64c41473',
   kylin: '5fff1dae8dc8e2fc4d5b23b2c7665c97f9e9d8edf2b6485a86ba311c25639191',
-  // local: process.env.COMPILER === 'local' ? eosioLocalChainID : dockerLocalChainID,
-  local: 'cf057bbfb72640471fd910bcb67639c22df9f92470936cddc1ade0e2f2e7dc4f',
+  local: process.env.COMPILER === 'local' ? eosioLocalChainID : dockerLocalChainID,
   telosTestnet: '1eaa0824707c8c16bd25145493bf062aecddfeb56c736f6ba6397f3195f33c9f',
   telosMainnet: '4667b205c6838ef70ff7988f6e8257e8be0e1284a2f59699054a018f743b1d11'
 }
@@ -85,7 +84,7 @@ const payForCPUKeys = {
 const payForCPUPublicKey = payForCPUKeys[chainId]
 
 const applicationKeys = {
-  [networks.local]: 'EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV', // 'EOS7HXZn1yhQJAiHbUXeEnPTVHoZLgAScNNELAyvWxoqQJzcLbbjq',
+  [networks.local]: 'EOS7HXZn1yhQJAiHbUXeEnPTVHoZLgAScNNELAyvWxoqQJzcLbbjq',
   [networks.telosMainnet]: 'EOS7HXZn1yhQJAiHbUXeEnPTVHoZLgAScNNELAyvWxoqQJzcLbbjq',
   [networks.telosTestnet]: 'EOS7HXZn1yhQJAiHbUXeEnPTVHoZLgAScNNELAyvWxoqQJzcLbbjq'
 }

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -11,7 +11,8 @@ const networks = {
   mainnet: 'aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906',
   jungle: 'e70aaab8997e1dfce58fbfac80cbbb8fecec7b99cf982a9444273cbc64c41473',
   kylin: '5fff1dae8dc8e2fc4d5b23b2c7665c97f9e9d8edf2b6485a86ba311c25639191',
-  local: process.env.COMPILER === 'local' ? eosioLocalChainID : dockerLocalChainID,
+  // local: process.env.COMPILER === 'local' ? eosioLocalChainID : dockerLocalChainID,
+  local: 'cf057bbfb72640471fd910bcb67639c22df9f92470936cddc1ade0e2f2e7dc4f',
   telosTestnet: '1eaa0824707c8c16bd25145493bf062aecddfeb56c736f6ba6397f3195f33c9f',
   telosMainnet: '4667b205c6838ef70ff7988f6e8257e8be0e1284a2f59699054a018f743b1d11'
 }
@@ -84,7 +85,7 @@ const payForCPUKeys = {
 const payForCPUPublicKey = payForCPUKeys[chainId]
 
 const applicationKeys = {
-  [networks.local]: 'EOS7HXZn1yhQJAiHbUXeEnPTVHoZLgAScNNELAyvWxoqQJzcLbbjq',
+  [networks.local]: 'EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV', // 'EOS7HXZn1yhQJAiHbUXeEnPTVHoZLgAScNNELAyvWxoqQJzcLbbjq',
   [networks.telosMainnet]: 'EOS7HXZn1yhQJAiHbUXeEnPTVHoZLgAScNNELAyvWxoqQJzcLbbjq',
   [networks.telosTestnet]: 'EOS7HXZn1yhQJAiHbUXeEnPTVHoZLgAScNNELAyvWxoqQJzcLbbjq'
 }


### PR DESCRIPTION
- Added moonops table
- Added `configmoonop` action and modified `removeop` and `pauseop` to interact with the moon operations
- Removed action `confirm` this action wasn't helping to confirm the correct execution, it was just consuming cpu time


Modified contracts:
- [ ] Scheduler

No migrations nor permissions update is needed