### PR TITLE
Moon op improvements

### DIFF
--- a/include/seeds.scheduler.hpp
+++ b/include/seeds.scheduler.hpp
@@ -52,6 +52,7 @@ CONTRACT scheduler : public contract {
         void exec_op(name id, name contract, name action);
         void cancel_exec();
         void reset_aux(bool destructive);
+        uint64_t next_valid_moon_phase(uint64_t moon_cycle_id, uint64_t quarter_moon_cycles);
         bool should_preserve_op(name op_id) {
             return 
                 op_id == "exch.period"_n || 

--- a/include/seeds.scheduler.hpp
+++ b/include/seeds.scheduler.hpp
@@ -32,6 +32,8 @@ CONTRACT scheduler : public contract {
 
         ACTION configmoonop(name id, name action, name contract, uint64_t quarter_moon_cycles, uint64_t starttime);
 
+        ACTION addmoonop(name id, name action, name contract, uint64_t quarter_moon_cycles, string start_phase_name);
+
         ACTION removeop(name id);
 
         ACTION pauseop(name id, uint8_t pause);

--- a/src/seeds.scheduler.cpp
+++ b/src/seeds.scheduler.cpp
@@ -298,15 +298,17 @@ void scheduler::reset_aux(bool destructive) {
 
     // Moon Operations
     // All moon operations need to be preserved, so they need to be added/removed manually.
-/**
-cleos -u "https://test.hypha.earth" push action cycle.seeds configmoonop '{ 
-	"id":"inc.lprice",
-	"action":"incprice",
-	"contract":"tlosto.seeds",
-	"quarter_moon_cycles":"1",
-	"starttime":"1623322380"
-}' -p cycle.seeds@active
-*/
+    // use addmoonop
+    // example below
+    /**
+    cleos -u "https://test.hypha.earth" push action cycle.seeds addmoonop '{ 
+            "id":"inc.lprice",
+            "action":"incprice",
+            "contract":"tlosto.seeds",
+            "quarter_moon_cycles":"1",
+            "start_phase_name":"First Quarter"
+    }' -p cycle.seeds@active
+    */
 
 }
 
@@ -344,6 +346,36 @@ ACTION scheduler::configop(name id, name action, name contract, uint64_t period,
             noperation.timestamp = start - period;
         });
     }
+}
+
+ACTION scheduler::addmoonop(name id, name action, name contract, uint64_t quarter_moon_cycles, string start_phase_name) {
+    require_auth(_self);
+
+    check(quarter_moon_cycles <= 4 && quarter_moon_cycles > 0, "invalid quarter moon cycles, it should be greater than zero and less or equals to 4");
+
+    check(start_phase_name == "New Moon" ||
+        start_phase_name == "First Quarter" ||
+        start_phase_name == "Last Quarter" ||
+        start_phase_name == "Full Moon", "start_phase_name must be one of New Moon, First Quarter, Last Quarter, Full Moon");
+
+    uint64_t now = eosio::current_time_point().sec_since_epoch();
+
+    uint64_t starttime = 0;
+
+    auto mitr = moonphases.upper_bound(now);
+    uint8_t count = 0;
+    while (mitr != moonphases.end() && count < 4) {
+        if (mitr->phase_name == start_phase_name) {
+            starttime = mitr->timestamp;
+            break;
+        }
+        mitr++;
+        count++;
+    }
+
+    check(starttime != 0, "Unable to find moon phase. Must be one of New Moon, First Quarter, Last Quarter, Full Moon");
+
+    configmoonop(id, action, contract, quarter_moon_cycles, starttime);
 }
 
 ACTION scheduler::configmoonop(name id, name action, name contract, uint64_t quarter_moon_cycles, uint64_t starttime) {
@@ -652,5 +684,5 @@ uint64_t scheduler::next_valid_moon_phase(uint64_t moon_cycle_id, uint64_t quart
 
 
 EOSIO_DISPATCH(scheduler,
-    (configop)(configmoonop)(execute)(reset)(pauseop)(removeop)(stop)(start)(moonphase)(test1)(test2)(testexec)(updateops)
+    (configop)(configmoonop)(addmoonop)(execute)(reset)(pauseop)(removeop)(stop)(start)(moonphase)(test1)(test2)(testexec)(updateops)
 );

--- a/test/scheduler.test.js
+++ b/test/scheduler.test.js
@@ -570,7 +570,7 @@ describe('scheduler, moon phases', async assert => {
     }
 
     console.log('populate moonphases')
-    let dateTimestamp = parseInt(Date.now() / 1000)
+    let dateTimestamp = parseInt(Date.now() / 1000) + 1
     for (let i = 0; i < 50; i++) {
         await contracts.scheduler.moonphase(dateTimestamp + i, `phase ${(i % 4) + 1}`, '', { authorization: `${scheduler}@active` })
     }


### PR DESCRIPTION
added some code to make it easier to schedule moon ops

added some safety check so it's impossible to add a past op (as that would trigger an immediate firing, which would be bad if we have "incprice" or "run proposals"... ;) whoops!!!

Added "addmoonop" so we don't have to figure out unix time stamps - just set the phase as string, and it figures it out.

I also added one to testnet let's see if it fires next time, then can move to mainnet
'''
cleos -u "https://test.hypha.earth" push action cycle.seeds addmoonop '{ 
        "id":"inc.lprice",
        "action":"incprice",
        "contract":"tlosto.seeds",
        "quarter_moon_cycles":"1",
        "start_phase_name":"First Quarter"
}' -p cycle.seeds@active

> cleost get table cycle.seeds cycle.seeds moonops
{
  "rows": [{
      "id": "inc.lprice",
      "action": "incprice",
      "contract": "tlosto.seeds",
      "quarter_moon_cycles": 1,
      "start_time": 1623988440,
      "last_moon_cycle_id": 0,
      "pause": 0
    }
  ],
  "more": false,
  "next_key": ""
}

'''
