### PR TITLE
Create account only on active

### DIFF
--- a/include/seeds.region.hpp
+++ b/include/seeds.region.hpp
@@ -34,8 +34,9 @@ CONTRACT region : public contract {
             string description, 
             string locationJson, 
             float latitude, 
-            float longitude, 
-            string publicKey);
+            float longitude);
+
+        ACTION createacct(name region, string publicKey);
 
         ACTION join(name region, name account);
         ACTION leave(name region, name account);
@@ -194,7 +195,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
       execute_action<region>(name(receiver), name(code), &region::deposit);
   } else if (code == receiver) {
       switch (action) {
-          EOSIO_DISPATCH_HELPER(region, (reset)(create)(join)(leave)(addrole)(removerole)
+          EOSIO_DISPATCH_HELPER(region, (reset)(create)(createacct)(join)(leave)(addrole)(removerole)
           (removemember)(leaverole)(setfounder)(removergn))
       }
   }

--- a/src/seeds.region.cpp
+++ b/src/seeds.region.cpp
@@ -147,8 +147,7 @@ ACTION region::create(
     string description, 
     string locationJson, 
     float latitude, 
-    float longitude, 
-    string publicKey) 
+    float longitude) 
 {
     require_auth(founder);
     check_user(founder);
@@ -173,8 +172,6 @@ ACTION region::create(
     auto mitr = members.find(founder.value);
     check(mitr == members.end(), "Founder is part of another region. Leave the other region first.");
 
-    create_telos_account(founder, rgnaccount, publicKey);
-
     sponsors.modify(sitr, _self, [&](auto & mbalance) {
         mbalance.balance -= quantity;           
     });
@@ -197,7 +194,17 @@ ACTION region::create(
         item.account = founder;
         item.role = founder_role;
     });
+}
 
+ACTION region::createacct(name region, string publicKey) {
+    auto ritr = regions.require_find(region.value, "region not found");
+
+    require_auth(ritr->founder);
+    
+    check(ritr->status == status_active, "only can create account when the region is active");
+    check(!is_account(region), "region account already exists");
+
+    create_telos_account(ritr->founder, region, publicKey);
 }
 
 ACTION region::join(name region, name account) {

--- a/test/harvest.test.js
+++ b/test/harvest.test.js
@@ -1237,8 +1237,7 @@ async function testHarvest (assert, dSeeds) {
       'test rgn region',
       '{lat:0.0111,lon:1.3232}', 
       1.1, 
-      1.23, 
-      keypair.public, 
+      1.23,  
       { authorization: `${users[index]}@active` })
   }
 
@@ -1561,7 +1560,6 @@ describe('regions contribution score', async assert => {
       '{lat:0.0111,lon:1.3232}', 
       1.1, 
       1.23, 
-      keypair.public, 
       { authorization: `${users[index]}@active` })
   }
 

--- a/test/history.test.js
+++ b/test/history.test.js
@@ -834,7 +834,6 @@ describe('individual transactions', async assert => {
       '{lat:0.0111,lon:1.3232}', 
       1.1, 
       1.23, 
-      keypair.public, 
       { authorization: `${users[index]}@active` })
   }
 
@@ -983,7 +982,6 @@ describe('Transaction CBS', async assert => {
       '{lat:0.0111,lon:1.3232}', 
       1.1, 
       1.23, 
-      keypair.public, 
       { authorization: `${users[index]}@active` })
   }
 

--- a/test/region.test.js
+++ b/test/region.test.js
@@ -100,8 +100,7 @@ describe("regions general", async assert => {
     'test rgn region',
     '{lat:0.0111,lon:1.3232}', 
     1.1, 
-    1.23, 
-    keypair.public, 
+    1.23,  
     { authorization: `${firstuser}@active` })
 
     const regions = await getTableRows({
@@ -127,9 +126,21 @@ describe("regions general", async assert => {
   console.log('join a region')
   await contracts.region.join(rgnname, seconduser, { authorization: `${seconduser}@active` })
 
+  console.log('create the region account')
+  await contracts.region.createacct(rgnname, keypair.public, { authorization: `${firstuser}@active` })
+
+  let onlyCreateOnce = true
+  try {
+    await contracts.region.createacct(rgnname, keypair.public, { authorization: `${firstuser}@active` })
+    onlyCreateOnce = false
+  } catch (error) {
+    console.log('account region already exists (expected)')
+  }
+
   const members = await getMembers()
   //console.log("members "+JSON.stringify(members, null, 2))
   await checkStatus(rgnname, statusActive, `${seconduser} joined`, 'have the correct status')
+
 
   console.log('leave a region')
   await contracts.region.leave(rgnname, seconduser, { authorization: `${seconduser}@active` })
@@ -226,96 +237,101 @@ describe("regions general", async assert => {
     expected: seconduser
   })
   
+  assert({
+    given: 'region account created',
+    should: 'fail if called twice',
+    actual: onlyCreateOnce,
+    expected: true
+  })
 
 
+  assert({
+    given: 'create region',
+    should: 'have region',
+    actual: regions.rows.length,
+    expected: 1
+  })
 
-assert({
-  given: 'create region',
-  should: 'have region',
-  actual: regions.rows.length,
-  expected: 1
-})
+  assert({
+    given: 'create region',
+    should: 'have member',
+    actual: initialMembers.rows.length,
+    expected: 1
+  })
 
-assert({
-  given: 'create region',
-  should: 'have member',
-  actual: initialMembers.rows.length,
-  expected: 1
-})
+  assert({
+    given: 'join member',
+    should: 'have one more member',
+    actual: members.rows.length,
+    expected: 2
+  })
 
-assert({
-  given: 'join member',
-  should: 'have one more member',
-  actual: members.rows.length,
-  expected: 2
-})
+  assert({
+    given: 'leave',
+    should: 'have one less member',
+    actual: membersAfter.rows.length,
+    expected: 1
+  })
 
-assert({
-  given: 'leave',
-  should: 'have one less member',
-  actual: membersAfter.rows.length,
-  expected: 1
-})
+  assert({
+    given: 'member removed',
+    should: 'have one less member',
+    actual: membersAfterRemove.rows.length,
+    expected: 1
+  })
 
-assert({
-  given: 'member removed',
-  should: 'have one less member',
-  actual: membersAfterRemove.rows.length,
-  expected: 1
-})
-
-assert({
-  given: 'add role',
-  should: 'have role',
-  actual: roles.rows.map(({account})=>account),
-  expected: [
-    firstuser,
-    seconduser,
-]
-})
-assert({
-  given: 'remove role',
-  should: 'have role',
-  actual: rolesAfter.rows.map(({account})=>account),
-  expected: [
-    firstuser,
+  assert({
+    given: 'add role',
+    should: 'have role',
+    actual: roles.rows.map(({account})=>account),
+    expected: [
+      firstuser,
+      seconduser,
   ]
-})
+  })
+  assert({
+    given: 'remove role',
+    should: 'have role',
+    actual: rolesAfter.rows.map(({account})=>account),
+    expected: [
+      firstuser,
+    ]
+  })
 
-assert({
-  given: 'remove admin',
-  should: 'have one less member',
-  actual: membersBeforeAdminRemove.rows.length - membersAfterAdminRemove.rows.length,
-  expected: 1
-})
+  assert({
+    given: 'remove admin',
+    should: 'have one less member',
+    actual: membersBeforeAdminRemove.rows.length - membersAfterAdminRemove.rows.length,
+    expected: 1
+  })
 
-assert({
-  given: 'not allowed to remove member',
-  should: 'be true',
-  actual: cantremove,
-  expected: true
-})
+  assert({
+    given: 'not allowed to remove member',
+    should: 'be true',
+    actual: cantremove,
+    expected: true
+  })
 
-assert({
-  given: 'not allowed to add role',
-  should: 'be true',
-  actual: cantaddrole,
-  expected: true
-})
+  assert({
+    given: 'not allowed to add role',
+    should: 'be true',
+    actual: cantaddrole,
+    expected: true
+  })
 
-assert({
-  given: 'not allowed to set founder',
-  should: 'be true',
-  actual: cantsetfounder,
-  expected: true
-})
+  assert({
+    given: 'not allowed to set founder',
+    should: 'be true',
+    actual: cantsetfounder,
+    expected: true
+  })
 
-assert({
-  given: 'user left',
-  should: 'have to wait for the delay to end',
-  actual: delayWorks,
-  expected: true
-})
+  assert({
+    given: 'user left',
+    should: 'have to wait for the delay to end',
+    actual: delayWorks,
+    expected: true
+  })
 
 
 })
@@ -381,8 +397,7 @@ describe("regions Test Delete", async assert => {
     'test rgn region',
     '{lat:0.0111,lon:1.3232}', 
     1.1, 
-    1.23, 
-    keypair.public, 
+    1.23,
     { authorization: `${firstuser}@active` })
 
     lat = 39.0894
@@ -397,7 +412,6 @@ describe("regions Test Delete", async assert => {
       '{lat:0.0111,lon:1.3232}', 
       1.1, 
       1.23, 
-      keypair.public, 
       { authorization: `${seconduser}@active` })
   
   


### PR DESCRIPTION
- Added action `createacct` so the founder can create the region account when the regions is active
- Fixed tests

Contracts that need to be deployed:
- [ ] Regions

No migrations nor settings update are needed
