### PR TITLE
Added cleanptrxs action to delete the unused ptrx entries in history

### DIFF
--- a/include/seeds.history.hpp
+++ b/include/seeds.history.hpp
@@ -54,10 +54,13 @@ CONTRACT history : public contract {
 
         ACTION updatetxpt(uint64_t deferred_id, name from);
 
+        ACTION cleanptrxs();
+
         ACTION testtotalqev(uint64_t numdays, uint64_t volume);
         ACTION migrate();
         ACTION migrateusers();
         ACTION migrateuser(uint64_t start, uint64_t transaction_id, uint64_t chunksize);
+        ACTION testptrx(uint64_t timestamp);
 
 
     private:
@@ -342,6 +345,7 @@ EOSIO_DISPATCH(history,
   (deldailytrx)(savepoints)
   (testtotalqev)
   (sendtrxcbp)(updatetxpt)
+  (cleanptrxs)
   (migrateusers)(migrateuser)
-  (migrate)
+  (migrate)(testptrx)
 );

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -695,6 +695,17 @@ var permissions = [{
 }, {
   target: `${accounts.organization.account}@execute`,
   action: 'rankappuses'
+}, {
+  target: `${accounts.history.account}@active`,
+  actor: `${accounts.history.account}@eosio.code`
+}, {
+  target: `${accounts.history.account}@execute`,
+  actor: `${accounts.scheduler.account}@eosio.code`,
+  parent: 'active',
+  type: 'createActorPermission'
+}, {
+  target: `${accounts.history.account}@execute`,
+  action: 'cleanptrxs'
 }]
 
 const isTestnet = chainId == networks.telosTestnet

--- a/src/seeds.scheduler.cpp
+++ b/src/seeds.scheduler.cpp
@@ -120,7 +120,9 @@ void scheduler::reset_aux(bool destructive) {
         name("hrvst.hrvst"),
 
         name("org.appuses"),
-        name("org.rankapps")
+        name("org.rankapps"),
+
+        name("hstry.ptrxs")
     };
     
     std::vector<name> operations_v = {
@@ -156,7 +158,9 @@ void scheduler::reset_aux(bool destructive) {
         name("runharvest"),
 
         name("calcmappuses"),
-        name("rankappuses")
+        name("rankappuses"),
+
+        name("cleanptrxs")
     };
 
     std::vector<name> contracts_v = {
@@ -192,7 +196,9 @@ void scheduler::reset_aux(bool destructive) {
         contracts::harvest,
 
         contracts::organization,
-        contracts::organization
+        contracts::organization,
+
+        contracts::history
     };
 
     std::vector<uint64_t> delay_v = {
@@ -228,6 +234,8 @@ void scheduler::reset_aux(bool destructive) {
         utils::seconds_per_hour,
 
         utils::seconds_per_day,
+        utils::seconds_per_day,
+
         utils::seconds_per_day
     };
 
@@ -268,6 +276,8 @@ void scheduler::reset_aux(bool destructive) {
 
         now,
         now + 600 - utils::seconds_per_hour, // kicks off 10 minutes later
+        
+        now
     };
 
     int i = 0;

--- a/test/history.test.js
+++ b/test/history.test.js
@@ -97,6 +97,24 @@ describe('make a transaction entry', async assert => {
   const timestamp = txresult.timestamp
   delete txresult.timestamp
 
+
+  console.log('Delete ptrxs')
+  await contracts.settings.configure('batchsize', 1, { authorization: `${settings}@active` })
+
+  await contracts.history.testptrx(0, { authorization: `${history}@active` })
+  await contracts.history.testptrx(0, { authorization: `${history}@active` })
+
+  await contracts.history.cleanptrxs({ authorization: `${history}@active` })
+  await sleep(4000)
+
+  const ptrxTable = await getTableRows({
+    code: history,
+    scope: history,
+    table: 'ptrx',
+    json: true
+  })
+
+
   assert({
     given: 'transactions table',
     should: 'have transaction entry',
@@ -163,6 +181,13 @@ describe('make a transaction entry', async assert => {
         total_outgoing_to_rep_orgs: 0
       }
     ]
+  })
+
+  assert({
+    given: 'ptrx deleted',
+    should: 'only delete the previous transactions',
+    actual: ptrxTable.rows.length,
+    expected: 1
   })
 
 })
@@ -1009,6 +1034,8 @@ describe('Transaction CBS', async assert => {
     table: 'cbs',
     json: true
   })
+
+  await contracts.history.cleanptrxs({ authorization: `${history}@active` })
 
   assert({
     given: 'transactions made',

--- a/test/scheduler.test.js
+++ b/test/scheduler.test.js
@@ -2,7 +2,7 @@ const { describe } = require('riteway')
 const { eos, names, isLocal, getTableRows, initContracts } = require('../scripts/helper')
 const { equals, init } = require('ramda')
 
-const { scheduler, settings, organization, harvest, accounts, firstuser, token, forum } = names
+const { scheduler, settings, organization, harvest, accounts, firstuser, token, forum, history } = names
 
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -484,6 +484,11 @@ describe('scheduler, harvest', async assert => {
             id: 'hrvst.rorgcs',
             operation: 'rankorgcss',
             contract: harvest
+        },
+        {
+            id: 'hstry.ptrxs',
+            operation: 'cleanptrxs',
+            contract: history
         }
     ]
 


### PR DESCRIPTION
- Added the action `cleanptrxs` to delete the unused ptrx entries
- Added tests
- Added new permissions for scheduler

I configured the action to be executed daily. We should keep the daily transactions in that table so everything works fine.

Contracts that need to be deployed:
- [ ] History
- [ ] Scheduler

Other considerations:
- [ ] Permissions need to be updated
- [ ] Scheduler needs to be updated