### PR TITLE
use double for higher precision quorum

### DIFF
--- a/include/seeds.dao.hpp
+++ b/include/seeds.dao.hpp
@@ -248,7 +248,7 @@ CONTRACT dao : public contract {
     void increase_voice_cast(const uint64_t & amount, const name & option, const name & prop_type);
     void add_voice_cast(const uint64_t & cycle, const uint64_t & voice_cast, const name & type);
     uint64_t calc_voice_needed(const uint64_t & total_voice, const uint64_t & num_proposals);
-    uint64_t get_quorum(const uint64_t & total_proposals);
+    double get_quorum(const uint64_t total_proposals);
 
     void check_citizen(const name & account);
     void vote_aux(const name & voter, const uint64_t & referendum_id, const uint64_t & amount, const name & option, const bool & is_delegated);

--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -87,6 +87,7 @@ CONTRACT proposals : public contract {
       ACTION decayvoice(uint64_t start, uint64_t chunksize);
 
       ACTION testquorum(uint64_t total_proposals);
+      ACTION testvn(uint64_t total_voice, uint64_t num_proposals);
 
       ACTION testvdecay(uint64_t timestamp);
 
@@ -471,6 +472,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
         (fixdesc)(applyfixprop)(backfixprop)
         (revertvote)(mimicrevert)
         (rewind)(fixcycstat)
+        (testvn)
         )
       }
   }

--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -193,7 +193,7 @@ CONTRACT proposals : public contract {
       void size_change(name id, int64_t delta);
       void size_set(name id, int64_t value);
 
-      uint64_t get_quorum(uint64_t total_proposals);
+      double get_quorum(uint64_t total_proposals);
       void recover_voice(name account);
       void demote_citizen(name account);
       uint64_t calculate_decay(uint64_t voice);

--- a/src/seeds.dao.cpp
+++ b/src/seeds.dao.cpp
@@ -839,16 +839,15 @@ uint64_t dao::calc_voice_needed (const uint64_t & total_voice, const uint64_t & 
   return ceil(total_voice * (get_quorum(num_proposals) / 100.0));
 }
 
-uint64_t dao::get_quorum (const uint64_t & total_proposals) {
+// quorum as % value - e.g. 90.0 == 90%
+double dao::get_quorum(const uint64_t total_proposals) {
+  double base_quorum = config_get("quorum.base"_n);
+  double quorum_min = config_get("quor.min.pct"_n);
+  double quorum_max = config_get("quor.max.pct"_n);
 
-  uint64_t base_quorum = config_get("quorum.base"_n);
-  uint64_t quorum_min = config_get("quor.min.pct"_n);
-  uint64_t quorum_max = config_get("quor.max.pct"_n);
-
-  uint64_t quorum = total_proposals ? base_quorum / total_proposals : 0;
+  double quorum = total_proposals ? (double)base_quorum / (double)total_proposals : 0;
   quorum = std::max(quorum_min, quorum);
   return std::min(quorum_max, quorum);
-
 }
 
 

--- a/src/seeds.dao.cpp
+++ b/src/seeds.dao.cpp
@@ -836,7 +836,7 @@ void dao::add_voice_cast (const uint64_t & cycle, const uint64_t & voice_cast, c
 }
 
 uint64_t dao::calc_voice_needed (const uint64_t & total_voice, const uint64_t & num_proposals) {
-  return ceil(total_voice * (get_quorum(num_proposals) / 100.0));
+  return ceil( total_voice * (get_quorum(num_proposals) / 100.0) - 0.000000001);
 }
 
 // quorum as % value - e.g. 90.0 == 90%

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -141,13 +141,13 @@ void proposals::update_min_stake(uint64_t prop_id) {
   }
 }
 
-// quorum as integer % value - e.g. 90 == 90%
-uint64_t proposals::get_quorum(uint64_t total_proposals) {
-  uint64_t base_quorum = config_get("quorum.base"_n);
-  uint64_t quorum_min = config_get("quor.min.pct"_n);
-  uint64_t quorum_max = config_get("quor.max.pct"_n);
+// quorum as % value - e.g. 90.0 == 90%
+double proposals::get_quorum(uint64_t total_proposals) {
+  double base_quorum = config_get("quorum.base"_n);
+  double quorum_min = config_get("quor.min.pct"_n);
+  double quorum_max = config_get("quor.max.pct"_n);
 
-  uint64_t quorum = total_proposals ? base_quorum / total_proposals : 0;
+  double quorum = total_proposals ? (double)base_quorum / (double)total_proposals : 0;
   quorum = std::max(quorum_min, quorum);
   return std::min(quorum_max, quorum);
 }

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -285,7 +285,15 @@ void proposals::add_voice_cast(uint64_t cycle, uint64_t voice_cast, name type) {
 }
 
 uint64_t proposals::calc_voice_needed(uint64_t total_voice, uint64_t num_proposals) {
-  return ceil(total_voice * (get_quorum(num_proposals) / 100.0));
+  // note the factor -0.000000001 at the end is needed because ceil() for a perfectly even number like 20.0 will return the 
+  // number + 1, like 21 in this case. This is a weirdness of ceil().
+  return ceil( total_voice * (get_quorum(num_proposals) / 100.0) - 0.000000001);
+}
+
+void proposals::testvn(uint64_t total_voice, uint64_t num_proposals) {
+  require_auth(_self);
+  uint64_t res = calc_voice_needed(total_voice, num_proposals);
+  print(res);
 }
 
 void proposals::add_num_prop(uint64_t cycle, uint64_t num_prop, name type) {

--- a/test/proposals.test.js
+++ b/test/proposals.test.js
@@ -1280,7 +1280,7 @@ describe('Proposals Quorum And Support Levels', async assert => {
     json: true
   })
 
-  // console.log("supportForCampaigns "+JSON.stringify(supportForCampaigns, null, 2))
+  console.log("supportForCampaigns "+JSON.stringify(supportForCampaigns, null, 2))
   // console.log("supportForAlliances "+JSON.stringify(supportForAlliances, null, 2))
 
   console.log('execute proposals')
@@ -1304,7 +1304,7 @@ describe('Proposals Quorum And Support Levels', async assert => {
       assert({
         given: 'get quorum called',
         should: 'give the correct quorum threshold',
-        expected: `assertion failure with message: ${expectedValue}`,
+        expected: `assertion failure with message: ${expectedValue}.000000`,
         actual: err.json.error.details[0].message
       })
     }


### PR DESCRIPTION
We need to use double for quorum to prevent rounding errors...



Bug report

Sorin: 

> Is it too much trouble to use 3 decimals for the code that calculates the percent for quorum?
> For example:
> Last cycle: 1/8 proposals = 0.125 rounded at 0.12. 
> Instead of 0.125 x 13 166 = 1646 trust tokens we had
> 0.12 x 13166 = 1580 trust tokens needed 
> 
> While this cycle we have 1/4 proposals = 0.25 ...no issue here :slight_smile:
> 
> So my question is, how hard is to code that change (from 2 to 3 decimals) and if you want to adjust that to have a more accurate value?
> 
> Thanks!
