### PR TITLE
check if the user balance has been inited when calculating acks

### DIFF
--- a/src/seeds.gratitude.cpp
+++ b/src/seeds.gratitude.cpp
@@ -261,6 +261,11 @@ void gratitude::check_user (name account) {
 
 void gratitude::_calc_acks (name donor) {
   auto bitr = balances.find(donor.value);
+  if (bitr == balances.end()) {
+    init_balances(donor);
+    bitr = balances.find(donor.value);
+  }
+
   uint64_t remaining = bitr->remaining.amount;
 
   auto min_acks = config_get(gratz_acks);

--- a/test/gratitude.test.js
+++ b/test/gratitude.test.js
@@ -134,7 +134,7 @@ describe('gratitude general', async assert => {
 
   console.log('reset contract balance')
   const stale_balance = await getBalance(gratitude)
-  await contracts.token.transfer(gratitude, firstuser, `${stale_balance}.0000 SEEDS`, 'test', { authorization: `${gratitude}@active` })
+  if (stale_balance) await contracts.token.transfer(gratitude, firstuser, `${stale_balance}.0000 SEEDS`, 'test', { authorization: `${gratitude}@active` })
 
   await contracts.settings.configure("batchsize", 1, { authorization: `${settings}@active` })
 


### PR DESCRIPTION
Checks if the user balance has been inited when calculating acks. This bug should only happen when mixing acks being created with the old version of the gratitude contract, that didn't init that account.