### PR TITLE
Fixing Gratitude Tokens recursive new round

### DIFF
--- a/include/seeds.gratitude.hpp
+++ b/include/seeds.gratitude.hpp
@@ -24,6 +24,7 @@ CONTRACT gratitude : public contract {
         balances(receiver, receiver.value),
         acks(receiver, receiver.value),
         stats(receiver, receiver.value),
+        stats2(receiver, receiver.value),
         sizes(receiver, receiver.value),
         users(contracts::accounts, contracts::accounts.value),
         config(contracts::settings, contracts::settings.value)
@@ -41,7 +42,7 @@ CONTRACT gratitude : public contract {
     ACTION newround();
 
     // Called after all acks are calculated
-    ACTION payround();
+    ACTION payround(uint64_t start, uint64_t usable_bal);
 
     // Recursivelly calculate acks
     ACTION calcacks(uint64_t start);
@@ -108,6 +109,14 @@ CONTRACT gratitude : public contract {
     TABLE stats_table {
       uint64_t round_id;
       uint64_t num_transfers;
+      asset volume;
+
+      uint64_t primary_key() const { return round_id; }
+    };
+
+    TABLE stats_table_v2 {
+      uint64_t round_id;
+      uint64_t num_transfers;
       uint64_t num_acks;
       asset round_pot;
       asset volume;
@@ -124,9 +133,12 @@ CONTRACT gratitude : public contract {
 
     typedef eosio::multi_index<"stats"_n, stats_table> stats_tables;
 
+    typedef eosio::multi_index<"stats2"_n, stats_table_v2> stats_tables_v2;
+
     balance_tables balances;
     acks_tables acks;
     stats_tables stats;
+    stats_tables_v2 stats2;
 
     // External tables
     user_tables users;

--- a/include/seeds.gratitude.hpp
+++ b/include/seeds.gratitude.hpp
@@ -61,6 +61,7 @@ CONTRACT gratitude : public contract {
 
     void check_user(name account);
     void init_balances(name account);
+    void reset_balances(name account);
     void _calc_acks(name account);
     void add_gratitude(name account, asset quantity);
     void sub_gratitude(name account, asset quantity);

--- a/include/seeds.gratitude.hpp
+++ b/include/seeds.gratitude.hpp
@@ -40,13 +40,25 @@ CONTRACT gratitude : public contract {
     // Generates a new gratitude round, regenerating gratitude and splitting stored SEEDS
     ACTION newround();
 
+    // Called after all acks are calculated
+    ACTION payround();
+
+    //  Recursivelly calculate acks
+    ACTION calcacks(uint64_t start);
+
+    //  Calculate acks for testing
     ACTION testacks();
+
+
+    // Called when depositing SEEDS into the pot
+    ACTION deposit(name from, name to, asset quantity, string memo);
+
 
   private:
 
     void check_user(name account);
     void init_balances(name account);
-    void calc_acks(name account);
+    void _calc_acks(name account);
     void add_gratitude(name account, asset quantity);
     void sub_gratitude(name account, asset quantity);
     uint64_t get_current_volume();
@@ -94,6 +106,8 @@ CONTRACT gratitude : public contract {
     TABLE stats_table {
       uint64_t round_id;
       uint64_t num_transfers;
+      uint64_t num_acks;
+      asset round_pot;
       asset volume;
 
       uint64_t primary_key() const { return round_id; }
@@ -120,8 +134,24 @@ CONTRACT gratitude : public contract {
     const name gratzgen_res = "gratz1.gen"_n; // Gratitude generated per cycle for residents
     const name gratzgen_cit = "gratz2.gen"_n; // Gratitude generated per cycle for citizens
     const name gratz_acks = "gratz.acks"_n; // Gratitude generated per cycle for citizens
+    const name gratz_potkp = "gratz.potkp"_n; // Percentil of the pot to keep each round
 };
 
-EOSIO_DISPATCH(gratitude, 
-  (reset)(give)(acknowledge)(newround)(testacks)
-);
+extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
+  if (action == name("transfer").value && code == contracts::token.value) {
+      execute_action<gratitude>(name(receiver), name(code), &gratitude::deposit);
+  } else if (code == receiver) {
+      switch (action) {
+        EOSIO_DISPATCH_HELPER(gratitude, 
+          (reset)
+          (give)
+          (acknowledge)
+          (newround)
+          (payround)
+          (calcacks)
+          (testacks)
+        )
+      }
+  }
+}
+

--- a/include/seeds.gratitude.hpp
+++ b/include/seeds.gratitude.hpp
@@ -43,12 +43,14 @@ CONTRACT gratitude : public contract {
     // Called after all acks are calculated
     ACTION payround();
 
-    //  Recursivelly calculate acks
+    // Recursivelly calculate acks
     ACTION calcacks(uint64_t start);
 
-    //  Calculate acks for testing
-    ACTION testacks();
+    // For stats migration
+    ACTION migratestats();
 
+    // Calculate acks for testing
+    ACTION testacks();
 
     // Called when depositing SEEDS into the pot
     ACTION deposit(name from, name to, asset quantity, string memo);
@@ -150,6 +152,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
           (payround)
           (calcacks)
           (testacks)
+          (migratestats)
         )
       }
   }

--- a/src/seeds.gratitude.cpp
+++ b/src/seeds.gratitude.cpp
@@ -165,7 +165,9 @@ ACTION gratitude::payround() {
   stats.emplace(_self, [&](auto& item) {
     item.round_id = ++cur_round_id;
     item.num_transfers = 0;
+    item.num_acks = 0;
     item.volume = asset(0, gratitude_symbol);
+    item.round_pot = asset(0, seeds_symbol);
   });
 
 

--- a/src/seeds.gratitude.cpp
+++ b/src/seeds.gratitude.cpp
@@ -24,13 +24,18 @@ ACTION gratitude::reset () {
     stitr = stats.erase(stitr);
   }
 
+  auto stitr2 = stats2.begin();
+  while (stitr2 != stats2.end()) {
+    stitr2 = stats2.erase(stitr2);
+  }
+
   // setup first round
-  stats.emplace(_self, [&](auto& item) {
+  stats2.emplace(_self, [&](auto& item) {
     item.round_id = 1;
     item.num_transfers = 0;
     item.num_acks = 0;
     item.volume = asset(0, gratitude_symbol);
-    item.round_pot = asset(0, seeds_symbol);
+    item.round_pot = eosio::token::get_balance(contracts::token, get_self(), seeds_symbol.code());
   });
 
 }
@@ -38,12 +43,9 @@ ACTION gratitude::reset () {
 ACTION gratitude::migratestats() {
   require_auth(get_self());
 
-  name old = "gratz.seeds"_n;
-
-  stats_tables other_stats(old, old.value);
-  auto sitr = other_stats.begin();
-  while(sitr != other_stats.end()) {
-    stats.emplace(get_self(), [&](auto& item) {
+  auto sitr = stats.begin();
+  while(sitr != stats.end()) {
+    stats2.emplace(get_self(), [&](auto& item) {
       item.round_id = sitr->round_id;
       item.num_transfers = sitr->num_transfers;
       item.volume = sitr->volume;
@@ -51,7 +53,8 @@ ACTION gratitude::migratestats() {
       item.num_acks = 0;
       item.round_pot = asset(0, seeds_symbol);
     });
-    sitr++;
+    // Remove old one
+    sitr = stats.erase(sitr);
   }
 }
 
@@ -81,6 +84,10 @@ ACTION gratitude::acknowledge (name from, name to, string memo) {
   check(is_account(to), "gratitude: to account does not exist");
   check_user(to);
 
+  // Should create balances if not there yet
+  init_balances(to);
+  init_balances(from);
+
   auto actr = acks.find(from.value);
   if (actr == acks.end()) {
     acks.emplace(_self, [&](auto& item) {
@@ -94,12 +101,12 @@ ACTION gratitude::acknowledge (name from, name to, string memo) {
   }
 
   // Updates ack stats
-  auto stitr = stats.rbegin();
+  auto stitr = stats2.rbegin();
   auto round_id = stitr->round_id;
 
-  auto stitr2 = stats.find(round_id);
+  auto stitr2 = stats2.find(round_id);
   auto oldacks = stitr2->num_acks;
-  stats.modify(stitr2, _self, [&](auto& item) {
+  stats2.modify(stitr2, _self, [&](auto& item) {
       item.num_acks = oldacks + 1;
   });
 
@@ -113,7 +120,7 @@ ACTION gratitude::testacks() {
 
   while (actr != acks.end()) {
     _calc_acks(actr->donor);
-    actr++;
+    actr = acks.erase(actr);
   }
 }
 
@@ -122,12 +129,9 @@ ACTION gratitude::calcacks(uint64_t start) {
 
   auto actr = start == 0 ? acks.begin() : acks.find(start);
 
-  _calc_acks(actr->donor);
-
-  actr++;
-
   // Recursion call
   if (actr != acks.end()) {
+    _calc_acks(actr->donor);
     action next_execution(
       permission_level{get_self(), "active"_n},
       get_self(),
@@ -139,59 +143,79 @@ ACTION gratitude::calcacks(uint64_t start) {
     tx.actions.emplace_back(next_execution);
     tx.delay_sec = 1;
     tx.send(actr->donor.value, _self);
+    actr++;
   } else {
-    // Cleanup on last exec
     auto actr2 = acks.begin();
     while (actr2 != acks.end()) {
       actr2 = acks.erase(actr2);
     }
 
-    // Start payout
+    // Starts recursive payout
+    auto contract_balance = eosio::token::get_balance(contracts::token, get_self(), seeds_symbol.code());
+    float potkeep = config_get(gratz_potkp) / (float)100;
+    uint64_t usable_amount = contract_balance.amount - (contract_balance.amount * potkeep);
+
     action(
       permission_level{get_self(), "active"_n},
       get_self(),
       "payround"_n,
-      std::make_tuple()
+      std::make_tuple((uint64_t)0, usable_amount)
     ).send();
-
   }
 }
 
-// Called after all Acks are calculated
-ACTION gratitude::payround() {
+// Recursively pay accounts
+ACTION gratitude::payround(uint64_t start, uint64_t usable_bal) {
   require_auth(get_self());
 
-  auto contract_balance = eosio::token::get_balance(contracts::token, get_self(), seeds_symbol.code());
-  uint64_t tot_accounts = get_size("balances.sz"_n);
   uint64_t volume = get_current_volume();
-  float potkeep = config_get(gratz_potkp) / (float)100;
-  uint64_t usable_amount = contract_balance.amount - (contract_balance.amount * potkeep);
+  auto bitr = start == 0 ? balances.begin() : balances.find(start);
+  uint64_t current = 0;
+  auto chunksize = config_get("batchsize"_n);
 
-  auto bitr = balances.begin();
-  while (bitr != balances.end()) {
-    uint64_t my_received = bitr->received.amount;
-    // reset gratitude for account
-    init_balances(bitr->account);
-    float split_factor = my_received / (float)volume;
-    uint64_t payout = usable_amount * split_factor;
-    // Pay out SEEDS in store
-    if (payout > 0) _transfer(bitr->account, asset(payout, seeds_symbol), "gratitude bonus");
-    bitr++;
+  if (bitr != balances.end()) 
+    if (current < chunksize) {
+      eosio::print("PAYROUND1\n");
+      uint64_t my_received = bitr->received.amount;
+      // reset gratitude for account
+      init_balances(bitr->account);
+      float split_factor = my_received / (float)volume;
+      uint64_t payout = usable_bal * split_factor;
+      // Pay out SEEDS in store if value >= 1.0 SEEDS
+      if (payout >= 0) _transfer(bitr->account, asset(payout, seeds_symbol), "gratitude bonus");
+      bitr++;
+      current++;
+    } else {
+      eosio::print("PAYROUND2\n");
+      action next_execution(
+        permission_level{get_self(), "active"_n},
+        get_self(),
+        "payround"_n,
+        std::make_tuple(bitr->account.value, usable_bal)
+      );
+
+      transaction tx;
+      tx.actions.emplace_back(next_execution);
+      tx.delay_sec = 1;
+      tx.send(bitr->account.value, _self);
+    }
+  // After all payouts are complete
+  else {
+    eosio::print("PAYROUND3\n");
+    // adds a new round
+    auto stitr = stats2.rbegin();
+    auto cur_round_id = stitr->round_id;
+    stats2.emplace(_self, [&](auto& item) {
+      item.round_id = ++cur_round_id;
+      item.num_transfers = 0;
+      item.num_acks = 0;
+      item.volume = asset(0, gratitude_symbol);
+      item.round_pot = eosio::token::get_balance(contracts::token, get_self(), seeds_symbol.code());
+    });
   }
 
-  // adds a new round
-  auto stitr = stats.rbegin();
-  auto cur_round_id = stitr->round_id;
-  stats.emplace(_self, [&](auto& item) {
-    item.round_id = ++cur_round_id;
-    item.num_transfers = 0;
-    item.num_acks = 0;
-    item.volume = asset(0, gratitude_symbol);
-    item.round_pot = asset(0, seeds_symbol);
-  });
-
-
 }
+
 
 ACTION gratitude::newround() {
   require_auth(get_self());
@@ -216,12 +240,12 @@ ACTION gratitude::deposit (name from, name to, asset quantity, string memo) {
     utils::check_asset(quantity);
 
     // Updates status
-    auto stitr = stats.rbegin();
+    auto stitr = stats2.rbegin();
     auto round_id = stitr->round_id;
 
-    auto stitr2 = stats.find(round_id);
+    auto stitr2 = stats2.find(round_id);
     auto oldpot = stitr2->round_pot.amount;
-    stats.modify(stitr2, _self, [&](auto& item) {
+    stats2.modify(stitr2, _self, [&](auto& item) {
         item.round_pot = asset(oldpot + quantity.amount, seeds_symbol);
     });
 
@@ -241,6 +265,7 @@ void gratitude::check_user (name account) {
 }
 
 void gratitude::_calc_acks (name donor) {
+  eosio::print("DEBUG2 ", eosio::name(donor), "\n");
   auto bitr = balances.find(donor.value);
   uint64_t remaining = bitr->remaining.amount;
 
@@ -270,19 +295,19 @@ void gratitude::_calc_acks (name donor) {
 }
 
 uint64_t gratitude::get_current_volume() {
-  auto stitr = stats.rbegin();
+  auto stitr = stats2.rbegin();
   // Should always work because reset always creates first round
   return stitr->volume.amount;
 }
 
 void gratitude::update_stats(name from, name to, asset quantity) {
-  auto stitr = stats.rbegin();
+  auto stitr = stats2.rbegin();
   auto round_id = stitr->round_id;
 
-  auto stitr2 = stats.find(round_id);
+  auto stitr2 = stats2.find(round_id);
   auto oldvolume = stitr2->volume.amount;
   auto oldtransfers = stitr2->num_transfers;
-  stats.modify(stitr2, _self, [&](auto& item) {
+  stats2.modify(stitr2, _self, [&](auto& item) {
       item.volume = asset(oldvolume + quantity.amount, gratitude_symbol);
       item.num_transfers = oldtransfers + 1;
   });

--- a/src/seeds.gratitude.cpp
+++ b/src/seeds.gratitude.cpp
@@ -104,12 +104,12 @@ ACTION gratitude::acknowledge (name from, name to, string memo) {
   auto stitr = stats2.rbegin();
   auto round_id = stitr->round_id;
 
+  // Have to use find to get a modifiable operator
   auto stitr2 = stats2.find(round_id);
   auto oldacks = stitr2->num_acks;
   stats2.modify(stitr2, _self, [&](auto& item) {
       item.num_acks = oldacks + 1;
   });
-
 }
 
 
@@ -214,9 +214,7 @@ ACTION gratitude::payround(uint64_t start, uint64_t usable_bal) {
       item.round_pot = asset(newpot, seeds_symbol);
     });
   }
-
 }
-
 
 ACTION gratitude::newround() {
   require_auth(get_self());
@@ -244,19 +242,15 @@ ACTION gratitude::deposit (name from, name to, asset quantity, string memo) {
     auto stitr = stats2.rbegin();
     auto round_id = stitr->round_id;
 
+    // Have to use find to get a modifiable operator
     auto stitr2 = stats2.find(round_id);
     auto oldpot = stitr2->round_pot.amount;
     stats2.modify(stitr2, _self, [&](auto& item) {
         item.round_pot = asset(oldpot + quantity.amount, seeds_symbol);
     });
-
-    // // Continue with transfer
-    // token::transfer_action action{contracts::token, {_self, "active"_n}};
-    // action.send(_self, from, quantity, memo);
   }
 
 }
-
 
 /// ----------================ PRIVATE ================----------
 

--- a/src/seeds.gratitude.cpp
+++ b/src/seeds.gratitude.cpp
@@ -35,6 +35,26 @@ ACTION gratitude::reset () {
 
 }
 
+ACTION gratitude::migratestats() {
+  require_auth(get_self());
+
+  name old = "gratz.seeds"_n;
+
+  stats_tables other_stats(old, old.value);
+  auto sitr = other_stats.begin();
+  while(sitr != other_stats.end()) {
+    stats.emplace(get_self(), [&](auto& item) {
+      item.round_id = sitr->round_id;
+      item.num_transfers = sitr->num_transfers;
+      item.volume = sitr->volume;
+      // new values
+      item.num_acks = 0;
+      item.round_pot = asset(0, seeds_symbol);
+    });
+    sitr++;
+  }
+}
+
 ACTION gratitude::give (name from, name to, asset quantity, string memo) {
   require_auth(from);
 
@@ -187,6 +207,7 @@ ACTION gratitude::newround() {
 
 // Receive incoming SEEDS
 ACTION gratitude::deposit (name from, name to, asset quantity, string memo) {
+  require_auth(from);
 
   if (get_first_receiver() == contracts::token  &&  // from SEEDS token account
       to  ==  get_self() &&                     // to here

--- a/src/seeds.settings.cpp
+++ b/src/seeds.settings.cpp
@@ -331,6 +331,7 @@ void settings::reset() {
   confwithdesc(name("gratz1.gen"), 100 * 10000, "Base quantity of gratitude tokens received for residents per cycle", medium_impact);
   confwithdesc(name("gratz2.gen"), 200 * 10000, "Base quantity of gratitude tokens received for citizens per cycle", medium_impact);
   confwithdesc(name("gratz.acks"), 10, "Minumum number of gratitude acks to fully use your tokens", medium_impact);
+  confwithdesc(name("gratz.potkp"), 0, "Percent to keep on Gratitude Pot at new round", medium_impact);
 
   // =====================================
   // onboarding/invite

--- a/test/gratitude.test.js
+++ b/test/gratitude.test.js
@@ -2,7 +2,7 @@ const { describe } = require("riteway")
 const { eos, names, getTableRows, isLocal, initContracts, getBalance, sleep } = require("../scripts/helper")
 const eosDevKey = "EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV"
 
-const { firstuser, seconduser, settings, gratitude, accounts, token, bank } = names
+const { firstuser, seconduser, thirduser, fourthuser, settings, gratitude, accounts, token, bank } = names
 
 describe('gratitude general', async assert => {
 
@@ -120,9 +120,6 @@ describe('gratitude general', async assert => {
 
   const contracts = await initContracts({ gratitude, accounts, settings, token })
 
-  console.log('gratitude reset')
-  await contracts.gratitude.reset({ authorization: `${gratitude}@active` })
-
   console.log('accounts reset')
   await contracts.accounts.reset({ authorization: `${accounts}@active` })
   
@@ -132,12 +129,15 @@ describe('gratitude general', async assert => {
   console.log('reset settings')
   await contracts.settings.reset({ authorization: `${settings}@active` })
 
+  console.log('gratitude reset')
+  await contracts.gratitude.reset({ authorization: `${gratitude}@active` })
+
   await contracts.settings.configure("batchsize", 1, { authorization: `${settings}@active` })
 
   const initialGratitude = await get_settings("gratz1.gen") / 10000; // in GRATZ
 
   console.log('add SEEDS users')
-  const users = [firstuser, seconduser]
+  const users = [firstuser, seconduser, thirduser, fourthuser]
   for (const user of users) {
     await contracts.accounts.adduser(user, '', 'individual', { authorization: `${accounts}@active` })
     await contracts.accounts.testresident(user, { authorization: `${accounts}@active` })
@@ -167,6 +167,14 @@ describe('gratitude general', async assert => {
   // TODO check if round status updated (volume, transfers, acks)
   checkRoundAcks(1)
 
+  var balTable = await getTableRows({
+    code: gratitude,
+    scope: gratitude,
+    table: 'balances',
+    json: true
+  })
+  //console.log("balances:" + JSON.stringify(balTable))
+
   console.log('test acks non recursive')
   await contracts.gratitude.testacks({ authorization: `${gratitude}@active` })
 
@@ -176,34 +184,37 @@ describe('gratitude general', async assert => {
     table: 'acks',
     json: true
   })
-  //console.log(acksTable)
+  //console.log("acks:" + JSON.stringify(acksTable))
 
   const gratzAcks = await get_settings("gratz.acks")
   const transferPerAckAmount = initialGratitude / gratzAcks
   checkRemainingGratitude(seconduser, initialGratitude-transferPerAckAmount)
   checkReceivedGratitude(firstuser, transferPerAckAmount)
 
-  console.log('current contract bal: ' + await getBalance(gratitude))
-  console.log('one more time.....')
-  await contracts.gratitude.newround({ authorization: `${gratitude}@active` })
-
-  console.log('give gratitude')
-  await contracts.gratitude.give(firstuser, seconduser, `${transferAmount}.0000 GRATZ`, '', { authorization: `${firstuser}@active` })
-
-  console.log('acknowledge')
-  await contracts.gratitude.acknowledge(seconduser, firstuser, 'Thanks!', { authorization: `${seconduser}@active` })
-
-  console.log('restart gratitude round')
-
   const firstBalanceBefore = await getBalance(firstuser)  
-  const secondBalanceBefore = await getBalance(seconduser)  
+  const secondBalanceBefore = await getBalance(seconduser)
+
+  //console.log('stats: '+ JSON.stringify(await getGratitudeStats()))
+
+  balTable = await getTableRows({
+    code: gratitude,
+    scope: gratitude,
+    table: 'balances',
+    json: true
+  })
+  //console.log("balances:"+JSON.stringify(balTable))
+
+  console.log('new round')
   await contracts.gratitude.newround({ authorization: `${gratitude}@active` })
-  await sleep(3000)
+  await sleep(1000) // wait for parallel processing
 
   const contractBalanceAfter = await getBalance(gratitude)
   const firstBalanceAfter = await getBalance(firstuser)
   const secondBalanceAfter = await getBalance(seconduser)
 
+  checkRoundPot(`${contractBalanceAfter}.0000 SEEDS`)
+
+  //console.log('stats: '+ JSON.stringify(await getGratitudeStats()))
 
   assert({
     given: 'gratitude round finished',
@@ -227,4 +238,118 @@ describe('gratitude general', async assert => {
   })
 
 
+})
+
+
+describe('gratitude many acks', async assert => {
+ 
+  const getGratitudeStats = async () => {
+    const statsTable = await getTableRows({
+      code: gratitude,
+      scope: gratitude,
+      table: 'stats2',
+      json: true
+    })
+    if (statsTable.rows) {
+      return statsTable.rows[statsTable.rows.length-1];
+    }
+    return [];
+  }
+
+  const checkRoundAcks = async (expected) => {
+    const grstats = await getGratitudeStats()
+    assert({
+      given: `performed ack`,
+      should: 'have the correct num acks',
+      actual: grstats.num_acks,
+      expected: expected
+    })
+  }
+
+
+  if (!isLocal()) {
+    console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
+    return
+  }
+
+  const contracts = await initContracts({ gratitude, accounts, settings, token })
+
+  console.log('accounts reset')
+  await contracts.accounts.reset({ authorization: `${accounts}@active` })
+  
+  console.log('token reset weekly')
+  await contracts.token.resetweekly({ authorization: `${token}@active` })
+
+  console.log('reset settings')
+  await contracts.settings.reset({ authorization: `${settings}@active` })
+
+  console.log('gratitude reset')
+  await contracts.gratitude.reset({ authorization: `${gratitude}@active` })
+
+  await contracts.settings.configure("batchsize", 1, { authorization: `${settings}@active` })
+
+  console.log('add SEEDS users')
+  const users = [firstuser, seconduser, thirduser, fourthuser]
+  for (const user of users) {
+    await contracts.accounts.adduser(user, '', 'individual', { authorization: `${accounts}@active` })
+    await contracts.accounts.testresident(user, { authorization: `${accounts}@active` })
+  }
+
+  const amount = 1000
+
+  const contractBalanceBefore = await getBalance(gratitude) || 0
+
+  console.log('refill gratitude contract')
+  await contracts.token.transfer(firstuser, gratitude, `${amount}.0000 SEEDS`, 'test', { authorization: `${firstuser}@active` })
+
+  const balancesBefore = [await getBalance(firstuser), await getBalance(seconduser), await getBalance(thirduser), await getBalance(fourthuser)]
+
+  console.log('test ack 1')
+  await contracts.gratitude.acknowledge(firstuser, seconduser, 'Thanks!', { authorization: `${firstuser}@active` })
+
+  console.log('test ack 2')
+  await contracts.gratitude.acknowledge(firstuser, fourthuser, 'Thanks!', { authorization: `${firstuser}@active` })
+
+  console.log('test ack 3')
+  await contracts.gratitude.acknowledge(firstuser, thirduser, 'Thanks!', { authorization: `${firstuser}@active` })
+
+  console.log('test ack 4')
+  await contracts.gratitude.acknowledge(seconduser, thirduser, 'Thanks!', { authorization: `${seconduser}@active` })
+
+  console.log('test ack 5')
+  await contracts.gratitude.acknowledge(seconduser, fourthuser, 'Thanks!', { authorization: `${seconduser}@active` })
+
+  console.log('test ack 6')
+  await contracts.gratitude.acknowledge(seconduser, firstuser, 'Thanks!', { authorization: `${seconduser}@active` })
+
+  console.log('test ack 7')
+  await contracts.gratitude.acknowledge(thirduser, firstuser, 'Thanks!', { authorization: `${thirduser}@active` })
+
+  // TODO check if round status updated (volume, transfers, acks)
+  checkRoundAcks(7)
+
+  console.log('new round')
+  await contracts.gratitude.newround({ authorization: `${gratitude}@active` })
+  await sleep(5000) // wait for parallel processing
+
+  const contractBalanceAfter = await getBalance(gratitude)
+  const balancesAfter = [await getBalance(firstuser), await getBalance(seconduser), await getBalance(thirduser), await getBalance(fourthuser)]
+
+  const statsTable = await getTableRows({
+    code: gratitude,
+    scope: gratitude,
+    table: 'stats2',
+    json: true
+  })
+  console.log('stats: '+ JSON.stringify(statsTable))
+  console.log('balances orig: '+ balancesBefore)
+  console.log('balances diff: '+ balancesAfter)
+
+
+  assert({
+    given: 'gratitude round finished',
+    should: 'reset contract balance',
+    actual: contractBalanceAfter,
+    expected: contractBalanceBefore
+  })
 })


### PR DESCRIPTION
This fixes the code for the `newround` action, that was failing on mainnet because it was running `calc_acks` over too many accounts at once, now we call `calc_acks` recursively.

Also took the opportunity to add acks stats and a new setting to determine how much % of the gratitude pot is saved for the next round (default 0, to behave as now).

### Instructions
- [x] Deploy: gratitude / settings
- [x] New settings / run updateSettings
- [x] Required migration: `gratitude::migratestats`
- [ ] No new Permissions