### PR TITLE
 dao.seeds allow voice scopes being added or removed #395 

### DIFF
--- a/include/seeds.dao.hpp
+++ b/include/seeds.dao.hpp
@@ -116,7 +116,7 @@ CONTRACT dao : public contract {
 
       ACTION updatevoices();
 
-      ACTION updatevoice(const uint64_t & start);
+      ACTION updatevoice(const uint64_t & start, const name & scope);
 
       ACTION erasepartpts(const uint64_t & active_proposals);
 
@@ -135,6 +135,10 @@ CONTRACT dao : public contract {
       ACTION dhocleanvote(const uint64_t & cutoff, const uint64_t & chunksize);
 
       ACTION dhocalcdists();
+
+      ACTION deletescope(const uint64_t & start, const name & scope); 
+
+      ACTION addvoice(const uint64_t & start, const name & scope);
 
 
       ACTION testsetvoice(const name & account, const uint64_t & amount);
@@ -392,7 +396,7 @@ extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
           (updatevoices)(updatevoice)
           (erasepartpts)
           (createdho)(removedho)(removedhovts)(votedhos)(dhomimicvote)(dhocleanvts)(dhocleanvote)(dhocalcdists)
-          (testsetvoice)
+          (testsetvoice)(deletescope)(addvoice)
         )
       }
   }


### PR DESCRIPTION
Fix #395

Actions added 
- deletescope
- addvoice

Actions updated
- updatevoice
- updatevoices

Changes made:
`updatevoice` now updates all voices or just a one.
`updatevoices` small change because it calls `updatevoice`.
`deletescope` deletes all voice values from all users for a given proposal scope contained in `scopes` vector.
`addvoice` add all voice values from all users, with its respective value (decay calculated) for a given proposal scope contained in `scopes` vector.

**Contracts to be deployed:**
- [ ] dao.seeds

Other considerations:
- No settings added
- No permissions added
- No migrations required