### PR TITLE
changed evaldemote action to eval status change based on rep

### DIFF
--- a/src/seeds.accounts.cpp
+++ b/src/seeds.accounts.cpp
@@ -1269,9 +1269,6 @@ void accounts::flag (name from, name to) {
   
   points = base_points * utils::rep_multiplier_for_score(ritr.rank);
 
-
-  print("flag points", points);
-
   flags.emplace(_self, [&](auto & item){
     item.account = from;
     item.flag_points = points;
@@ -1288,8 +1285,6 @@ void accounts::flag (name from, name to) {
   if (removed_flag_p_itr != removed_flags.end()) { removed_flag_points = removed_flag_p_itr -> flag_points; }
 
   uint64_t flag_threshold = config_get("flag.thresh"_n);
-
-  print("flag tresh", flag_threshold);
 
   if (total_flag_points >= flag_threshold && removed_flag_points < total_flag_points) {
 
@@ -1399,8 +1394,6 @@ void accounts::evaldemote (name to, uint64_t start_val, uint64_t chunk, uint64_t
       uint64_t min_rep_score_resident = config_get("res.rep.pt"_n);
 
       name current_status = uitr->status;
-      print("\nDEMOTE", ritr->account);
-      print("\nstatus_b", current_status);
 
       if (rep < min_rep_score_resident) {
         current_status = visitor;
@@ -1409,8 +1402,6 @@ void accounts::evaldemote (name to, uint64_t start_val, uint64_t chunk, uint64_t
       } else {
         current_status = citizen;
       }
-
-      print("\nstatus_a", current_status);
 
       if (uitr->status == citizen && current_status != citizen) {
         updatestatus(uitr->account, current_status);

--- a/src/seeds.accounts.cpp
+++ b/src/seeds.accounts.cpp
@@ -1269,6 +1269,9 @@ void accounts::flag (name from, name to) {
   
   points = base_points * utils::rep_multiplier_for_score(ritr.rank);
 
+
+  print("flag points", points);
+
   flags.emplace(_self, [&](auto & item){
     item.account = from;
     item.flag_points = points;
@@ -1285,6 +1288,8 @@ void accounts::flag (name from, name to) {
   if (removed_flag_p_itr != removed_flags.end()) { removed_flag_points = removed_flag_p_itr -> flag_points; }
 
   uint64_t flag_threshold = config_get("flag.thresh"_n);
+
+  print("flag tresh", flag_threshold);
 
   if (total_flag_points >= flag_threshold && removed_flag_points < total_flag_points) {
 
@@ -1382,6 +1387,7 @@ void accounts::evaldemote (name to, uint64_t start_val, uint64_t chunk, uint64_t
 
     if (ritr->account == to) {
       uint64_t rank = utils::spline_rank(current, total);
+      uint32_t rep = ritr->rep;
 
       rep_by_rep.modify(ritr, _self, [&](auto& item) {
         item.rank = rank;
@@ -1392,20 +1398,24 @@ void accounts::evaldemote (name to, uint64_t start_val, uint64_t chunk, uint64_t
       uint64_t min_rep_score_citizen = config_get("cit.rep.sc"_n);
       uint64_t min_rep_score_resident = config_get("res.rep.pt"_n);
 
-      name current_rank = uitr->status;
+      name current_status = uitr->status;
+      print("\nDEMOTE", ritr->account);
+      print("\nstatus_b", current_status);
 
-      if (rank < min_rep_score_resident) {
-        current_rank = visitor;
-      } else if (rank < min_rep_score_citizen) {
-        current_rank = resident;
+      if (rep < min_rep_score_resident) {
+        current_status = visitor;
+      } else if (rep < min_rep_score_citizen) {
+        current_status = resident;
       } else {
-        current_rank = citizen;
+        current_status = citizen;
       }
 
-      if (uitr->status == citizen && current_rank != citizen) {
-        updatestatus(uitr->account, current_rank);
+      print("\nstatus_a", current_status);
+
+      if (uitr->status == citizen && current_status != citizen) {
+        updatestatus(uitr->account, current_status);
       }
-      else if (uitr->status == resident && current_rank == visitor) {
+      else if (uitr->status == resident && current_status == visitor) {
         updatestatus(uitr->account, visitor);
       }
 

--- a/test/accounts.test.js
+++ b/test/accounts.test.js
@@ -1621,7 +1621,7 @@ const accept = async (newAccount, inviteSecret, publicKey, contracts) => {
   console.log("accept success!")
 }
 
-describe.only('Punishment', async assert => {
+describe('Punishment', async assert => {
 
   if (!isLocal()) {
     console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
@@ -1646,6 +1646,7 @@ describe.only('Punishment', async assert => {
       table: 'rep',
       json: true
     })
+
     assert({
       given: 'user punished',
       should: 'have the correct reputation',

--- a/test/accounts.test.js
+++ b/test/accounts.test.js
@@ -1646,7 +1646,6 @@ describe('Punishment', async assert => {
       table: 'rep',
       json: true
     })
-
     assert({
       given: 'user punished',
       should: 'have the correct reputation',
@@ -1827,6 +1826,12 @@ describe('Punishment', async assert => {
     expected: true
   })
 
+  await contracts.accounts.addrep(fifthuser, 300, { authorization: `${accounts}@active` })
+  await contracts.accounts.testsetrs(fifthuser, 30, { authorization: `${accounts}@active` })
+  await contracts.accounts.evaldemote(fifthuser, 0, 0, 1, { authorization: `${accounts}@active` })
+
+  await checkReps([66, 165, 300, 306])
+  await checkUserStatus(fifthuser, 'citizen')
 })
 
 // describe('Migrate cbs and rep for orgs', async assert => {

--- a/test/accounts.test.js
+++ b/test/accounts.test.js
@@ -1621,7 +1621,7 @@ const accept = async (newAccount, inviteSecret, publicKey, contracts) => {
   console.log("accept success!")
 }
 
-describe('Punishment', async assert => {
+describe.only('Punishment', async assert => {
 
   if (!isLocal()) {
     console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")


### PR DESCRIPTION
Changed "accounts::evaldemote" action to check status demotion based in reputation points instead of  rank, and added test.

Contracts to be deployed
- [x] accounts

Contracts to be tested
- [x]  accounts