### PR TITLE
Onboarding: Don't accept existing account in accept action

### DIFF
--- a/include/seeds.onboarding.hpp
+++ b/include/seeds.onboarding.hpp
@@ -33,7 +33,7 @@ CONTRACT onboarding : public contract {
     ACTION invitefor(name sponsor, name referrer, asset transfer_quantity, asset sow_quantity, checksum256 invite_hash);
     ACTION accept(name account, checksum256 invite_secret, string publicKey);
     ACTION acceptnew(name account, checksum256 invite_secret, string publicKey, string fullname);
-    ACTION acceptexist(name account, checksum256 invite_secret, string publicKey);
+    ACTION acceptexist(name account, checksum256 invite_secret);
     ACTION onboardorg(name sponsor, name account, string fullname, string publicKey);
     ACTION createregion(name sponsor, name region, string publicKey);
 
@@ -64,7 +64,7 @@ CONTRACT onboarding : public contract {
     void sow_seeds(name account, asset quantity);
     void add_referral(name sponsor, name account);
     void invitevouch(name sponsor, name account);
-    void accept_invite(name account, checksum256 invite_secret, string publicKey, string fullname);
+    void accept_invite(name account, checksum256 invite_secret, string publicKey, string fullname, bool existingTelosAccount);
     void _invite(name sponsor, name referrer, asset transfer_quantity, asset sow_quantity, checksum256 invite_hash, uint64_t campaign_id);
     void check_user(name account);
     uint64_t config_get(name key);

--- a/src/seeds.onboarding.cpp
+++ b/src/seeds.onboarding.cpp
@@ -385,12 +385,11 @@ void onboarding::acceptnew(name account, checksum256 invite_secret, string publi
 
 // accept invite using already existing account - needs to be signed by existing account
 // to prove ownership
-void onboarding::acceptexist(name account, checksum256 invite_secret) {
-  
-  // TODO: Add this later so users don't accidentally onboard an account they don't own.
-  //require_auth(account);
+void onboarding::acceptexist(name account, checksum256 invite_secret) {  
 
   check(is_account(account) == true, "Account does not exist " + account.to_string());
+
+  require_auth(account);
 
   accept_invite(account, invite_secret, string(""), string(""), true);
 }

--- a/src/seeds.onboarding.cpp
+++ b/src/seeds.onboarding.cpp
@@ -103,7 +103,7 @@ void onboarding::send_campaign_reward (uint64_t campaign_id) {
   transfer_seeds(citr->reward_owner, citr->reward, string("campaign reward"));
 }
 
-void onboarding::accept_invite(name account, checksum256 invite_secret, string publicKey, string fullname) {
+void onboarding::accept_invite(name account, checksum256 invite_secret, string publicKey, string fullname, bool existingTelosAccount) {
   require_auth(get_self());
 
   auto _invite_secret = invite_secret.extract_as_byte_array();
@@ -133,6 +133,12 @@ void onboarding::accept_invite(name account, checksum256 invite_secret, string p
 
   bool is_existing_telos_user = is_account(account);
   bool is_existing_seeds_user = is_seeds_user(account);
+
+  if (existingTelosAccount) {
+    check(is_existing_telos_user, "telos account does not exist: " + account.to_string());
+  } else {
+    check(!is_existing_telos_user, "telos account already exists: " + account.to_string());
+  }
 
   if (!is_existing_telos_user) {
     create_account(account, publicKey, ""_n);
@@ -374,19 +380,24 @@ void onboarding::_cancel(name sponsor, checksum256 invite_hash, bool check_auth)
 void onboarding::acceptnew(name account, checksum256 invite_secret, string publicKey, string fullname) {
   check(is_account(account) == false, "Account already exists " + account.to_string());
 
-  accept_invite(account, invite_secret, publicKey, fullname);
+  accept_invite(account, invite_secret, publicKey, fullname, false);
 }
 
-// accept invite using already existing account
-void onboarding::acceptexist(name account, checksum256 invite_secret, string publicKey) {
+// accept invite using already existing account - needs to be signed by existing account
+// to prove ownership
+void onboarding::acceptexist(name account, checksum256 invite_secret) {
+  
+  // TODO: Add this later so users don't accidentally onboard an account they don't own.
+  //require_auth(account);
+
   check(is_account(account) == true, "Account does not exist " + account.to_string());
 
-  accept_invite(account, invite_secret, publicKey, string(""));
+  accept_invite(account, invite_secret, string(""), string(""), true);
 }
 
-// accept invite using already existing account or creating new account
+// accept invite creating new account
 void onboarding::accept(name account, checksum256 invite_secret, string publicKey) {
-  accept_invite(account, invite_secret, publicKey, string(""));
+  accept_invite(account, invite_secret, publicKey, string(""), false);
 }
 
 void onboarding::cleanup(uint64_t start_id, uint64_t max_id, uint64_t batch_size) {
@@ -519,8 +530,15 @@ ACTION onboarding::campinvite (uint64_t campaign_id, name authorizing_account, a
   auto citr = campaigns.find(campaign_id);
   check(citr != campaigns.end(), "campaign not found");
   
-  check(std::binary_search(citr->authorized_accounts.begin(), citr->authorized_accounts.end(), authorizing_account), 
-    authorizing_account.to_string() + " is not authorized to invite in this campaign");
+  bool is_authorized = false;
+  for (std::size_t i = 0; i < citr->authorized_accounts.size(); i++) {
+      if (authorizing_account == citr->authorized_accounts[i]) {
+        is_authorized = true;
+        break;
+      }
+  }
+
+  check(is_authorized, authorizing_account.to_string() + " is not authorized to invite in this campaign");
 
   require_auth(authorizing_account);
 

--- a/test/onboarding.test.js
+++ b/test/onboarding.test.js
@@ -387,16 +387,16 @@ describe('Use application permission to accept', async assert => {
     console.log(`reset ${onboarding}`)
     await contracts.onboarding.reset({ authorization: `${onboarding}@active` })
 
-    console.log(`${accounts}.adduser (${firstuser})`)
+    console.log(`adduser (${firstuser})`)
     await contracts.accounts.adduser(firstuser, '', 'individual', { authorization: `${accounts}@active` })     
     
     await contracts.accounts.testresident(firstuser, { authorization: `${accounts}@active` })
     await contracts.accounts.testsetrs(firstuser, 22, { authorization: `${accounts}@active` })
 
-    console.log(`${token}.transfer from ${firstuser} to ${onboarding} (${totalQuantity})`)
+    console.log(`transfer from ${firstuser} to ${onboarding} (${totalQuantity})`)
     await contracts.token.transfer(firstuser, onboarding, totalQuantity, '', { authorization: `${firstuser}@active` })    
 
-    console.log(`${onboarding}.invite from ${firstuser}`)
+    console.log(`invite from ${firstuser}`)
     await contracts.onboarding.invite(firstuser, transferQuantity, sowQuantity, inviteHash, { authorization: `${firstuser}@active` })
 
     const vouchBeforeInvite = await eos.getTableRows({
@@ -406,7 +406,7 @@ describe('Use application permission to accept', async assert => {
         json: true
       })
 
-    console.log(`${onboarding}.accept from Application`)
+    console.log(`accept from Application`)
     await contracts.onboarding.accept(newAccount, inviteSecret, newAccountPublicKey, { authorization: `${onboarding}@application` })    
 
     const acceptUsers = await eos.getTableRows({
@@ -516,7 +516,7 @@ describe('Invite from non-seeds user - sp', async assert => {
 
     await invite()
 
-    console.log(`onboarding ${onboarding}.accept from Application for `+newAccount)
+    console.log(`onboarding accept from Application for `+newAccount)
     await contracts.onboarding.accept(newAccount, inviteSecret, newAccountPublicKey, { authorization: `${onboarding}@application` })    
 
     const { rows } = await getTableRows({
@@ -595,9 +595,9 @@ describe('Campaign reward for existing user', async assert => {
         await contracts.onboarding.invite(firstuser, transferQuantity, sowQuantity, inviteHash, { authorization: `${firstuser}@active` })
     }
 
-    const accept = async () => {
-        console.log(`${onboarding}.accept from Application`)
-        await contracts.onboarding.accept(newAccount, inviteSecret, newAccountPublicKey, { authorization: `${onboarding}@application` })    
+    const acceptExisting = async () => {
+        console.log(`Existing user accept from Application`)
+        await contracts.onboarding.acceptexist(newAccount, inviteSecret, { authorization: `${onboarding}@application` })    
     }
 
     await adduser(firstuser)
@@ -621,7 +621,7 @@ describe('Campaign reward for existing user', async assert => {
 
     await invite()
 
-    await accept()
+    await acceptExisting()
 
     const { rows } = await getTableRows({
         code: harvest,
@@ -839,32 +839,33 @@ describe('Private campaign', async assert => {
     await checkCampaignFunds(1, maxAmount1)
     await checkCampaignFunds(2, maxAmount2)
 
-    console.log(`invite ${seconduser}`)
+    let user2 = randomAccountName()
+    console.log(`invite new user ${user2}`)
     const firstuserBalanceBeforeAccept = await getBalance(firstuser)
     await contracts.onboarding.campinvite(1, firstuser, '6.0000 SEEDS', '3.0000 SEEDS', inviteHash, { authorization: `${firstuser}@active` })
-    await contracts.onboarding.accept(seconduser, inviteSecret, newAccountPublicKey, { authorization: `${onboarding}@active` })
+
+    await contracts.onboarding.accept(user2, inviteSecret, newAccountPublicKey, { authorization: `${onboarding}@active` })
 
     await checkCampaignFunds(1, '10.0000 SEEDS')
     await checkCampaignInvites(1, 1, 0)
-    await checkUsers(seconduser, 2)
-    await checkVouches(seconduser, 1)
+    await checkUsers(user2, 2)
+    await checkVouches(user2, 1)
     
-    console.log(`authorize ${seconduser}`)
-    await contracts.onboarding.addauthorized(1, seconduser, { authorization: `${firstuser}@active` })
-    console.log(`authorize ${seconduser} again`)
-    await contracts.onboarding.addauthorized(1, seconduser, { authorization: `${firstuser}@active` })
+    console.log(`addauthorized ${user2}`)
+    await contracts.onboarding.addauthorized(1, user2, { authorization: `${firstuser}@active` })
 
+    console.log(`testing max invite amount`)
     let cantExceedMaxInviteAmount = true
     try {
-        await contracts.onboarding.campinvite(1, seconduser, '6.0000 SEEDS', '9.0000 SEEDS', inviteHash2, { authorization: `${seconduser}@active` })
+        await contracts.onboarding.campinvite(1, user2, '6.0000 SEEDS', '9.0000 SEEDS', inviteHash2, { authorization: `${user2}@active` })
         cantExceedMaxInviteAmount = false
     } catch (err) {
         console.log('can not exceed max invitation amount (expected)')
     }
 
-    console.log(`${seconduser} invites ${thirduser}`)
-    await contracts.onboarding.campinvite(1, seconduser, '6.0000 SEEDS', '1.0000 SEEDS', inviteHash2, { authorization: `${seconduser}@active` })
-    await contracts.onboarding.accept(thirduser, inviteSecret2, newAccountPublicKey, { authorization: `${onboarding}@active` })
+    console.log(`${user2} invites ${thirduser}`)
+    await contracts.onboarding.campinvite(1, user2, '6.0000 SEEDS', '1.0000 SEEDS', inviteHash2, { authorization: `${user2}@active` })
+    await contracts.onboarding.acceptexist(thirduser, inviteSecret2, { authorization: `${onboarding}@active` })
 
     const firstuserBalanceAfterAccept = await getBalance(firstuser)
 
@@ -873,13 +874,13 @@ describe('Private campaign', async assert => {
     await checkUsers(thirduser, 3)
     await checkVouches(thirduser, 1)
 
-    console.log(`remove ${seconduser} from the authorization list`)
-    await contracts.onboarding.remauthorized(1, seconduser, { authorization: `${firstuser}@active` })
+    console.log(`remove ${user2} from the authorization list`)
+    await contracts.onboarding.remauthorized(1, user2, { authorization: `${firstuser}@active` })
 
     console.log('invite without permission')
     let cantInviteWithoutPermission = true
     try {
-        await contracts.onboarding.campinvite(1, seconduser, '6.0000 SEEDS', '1.0000 SEEDS', inviteHash3, { authorization: `${seconduser}@active` })
+        await contracts.onboarding.campinvite(1, user2, '6.0000 SEEDS', '1.0000 SEEDS', inviteHash3, { authorization: `${user2}@active` })
         cantInviteWithoutPermission = false
     } catch (err) {
         console.log('can not invite without permission (expected)')

--- a/test/onboarding.test.js
+++ b/test/onboarding.test.js
@@ -597,7 +597,7 @@ describe('Campaign reward for existing user', async assert => {
 
     const acceptExisting = async () => {
         console.log(`Existing user accept from Application`)
-        await contracts.onboarding.acceptexist(newAccount, inviteSecret, { authorization: `${onboarding}@application` })    
+        await contracts.onboarding.acceptexist(newAccount, inviteSecret, { authorization: `${newAccount}@application` })    
     }
 
     await adduser(firstuser)
@@ -865,7 +865,7 @@ describe('Private campaign', async assert => {
 
     console.log(`${user2} invites ${thirduser}`)
     await contracts.onboarding.campinvite(1, user2, '6.0000 SEEDS', '1.0000 SEEDS', inviteHash2, { authorization: `${user2}@active` })
-    await contracts.onboarding.acceptexist(thirduser, inviteSecret2, { authorization: `${onboarding}@active` })
+    await contracts.onboarding.acceptexist(thirduser, inviteSecret2, { authorization: `${thirduser}@active` })
 
     const firstuserBalanceAfterAccept = await getBalance(firstuser)
 


### PR DESCRIPTION
## Hotfix - Don't accept existing Telos accounts

Reason / user story: One of our users signed on with an existing Telos account - not sure how that was possible in the app, but it was possible.

In reality this means she signed on with an account that was not her account! 

She did not realize this until much later, when 15,000 Seeds had been deposited into her account and she tried to use them.

The passport app had stored the public-private key pair that was created at account creation but that keypair was never actually used, because no new account was created.

Pic from the support channel chat

<img width="779" alt="image" src="https://user-images.githubusercontent.com/65412/121846881-4b3c0300-cd1a-11eb-85d4-b2547437be16.png">


## Other changes
Also: 
minor bugfixes - campinvite auth check didn't work with the random account, replaced binary search with code I can understand and it worked ;) 
fix unit tests