### PR TITLE
Fix referendum vote allication

### DIFF
--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -142,6 +142,8 @@ CONTRACT proposals : public contract {
 
       name alliance_type = "alliance"_n;
       name campaign_type = "campaign"_n;
+      name referendum_type = "referendum"_n;
+
       name campaign_invite_type = "cmp.invite"_n;
       name campaign_funding_type = "cmp.funding"_n;
       name milestone_type = "milestone"_n;
@@ -149,7 +151,8 @@ CONTRACT proposals : public contract {
       std::vector<name> scopes = {
         alliance_type,
         get_self(),
-        milestone_type
+        milestone_type,
+        referendum_type,
       };
 
       void update_cycle();

--- a/include/seeds.referendums.hpp
+++ b/include/seeds.referendums.hpp
@@ -70,6 +70,8 @@ CONTRACT referendums : public contract {
 
       ACTION addvoice(name account, uint64_t amount);
 
+      ACTION updatevoice(uint64_t start, uint64_t batchsize);
+
       ACTION cancelvote(name voter, uint64_t referendum_id);
 
       ACTION onperiod();
@@ -150,7 +152,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
       execute_action<referendums>(name(receiver), name(code), &referendums::stake);
   } else if (code == receiver) {
       switch (action) {
-        EOSIO_DISPATCH_HELPER(referendums, (reset)(addvoice)(create)(update)(favour)(against)(cancelvote)(onperiod))
+        EOSIO_DISPATCH_HELPER(referendums, (reset)(addvoice)(create)(update)(favour)(against)(cancelvote)(onperiod)(updatevoice))
       }
   }
 }

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -745,7 +745,6 @@ void proposals::updatevoice(uint64_t start) {
   uint64_t cutoff_date = active_cutoff_date();
 
   cs_points_tables cspoints(contracts::harvest, contracts::harvest.value);
-  voice_tables voice_alliance(get_self(), alliance_type.value);
 
   auto vitr = start == 0 ? voice.begin() : voice.find(start);
 


### PR DESCRIPTION
added referendum scope to votes

referendums grabs voice from proposals

missing: need to go through and see if anyone has been removed from voice in the meantime, and remove them from referendum voice too. but - they won't get updated so in any case voice decay should zero them out over time once that's implemented.