### PR TITLE
Bugfix/planting rules enforcement

### DIFF
--- a/include/seeds.accounts.hpp
+++ b/include/seeds.accounts.hpp
@@ -7,6 +7,7 @@
 #include <tables/cbs_table.hpp>
 #include <tables/user_table.hpp>
 #include <tables/config_table.hpp>
+#include <tables/ban_table.hpp>
 #include <tables/config_float_table.hpp>
 #include <utils.hpp>
 
@@ -79,6 +80,9 @@ CONTRACT accounts : public contract {
       ACTION punish(name account, uint64_t points);
       ACTION pnshvouchers(name account, uint64_t points, uint64_t start);
       ACTION evaldemote(name to, uint64_t start_val, uint64_t chunk, uint64_t chunksize);
+      ACTION bantree(name account, bool recurse);
+      ACTION refinfo(name account);
+      ACTION unban(name account);
 
       ACTION testresident(name user);
       ACTION testcitizen(name user);
@@ -171,6 +175,7 @@ CONTRACT accounts : public contract {
       void calc_vouch_rep(name account);
       name get_scope(name type);
       void send_add_cbs_org(name user, uint64_t amount);
+      void send_bantree(name account);
 
       DEFINE_USER_TABLE
 
@@ -187,6 +192,9 @@ CONTRACT accounts : public contract {
       DEFINE_CBS_TABLE
 
       DEFINE_CBS_TABLE_MULTI_INDEX
+
+      DEFINE_BAN_TABLE
+      DEFINE_BAN_TABLE_MULTI_INDEX
 
       TABLE ref_table {
         name referrer;
@@ -370,7 +378,8 @@ EOSIO_DISPATCH(accounts, (reset)(adduser)(canresident)(makeresident)(cancitizen)
 (subrep)(testsetrep)(testsetrs)(testcitizen)(testresident)(testvisitor)(testremove)(testsetcbs)
 (testreward)(requestvouch)(vouch)(pnishvouched)
 (rankreps)(rankorgreps)(rankrep)(rankcbss)(rankorgcbss)(rankcbs)
-(flag)(removeflag)(punish)(pnshvouchers)(evaldemote)
+(flag)(removeflag)(punish)(pnshvouchers)(evaldemote)(bantree)
+(refinfo)(unban)
 (testmvouch)
 (addcbs)
 );

--- a/include/seeds.onboarding.hpp
+++ b/include/seeds.onboarding.hpp
@@ -6,6 +6,7 @@
 #include <tables.hpp>
 #include <utils.hpp>
 #include <tables/config_table.hpp>
+#include <tables/ban_table.hpp>
 
 using namespace eosio;
 using abieos::authority;
@@ -75,6 +76,8 @@ private:
   void send_campaign_reward(uint64_t campaign_id);
   void send_return_funds_aux(uint64_t campaign_id);
   void _cancel(name sponsor, checksum256 invite_hash, bool check_auth);
+  void check_paused();
+  void check_is_banned(name account);
 
   TABLE invite_table
   {

--- a/include/tables/ban_table.hpp
+++ b/include/tables/ban_table.hpp
@@ -1,0 +1,11 @@
+#include <eosio/eosio.hpp>
+
+using eosio::name;
+
+#define DEFINE_BAN_TABLE TABLE ban_table { \
+        name account; \
+\
+        uint64_t primary_key()const { return account.value; } \
+      }; 
+
+#define DEFINE_BAN_TABLE_MULTI_INDEX typedef eosio::multi_index<"ban"_n, ban_table> ban_tables; 

--- a/scripts/deploy.command.js
+++ b/scripts/deploy.command.js
@@ -18,6 +18,13 @@ const deploy = async (name) => {
     if (!abi)
       throw new Error('abi not found')
 
+    await eos.setabi({
+        account: account.account,
+        abi: JSON.parse(abi)
+      }, {
+        authorization: `${account.account}@owner`
+      })
+  
     await eos.setcode({
       account: account.account,
       code,
@@ -28,12 +35,6 @@ const deploy = async (name) => {
     })
     console.log("code deployed")
 
-    await eos.setabi({
-      account: account.account,
-      abi: JSON.parse(abi)
-    }, {
-      authorization: `${account.account}@owner`
-    })
 
   console.log("abi deployed")
 

--- a/src/seeds.harvest.cpp
+++ b/src/seeds.harvest.cpp
@@ -135,14 +135,15 @@ void harvest::sub_planted(name account, asset quantity) {
 
   auto pitr = planted.find(account.value);
   check(pitr != planted.end(), "user has no balance");
-  if (pitr->planted.amount == quantity.amount) {
-    planted.erase(pitr);
-    size_change(planted_size, -1);
-  } else {
-    planted.modify(pitr, _self, [&](auto& item) {
-      item.planted -= quantity;
-    });
+
+  if (account != contracts::onboarding) {
+    uint64_t min_planted = config_get("inv.min.plnt"_n);
+    check(pitr->planted.amount - quantity.amount >= min_planted, "Can't unplant last Seeds " + std::to_string(min_planted/10000.0));
   }
+
+  planted.modify(pitr, _self, [&](auto& item) {
+    item.planted -= quantity;
+  });
   
   change_total(false, quantity);
 

--- a/src/seeds.harvest.cpp
+++ b/src/seeds.harvest.cpp
@@ -136,6 +136,7 @@ void harvest::sub_planted(name account, asset quantity) {
   auto pitr = planted.find(account.value);
   check(pitr != planted.end(), "user has no balance");
 
+  // enforce min plant, except for system contracts - onboarding uses "sow", which unplants
   if (account != contracts::onboarding) {
     uint64_t min_planted = config_get("inv.min.plnt"_n);
     check(pitr->planted.amount - quantity.amount >= min_planted, "Can't unplant last Seeds " + std::to_string(min_planted/10000.0));

--- a/src/seeds.onboarding.cpp
+++ b/src/seeds.onboarding.cpp
@@ -13,6 +13,8 @@ void onboarding::create_account(name account, string publicKey, name domain)
     domain = _self;
   }
 
+  //check(false, "invite contract is paused"); // REMOVE THIS AGAIN
+
   action(
       permission_level{domain, "owner"_n},
       "eosio"_n, "newaccount"_n,
@@ -339,6 +341,11 @@ void onboarding::_invite(name sponsor, name referrer, asset transfer_quantity, a
   checksum256 empty_checksum;
 
   uint64_t key = invites.available_primary_key();
+
+  uint64_t min_planted = config_get("inv.min.plnt"_n);
+  check(sow_quantity.amount >= min_planted, "the planted amount must be greater or equal than " + std::to_string(min_planted/10000.0));
+
+  print("sow "+std::to_string(sow_quantity.amount) + " >= " + std::to_string(min_planted));
 
   if (campaign_id != 0)
   {
@@ -704,7 +711,7 @@ ACTION onboarding::campinvite(uint64_t campaign_id, name authorizing_account, as
 
   require_auth(authorizing_account);
 
-  check(planted >= citr->planted, "the planted amount must be greater or equal than " + citr->planted.to_string());
+  check(planted >= citr->planted, "campaign: ``````````the planted amount must be greater or equal than " + citr->planted.to_string());
   check(quantity.amount > 0, "quantity should me greater than 0");
 
   _invite(citr->origin_account, citr->owner, quantity, planted, invite_hash, campaign_id);

--- a/src/seeds.onboarding.cpp
+++ b/src/seeds.onboarding.cpp
@@ -13,7 +13,7 @@ void onboarding::create_account(name account, string publicKey, name domain)
     domain = _self;
   }
 
-  //check(false, "invite contract is paused"); // REMOVE THIS AGAIN
+  check_paused();
 
   action(
       permission_level{domain, "owner"_n},
@@ -40,6 +40,17 @@ bool onboarding::is_seeds_user(name account)
   return uitr != users.end();
 }
 
+void onboarding::check_is_banned(name account)
+{
+  DEFINE_BAN_TABLE
+  DEFINE_BAN_TABLE_MULTI_INDEX
+  ban_tables ban(contracts::accounts, contracts::accounts.value);
+
+  auto bitr = ban.find(account.value);
+  check(bitr == ban.end(), "banned user.");
+}
+
+
 void onboarding::add_user(name account, string fullname, name type)
 {
 
@@ -55,6 +66,10 @@ void onboarding::add_user(name account, string fullname, name type)
       .send();
 }
 
+void onboarding::check_paused() {
+    //check(false, "invite contract is paused, check back later"); // REMOVE THIS AGAIN
+}
+
 void onboarding::transfer_seeds(name account, asset quantity, string memo)
 {
 
@@ -62,6 +77,8 @@ void onboarding::transfer_seeds(name account, asset quantity, string memo)
   {
     return;
   }
+
+  check_is_banned(account);
 
   action(
       permission_level{_self, "active"_n},
@@ -146,6 +163,7 @@ void onboarding::accept_invite(
     referrer = refitr->referrer;
   }
 
+
   invites_byhash.modify(iitr, get_self(), [&](auto &invite)
                         {
                           invite.account = account;
@@ -166,6 +184,8 @@ void onboarding::accept_invite(
   {
     check(!is_existing_telos_user, "telos account already exists: " + account.to_string());
   }
+
+  check_is_banned(referrer);
 
   if (!is_existing_telos_user)
   {
@@ -201,6 +221,8 @@ ACTION onboarding::onboardorg(name sponsor, name account, string fullname, strin
 {
   require_auth(get_self());
 
+  check_is_banned(sponsor);
+
   bool is_existing_telos_user = is_account(account);
   bool is_existing_seeds_user = is_seeds_user(account);
 
@@ -219,6 +241,8 @@ ACTION onboarding::onboardorg(name sponsor, name account, string fullname, strin
 ACTION onboarding::createregion(name sponsor, name region, string publicKey)
 {
   require_auth(get_self());
+
+  check_is_banned(sponsor);
 
   bool is_existing_telos_user = is_account(region);
 
@@ -405,6 +429,8 @@ void onboarding::cancel(name sponsor, checksum256 invite_hash)
 
 void onboarding::_cancel(name sponsor, checksum256 invite_hash, bool check_auth)
 {
+
+  check_is_banned(sponsor);
 
   checksum256 empty_checksum;
 

--- a/src/seeds.onboarding.cpp
+++ b/src/seeds.onboarding.cpp
@@ -369,8 +369,6 @@ void onboarding::_invite(name sponsor, name referrer, asset transfer_quantity, a
   uint64_t min_planted = config_get("inv.min.plnt"_n);
   check(sow_quantity.amount >= min_planted, "the planted amount must be greater or equal than " + std::to_string(min_planted/10000.0));
 
-  print("sow "+std::to_string(sow_quantity.amount) + " >= " + std::to_string(min_planted));
-
   if (campaign_id != 0)
   {
     auto citr = campaigns.find(campaign_id);

--- a/src/seeds.onboarding.cpp
+++ b/src/seeds.onboarding.cpp
@@ -24,7 +24,7 @@ void onboarding::create_account(name account, string publicKey, name domain)
   action(
       permission_level{_self, "owner"_n},
       "eosio"_n, "buyram"_n,
-      make_tuple(_self, account, asset(21000, network_symbol)))
+      make_tuple(_self, account, asset(5000, network_symbol)))
       .send();
 
   action(

--- a/test/harvest.test.js
+++ b/test/harvest.test.js
@@ -1669,3 +1669,96 @@ describe('regions contribution score', async assert => {
 })
 
 
+
+describe("harvest unplant protection", async assert => {
+
+  if (!isLocal()) {
+    console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
+    return
+  }
+
+  const contracts = await initContracts({ accounts, token, harvest, settings })
+
+  console.log('settings reset')
+  await contracts.settings.reset({ authorization: `${settings}@active` })
+
+  console.log('harvest reset')
+  await contracts.harvest.reset({ authorization: `${harvest}@active` })
+
+  console.log('accounts reset')
+  await contracts.accounts.reset({ authorization: `${accounts}@active` })
+
+  console.log('reset token stats')
+  await contracts.token.resetweekly({ authorization: `${token}@active` })
+
+  await contracts.settings.configure('batchsize', 1, { authorization: `${settings}@active` })
+
+  console.log('join users')
+  await contracts.accounts.adduser(firstuser, 'first user', 'individual', { authorization: `${accounts}@active` })
+  await contracts.accounts.adduser(seconduser, 'second user', 'individual', { authorization: `${accounts}@active` })
+
+  console.log('plant seeds')
+  await contracts.token.transfer(firstuser, harvest, '100.0000 SEEDS', '', { authorization: `${firstuser}@active` })
+  await contracts.token.transfer(seconduser, harvest, '5.0000 SEEDS', '', { authorization: `${seconduser}@active` })
+
+  // const planted = await eos.getTableRows({
+  //   code: harvest,
+  //   scope: harvest,
+  //   table: 'planted',
+  //   json: true,
+  // })
+  // console.log("planted: "+JSON.stringify(planted, null, 2))
+
+  var overdraw1 = false
+  try {
+    await contracts.harvest.unplant(firstuser, '95.0001 SEEDS', { authorization: `${firstuser}@active` })
+    overdraw1 = true
+  } catch (err) {
+    // expected
+  }
+
+  var overdraw2 = false
+  try {
+    await contracts.harvest.sow(seconduser, firstuser, '1.0000 SEEDS', { authorization: `${seconduser}@active` })
+    overdraw2 = true
+  } catch (err) {
+    // expected
+  }
+
+  var unplantOk = true
+  try {
+    await contracts.harvest.unplant(firstuser, '95.0000 SEEDS', { authorization: `${firstuser}@active` })
+  } catch (err) {
+    var unplantOk = false
+  }
+
+  // const planted2 = await eos.getTableRows({
+  //   code: harvest,
+  //   scope: harvest,
+  //   table: 'planted',
+  //   json: true,
+  // })
+  // console.log("planted 2: "+JSON.stringify(planted2, null, 2))
+
+  assert({
+    given: 'overdraw1',
+    should: 'be false',
+    actual: overdraw1,
+    expected: false
+  })
+  
+  assert({
+    given: 'overdraw2',
+    should: 'be false',
+    actual: overdraw2,
+    expected: false
+  })
+
+  assert({
+    given: 'unplantOk',
+    should: 'be true',
+    actual: unplantOk,
+    expected: true
+  })
+
+})

--- a/test/onboarding.test.js
+++ b/test/onboarding.test.js
@@ -1279,10 +1279,23 @@ describe('Ban', async assert => {
         isBan = message.indexOf("banned user") != -1
     }
 
+    await contracts.accounts.unban(firstuser, { authorization: `${accounts}@active` })
+
+    await contracts.onboarding.accept(newAccount, inviteSecret, newAccountPublicKey, { authorization: `${onboarding}@active` })
+
+    accepted = true // if we get here...
+
     assert({
         given: 'ban',
         should: 'cant accept invite',
         actual: isBan,
+        expected: true
+    })
+
+    assert({
+        given: 'unban',
+        should: 'can accept invite',
+        actual: accepted,
         expected: true
     })
 })

--- a/test/onboarding.test.js
+++ b/test/onboarding.test.js
@@ -1033,122 +1033,200 @@ describe('Private campaign', async assert => {
 })
 
 
-describe("clean up unused invites", async assert => {
+// describe("clean up unused invites", async assert => {
+
+//     if (!isLocal()) {
+//         console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
+//         return
+//     }
+
+//     const transferQuantity = `10.0000 SEEDS`
+//     const sowQuantity = '5.0000 SEEDS'
+//     const totalQuantity = '15.0000 SEEDS'
+
+//     const newAccount = randomAccountName()
+//     const newAccount2 = randomAccountName()
+
+//     const keyPair = await createKeypair()
+//     const keyPair2 = await createKeypair()
+
+//     console.log("new account keys: " + JSON.stringify(keyPair, null, 2))
+
+//     const contracts = await initContracts({ onboarding, token, accounts, harvest, settings })
+
+//     console.log(`reset ${settings}`)
+//     await contracts.settings.reset({ authorization: `${settings}@active` })
+
+//     console.log(`reset ${accounts}`)
+//     await contracts.accounts.reset({ authorization: `${accounts}@active` })
+
+//     console.log(`reset ${token}`)
+//     await contracts.token.resetweekly({ authorization: `${token}@active` })
+
+//     console.log(`reset ${onboarding}`)
+//     await contracts.onboarding.reset({ authorization: `${onboarding}@active` })
+
+//     console.log('join users')
+//     await contracts.accounts.adduser(firstuser, 'First user', "individual", { authorization: `${accounts}@active` })
+//     await contracts.accounts.adduser(seconduser, 'Second user', "individual", { authorization: `${accounts}@active` })
+
+//     const newAccountPublicKey = 'EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV'
+
+//     const inviteSecret = await ramdom64ByteHexString()
+//     const inviteHash = sha256(fromHexString(inviteSecret)).toString('hex')
+
+//     const inviteSecret2 = await ramdom64ByteHexString()
+//     const inviteHash2 = sha256(fromHexString(inviteSecret2)).toString('hex')
+
+//     const inviteSecret3 = await ramdom64ByteHexString()
+//     const inviteHash3 = sha256(fromHexString(inviteSecret3)).toString('hex')
+
+//     const deposit = async (user, memo = '') => {
+//         console.log(`${token}.transfer from ${user} to ${onboarding} (${totalQuantity})`)
+//         await contracts.token.transfer(user, onboarding, totalQuantity, memo, { authorization: `${user}@active` })
+//     }
+
+//     const invite = async (user, inviteHash) => {
+//         console.log(`${onboarding}.invite from ${user}`)
+//         await contracts.onboarding.invite(user, transferQuantity, sowQuantity, inviteHash, { authorization: `${user}@active` })
+//     }
+
+//     const checkInvites = async (numberInvites, expectedTimestamps) => {
+//         const allInvites = await getTableRows({
+//             code: onboarding,
+//             scope: onboarding,
+//             table: 'invites',
+//             json: true
+//         })
+//         console.log(allInvites)
+
+//         assert({
+//             given: 'cleanup ran',
+//             should: 'have the correct number of invites',
+//             actual: allInvites.rows.length,
+//             expected: numberInvites
+//         })
+
+//         const timestamps = await getTableRows({
+//             code: onboarding,
+//             scope: onboarding,
+//             table: 'timestamps',
+//             json: true
+//         })
+//         console.log(timestamps)
+
+//         assert({
+//             given: 'cleanup ran',
+//             should: 'have the correct timestamp entries',
+//             actual: timestamps.rows.map(r => {
+//                 delete r.timestamp
+//                 return { ...r }
+//             }),
+//             expected: expectedTimestamps
+//         })
+//     }
+
+//     await deposit(firstuser)
+//     await invite(firstuser, inviteHash)
+//     await deposit(seconduser)
+//     await invite(seconduser, inviteHash2)
+//     await deposit(seconduser)
+//     await invite(seconduser, inviteHash3)
+
+//     await contracts.onboarding.chkcleanup({ authorization: `${onboarding}@active` })
+//     await sleep(500)
+
+//     await checkInvites(3, [{ id: 0, invite_id: 2 }])
+
+//     await sleep(2000)
+
+//     await contracts.settings.configure('batchsize', 1, { authorization: `${settings}@active` })
+
+//     await contracts.onboarding.chkcleanup({ authorization: `${onboarding}@active` })
+//     await sleep(4000)
+
+//     await checkInvites(1, [
+//         { id: 0, invite_id: 2 },
+//         { id: 1, invite_id: 2 }
+//     ])
+
+// })
+
+
+describe('Invite amounts', async assert => {
 
     if (!isLocal()) {
         console.log("only run unit tests on local - don't reset accounts on mainnet or testnet")
         return
     }
 
-    const transferQuantity = `10.0000 SEEDS`
+    const contracts = await initContracts({ onboarding, token, accounts, harvest })
+
+    const transferQuantity = `0.0000 SEEDS`
     const sowQuantity = '5.0000 SEEDS'
-    const totalQuantity = '15.0000 SEEDS'
+    const totalQuantity = '5.0000 SEEDS'
 
     const newAccount = randomAccountName()
-    const newAccount2 = randomAccountName()
-
+    console.log("New account " + newAccount)
     const keyPair = await createKeypair()
-    const keyPair2 = await createKeypair()
-
     console.log("new account keys: " + JSON.stringify(keyPair, null, 2))
-
-    const contracts = await initContracts({ onboarding, token, accounts, harvest, settings })
-
-    console.log(`reset ${settings}`)
-    await contracts.settings.reset({ authorization: `${settings}@active` })
+    const newAccountPublicKey = keyPair.public
+    const inviteSecret = await ramdom64ByteHexString()
+    const inviteHash = sha256(fromHexString(inviteSecret)).toString('hex')
 
     console.log(`reset ${accounts}`)
     await contracts.accounts.reset({ authorization: `${accounts}@active` })
 
-    console.log(`reset ${token}`)
-    await contracts.token.resetweekly({ authorization: `${token}@active` })
-
     console.log(`reset ${onboarding}`)
     await contracts.onboarding.reset({ authorization: `${onboarding}@active` })
 
-    console.log('join users')
-    await contracts.accounts.adduser(firstuser, 'First user', "individual", { authorization: `${accounts}@active` })
-    await contracts.accounts.adduser(seconduser, 'Second user', "individual", { authorization: `${accounts}@active` })
+    console.log(`reset ${harvest}`)
+    await contracts.harvest.reset({ authorization: `${harvest}@active` })
 
-    const newAccountPublicKey = 'EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV'
+    await contracts.accounts.adduser(firstuser, "", "individual", { authorization: `${accounts}@active` })
 
-    const inviteSecret = await ramdom64ByteHexString()
-    const inviteHash = sha256(fromHexString(inviteSecret)).toString('hex')
+    await contracts.token.transfer(firstuser, onboarding, '4.9999 SEEDS', '', { authorization: `${firstuser}@active` })
 
-    const inviteSecret2 = await ramdom64ByteHexString()
-    const inviteHash2 = sha256(fromHexString(inviteSecret2)).toString('hex')
-
-    const inviteSecret3 = await ramdom64ByteHexString()
-    const inviteHash3 = sha256(fromHexString(inviteSecret3)).toString('hex')
-
-    const deposit = async (user, memo = '') => {
-        console.log(`${token}.transfer from ${user} to ${onboarding} (${totalQuantity})`)
-        await contracts.token.transfer(user, onboarding, totalQuantity, memo, { authorization: `${user}@active` })
+    var fail1 = false
+    try {
+        await contracts.onboarding.invite(firstuser, transferQuantity, '3.0000 SEEDS', inviteHash, { authorization: `${firstuser}@active` })
+    } catch (err) {
+        fail1 = true
+        // expected
     }
 
-    const invite = async (user, inviteHash) => {
-        console.log(`${onboarding}.invite from ${user}`)
-        await contracts.onboarding.invite(user, transferQuantity, sowQuantity, inviteHash, { authorization: `${user}@active` })
+    var fail2 = false
+    try {
+        await contracts.onboarding.invite(firstuser, transferQuantity, '5.0000 SEEDS', inviteHash, { authorization: `${firstuser}@active` })
+    } catch (err) {
+        fail2 = true
+        // expected
     }
 
-    const checkInvites = async (numberInvites, expectedTimestamps) => {
-        const allInvites = await getTableRows({
-            code: onboarding,
-            scope: onboarding,
-            table: 'invites',
-            json: true
-        })
-        console.log(allInvites)
+    console.log("increase balance")
+    await contracts.token.transfer(firstuser, onboarding, '0.0001 SEEDS', '', { authorization: `${firstuser}@active` })
+    
+    console.log("invite")
+    await contracts.onboarding.invite(firstuser, transferQuantity, '5.0000 SEEDS', inviteHash, { authorization: `${firstuser}@active` })
 
-        assert({
-            given: 'cleanup ran',
-            should: 'have the correct number of invites',
-            actual: allInvites.rows.length,
-            expected: numberInvites
-        })
+    succeed = true // if we get here...
 
-        const timestamps = await getTableRows({
-            code: onboarding,
-            scope: onboarding,
-            table: 'timestamps',
-            json: true
-        })
-        console.log(timestamps)
-
-        assert({
-            given: 'cleanup ran',
-            should: 'have the correct timestamp entries',
-            actual: timestamps.rows.map(r => {
-                delete r.timestamp
-                return { ...r }
-            }),
-            expected: expectedTimestamps
-        })
-    }
-
-    await deposit(firstuser)
-    await invite(firstuser, inviteHash)
-    await deposit(seconduser)
-    await invite(seconduser, inviteHash2)
-    await deposit(seconduser)
-    await invite(seconduser, inviteHash3)
-
-    await contracts.onboarding.chkcleanup({ authorization: `${onboarding}@active` })
-    await sleep(500)
-
-    await checkInvites(3, [{ id: 0, invite_id: 2 }])
-
-    await sleep(2000)
-
-    await contracts.settings.configure('batchsize', 1, { authorization: `${settings}@active` })
-
-    await contracts.onboarding.chkcleanup({ authorization: `${onboarding}@active` })
-    await sleep(4000)
-
-    await checkInvites(1, [
-        { id: 0, invite_id: 2 },
-        { id: 1, invite_id: 2 }
-    ])
-
+    assert({
+        given: 'too low sow',
+        should: 'fail to invite',
+        actual: fail1,
+        expected: true
+    })
+    assert({
+        given: 'too low balance',
+        should: 'fail to invite',
+        actual: fail2,
+        expected: true
+    })
+    assert({
+        given: 'enough sow',
+        should: 'succeed to invite',
+        actual: succeed,
+        expected: true
+    })
 })
-


### PR DESCRIPTION
Major changes
- Buy 0.5 TLOS worth of RAM, instead of 2 - that balances the price with Seeds at the moment.
- Can't unplant the last 5 Seeds (need to keep this to pay for RAM)
- Enforce minimum 5 Seeds invites - seems to have been a bug that it was not enforced in some cases
- Ban functions to ban scammers
