### PR TITLE
Token transfer bug - not all actions are recorded in history #316

### DIFF
--- a/include/seeds.history.hpp
+++ b/include/seeds.history.hpp
@@ -50,7 +50,9 @@ CONTRACT history : public contract {
 
         ACTION savepoints(uint64_t id, uint64_t timestamp);
 
-        ACTION sendtrxcbp(name from, name to);
+        ACTION sendtrxcbp(uint64_t deferred_id, name from, name to);
+
+        ACTION updatetxpt(uint64_t deferred_id, name from);
 
         ACTION testtotalqev(uint64_t numdays, uint64_t volume);
         ACTION migrate();
@@ -325,7 +327,7 @@ EOSIO_DISPATCH(history,
   (numtrx)
   (deldailytrx)(savepoints)
   (testtotalqev)
-  (sendtrxcbp)
+  (sendtrxcbp)(updatetxpt)
   (migrateusers)(migrateuser)
   (migrate)
 );

--- a/include/seeds.history.hpp
+++ b/include/seeds.history.hpp
@@ -220,6 +220,15 @@ CONTRACT history : public contract {
         uint64_t primary_key() const { return account.value; }
       };
 
+      TABLE processed_trx_table {
+        uint64_t id;
+        uint64_t transaction_id;
+        uint64_t timestamp;
+
+        uint64_t primary_key() const { return id; }
+        uint128_t by_timestamp_id() const { return (uint128_t(timestamp) << 64) + transaction_id; }
+      };
+
       DEFINE_ORGANIZATION_TABLE
 
       DEFINE_ORGANIZATION_TABLE_MULTI_INDEX
@@ -291,6 +300,11 @@ CONTRACT history : public contract {
       > qev_tables;
 
       typedef eosio::multi_index<"totals"_n, totals_table> totals_tables;
+
+      typedef eosio::multi_index<"ptrx"_n, processed_trx_table,
+        indexed_by<"bytimestmpid"_n,
+        const_mem_fun<processed_trx_table, uint128_t, &processed_trx_table::by_timestamp_id>>
+      > processed_trx_tables;
 
       typedef eosio::multi_index <"members"_n, members_table,
         indexed_by<"byregion"_n,const_mem_fun<members_table, uint64_t, &members_table::by_region>>

--- a/include/seeds.history.hpp
+++ b/include/seeds.history.hpp
@@ -2,6 +2,7 @@
 #include <contracts.hpp>
 #include <eosio/system.hpp>
 #include <eosio/asset.hpp>
+#include <eosio/singleton.hpp>
 #include <tables/config_table.hpp>
 #include <tables/config_float_table.hpp>
 #include <tables/size_table.hpp>
@@ -91,6 +92,7 @@ CONTRACT history : public contract {
       // migration functions
       void save_migration_user_transaction(name from, name to, asset quantity, uint64_t timestamp);
       void adjust_transactions(uint64_t id, uint64_t timestamp);
+      uint64_t get_deferred_id();
 
       TABLE citizen_table {
         uint64_t id;
@@ -238,6 +240,13 @@ CONTRACT history : public contract {
         uint64_t primary_key() const { return id; }
         uint128_t by_account_key() const { return (uint128_t(account.value) << 64) + key.value; }
       };
+
+      TABLE deferred_id_table {
+        uint64_t id;
+      };
+
+      typedef singleton<"deferredids"_n, deferred_id_table> deferred_id_tables;
+      typedef eosio::multi_index<"deferredids"_n, deferred_id_table> dump_for_deferred_id;
 
       typedef eosio::multi_index<"citizens"_n, citizen_table,
         indexed_by<"byaccount"_n,

--- a/test/history.test.js
+++ b/test/history.test.js
@@ -251,7 +251,7 @@ describe("make a history entry", async (assert) => {
 
 })
 
-describe('individual transactions', async assert => {
+describe.only('individual transactions', async assert => {
 
   if (!isLocal()) {
     console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
@@ -294,7 +294,6 @@ describe('individual transactions', async assert => {
 
   const transfer = async (from, to, quantity) => {
     await contracts.token.transfer(from, to, `${quantity}.0000 SEEDS`, 'test', { authorization: `${from}@active` })
-    await sleep(2000)
   }
 
   const getTransactionEntries = async (user) => {
@@ -345,6 +344,8 @@ describe('individual transactions', async assert => {
   await transfer(seconduser, thirduser, 100)
 
   await transfer(thirduser, firstuser, 10)
+
+  await sleep(6000)
 
   const infoFirstUser = await getTransactionEntries(firstuser)
   const infoSecondUser = await getTransactionEntries(seconduser)

--- a/test/history.test.js
+++ b/test/history.test.js
@@ -251,7 +251,7 @@ describe("make a history entry", async (assert) => {
 
 })
 
-describe.only('individual transactions', async assert => {
+describe('individual transactions', async assert => {
 
   if (!isLocal()) {
     console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
@@ -329,23 +329,25 @@ describe.only('individual transactions', async assert => {
   }
 
   console.log('add transaction entry')
-  // await transfer(firstuser, seconduser, 200) // trx points = 
-  // await transfer(firstuser, seconduser, 300)
-  // await transfer(firstuser, seconduser, 400)
+  await transfer(firstuser, seconduser, 200) // trx points = 
+  await transfer(firstuser, seconduser, 300)
+  await transfer(firstuser, seconduser, 400)
 
-  // await contracts.accounts.testsetrs(seconduser, 1, { authorization: `${accounts}@active` })
-  // await transfer(firstuser, seconduser, 750)
+  await sleep(2000)
 
-  // await transfer(seconduser, firstuser, 200)
-  // await transfer(seconduser, firstuser, 200)
+  await contracts.accounts.testsetrs(seconduser, 1, { authorization: `${accounts}@active` })
+  await transfer(firstuser, seconduser, 750)
+
+  await transfer(seconduser, firstuser, 200)
+  await transfer(seconduser, firstuser, 200)
 
   await transfer(seconduser, thirduser, 255)
   await transfer(seconduser, thirduser, 300)
   await transfer(seconduser, thirduser, 100)
 
-  // await transfer(thirduser, firstuser, 10)
+  await transfer(thirduser, firstuser, 10)
 
-  await sleep(6000)
+  await sleep(4000)
 
   const infoFirstUser = await getTransactionEntries(firstuser)
   const infoSecondUser = await getTransactionEntries(seconduser)
@@ -419,7 +421,7 @@ describe.only('individual transactions', async assert => {
         to_points: 0
       },
       {
-        id: 8,
+        id: 9,
         from: thirduser,
         to: firstuser,
         volume: 100000,
@@ -547,7 +549,6 @@ describe('org transaction entry', async assert => {
   
   const transfer = async (from, to, quantity) => {
     await contracts.token.transfer(from, to, `${quantity}.0000 SEEDS`, 'test', { authorization: `${from}@active` })
-    await sleep(2000)
   }
 
   const getTransactionEntries = async (user) => {
@@ -602,6 +603,8 @@ describe('org transaction entry', async assert => {
 
   await transfer(seconduser, firstorg, 1)
 
+  await sleep(5000)
+
   const infoFirstUser = await getTransactionEntries(firstuser)
   const infoFirstOrg = await getTransactionEntries(firstorg)
   const infoSecondUser = await getTransactionEntries(seconduser)
@@ -638,7 +641,7 @@ describe('org transaction entry', async assert => {
         to_points: 61
       },
       {
-        id: 3,
+        id: 5,
         from: firstorg,
         to: seconduser,
         volume: 20000,
@@ -647,7 +650,7 @@ describe('org transaction entry', async assert => {
         to_points: 0
       },
       {
-        id: 4,
+        id: 6,
         from: firstorg,
         to: seconduser,
         volume: 30000,
@@ -656,7 +659,7 @@ describe('org transaction entry', async assert => {
         to_points: 0
       },
       {
-        id: 7,
+        id: 10,
         from: firstorg,
         to: firstuser,
         volume: 10000,
@@ -665,7 +668,7 @@ describe('org transaction entry', async assert => {
         to_points: 0
       },
       {
-        id: 8,
+        id: 11,
         from: firstorg,
         to: firstuser,
         volume: 50000,
@@ -674,7 +677,7 @@ describe('org transaction entry', async assert => {
         to_points: 0
       },
       {
-        id: 9,
+        id: 12,
         from: firstorg,
         to: secondorg,
         volume: 10000,
@@ -683,7 +686,7 @@ describe('org transaction entry', async assert => {
         to_points: 2
       },
       {
-        id: 10,
+        id: 13,
         from: seconduser,
         to: firstorg,
         volume: 10000,

--- a/test/history.test.js
+++ b/test/history.test.js
@@ -329,21 +329,21 @@ describe.only('individual transactions', async assert => {
   }
 
   console.log('add transaction entry')
-  await transfer(firstuser, seconduser, 200) // trx points = 
-  await transfer(firstuser, seconduser, 300)
-  await transfer(firstuser, seconduser, 400)
+  // await transfer(firstuser, seconduser, 200) // trx points = 
+  // await transfer(firstuser, seconduser, 300)
+  // await transfer(firstuser, seconduser, 400)
 
-  await contracts.accounts.testsetrs(seconduser, 1, { authorization: `${accounts}@active` })
-  await transfer(firstuser, seconduser, 750)
+  // await contracts.accounts.testsetrs(seconduser, 1, { authorization: `${accounts}@active` })
+  // await transfer(firstuser, seconduser, 750)
 
-  await transfer(seconduser, firstuser, 200)
-  await transfer(seconduser, firstuser, 200)
+  // await transfer(seconduser, firstuser, 200)
+  // await transfer(seconduser, firstuser, 200)
 
   await transfer(seconduser, thirduser, 255)
   await transfer(seconduser, thirduser, 300)
   await transfer(seconduser, thirduser, 100)
 
-  await transfer(thirduser, firstuser, 10)
+  // await transfer(thirduser, firstuser, 10)
 
   await sleep(6000)
 

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -278,7 +278,10 @@ describe('token.resetweekly', async assert => {
     json: true
   })
 
-  balancesBefore = balancesBefore.rows.map(row => row.outgoing_transactions)
+  balancesBefore = balancesBefore.rows.filter(row => 
+      row.account == firstuser || row.account == seconduser || row.account == thirduser)
+
+  balancesBefore = balancesBefore.map(row => row.outgoing_transactions)
  
   console.log('reset token')
   await contracts.token.resetweekly({ authorization: `${token}@active` })
@@ -292,21 +295,24 @@ describe('token.resetweekly', async assert => {
     json: true
   })
 
-  balancesAfter = balancesAfter.rows.map(row => row.outgoing_transactions)
+  balancesAfter = balancesAfter.rows.filter(row => 
+    row.account == firstuser || row.account == seconduser || row.account == thirduser)
+
+  balancesAfter = balancesAfter.map(row => row.outgoing_transactions)
 
   await contracts.settings.reset({ authorization: `${settings}@active` })
 
   assert({
     given: 'called resetweekly',
     should: 'have trxstat table entry',
-    actual: balancesBefore.splice(0, 3),
+    actual: balancesBefore,
     expected: [1, 1, 1]
   })
 
   assert({
     given: 'called resetweekly',
     should: 'reset trxstat table',
-    actual: balancesAfter.splice(0, 3),
+    actual: balancesAfter,
     expected: [0, 0, 0]
   })
 


### PR DESCRIPTION
- Added a table to store the ids to use them in deferred transactions in history
- Added a new table to store the processed transactions. This is needed for the correct qev and trx points calculation.

Contracts modified:
- [ ] History

No migrations or settings are needed

