### PR TITLE
rename mintts to minthrvst

### DIFF
--- a/include/seeds.token.hpp
+++ b/include/seeds.token.hpp
@@ -180,7 +180,7 @@ namespace eosio {
 
          ACTION updatecirc();
 
-         ACTION minttst(const name& to, const asset& quantity, const string& memo);
+         ACTION minthrvst(const name& to, const asset& quantity, const string& memo);
 
          using create_action = eosio::action_wrapper<"create"_n, &token::create>;
          using issue_action = eosio::action_wrapper<"issue"_n, &token::issue>;
@@ -189,7 +189,7 @@ namespace eosio {
          using transfer_action = eosio::action_wrapper<"transfer"_n, &token::transfer>;
          using open_action = eosio::action_wrapper<"open"_n, &token::open>;
          using close_action = eosio::action_wrapper<"close"_n, &token::close>;
-         using issue_action_test = eosio::action_wrapper<"minttst"_n, &token::minttst>;
+         using mint_action = eosio::action_wrapper<"minthrvst"_n, &token::minthrvst>;
 
       private:
           symbol seeds_symbol = symbol("SEEDS", 4);

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -629,7 +629,7 @@ var permissions = [{
   type: 'createActorPermission'
 }, {
   target: `${accounts.token.account}@minthrvst`,
-  action: 'minttst'
+  action: 'minthrvst'
 }, { 
   target: `${accounts.harvest.account}@active`,
   actor: `${accounts.organization.account}@active`

--- a/src/seeds.harvest.cpp
+++ b/src/seeds.harvest.cpp
@@ -1272,7 +1272,7 @@ void harvest::runharvest() {
 
   print("minted:", quantity, "\n");
 
-  token::issue_action_test t_issue{contracts::token, { contracts::token, "minthrvst"_n }};
+  token::mint_action t_issue{contracts::token, { contracts::token, "minthrvst"_n }};
   t_issue.send(get_self(), quantity, memo);
 
   double users_percentage = config_get("hrvst.users"_n) / 1000000.0;

--- a/src/seeds.token.cpp
+++ b/src/seeds.token.cpp
@@ -407,7 +407,7 @@ uint64_t token::balance_for( const name& owner ) {
 }
 
 
-void token::minttst (const name& to, const asset& quantity, const string& memo) {
+void token::minthrvst (const name& to, const asset& quantity, const string& memo) {
 
   require_auth(get_self());
 
@@ -441,4 +441,4 @@ void token::minttst (const name& to, const asset& quantity, const string& memo) 
 
 } /// namespace eosio
 
-EOSIO_DISPATCH( eosio::token, (create)(issue)(transfer)(open)(close)(retire)(burn)(resetweekly)(resetwhelper)(updatecirc)(minttst) )
+EOSIO_DISPATCH( eosio::token, (create)(issue)(transfer)(open)(close)(retire)(burn)(resetweekly)(resetwhelper)(updatecirc)(minthrvst) )


### PR DESCRIPTION
Rename minttst to minthrvst since we will use it to mint

in the future adding permissions will be more complicated

## Deployment

remove existing minthrvst permission before deploying this, to be safe

```
  target: `${accounts.token.account}@minthrvst`,
  action: 'minttst'
  action: 'minthrvst'

```