### PR TITLE
Changed Gratitude Pot Keep to store 50% of the pot each round

### DIFF
--- a/src/seeds.settings.cpp
+++ b/src/seeds.settings.cpp
@@ -344,7 +344,7 @@ void settings::reset() {
   confwithdesc(name("gratz1.gen"), 100 * 10000, "Base quantity of gratitude tokens received for residents per cycle", medium_impact);
   confwithdesc(name("gratz2.gen"), 200 * 10000, "Base quantity of gratitude tokens received for citizens per cycle", medium_impact);
   confwithdesc(name("gratz.acks"), 10, "Minumum number of gratitude acks to fully use your tokens", medium_impact);
-  confwithdesc(name("gratz.potkp"), 0, "Percent to keep on Gratitude Pot at new round", medium_impact);
+  confwithdesc(name("gratz.potkp"), 50, "Percent to keep on Gratitude Pot at new round", medium_impact);
 
   // =====================================
   // onboarding/invite


### PR DESCRIPTION
Changing SEEDS settings `gratz.potkp` to 50%, to avoid the campaign reload that ran twice.