### PR TITLE
Added flag delegation

### DIFF
--- a/include/seeds.accounts.hpp
+++ b/include/seeds.accounts.hpp
@@ -80,7 +80,7 @@ CONTRACT accounts : public contract {
       ACTION removeflag(name from, name to);
       ACTION delegateflag(name delegator, name delegatee);
       ACTION undlgateflag(name delegator);
-      ACTION mimicflag(name delegatee, name to, uint64_t chunksize);
+      ACTION mimicflag(name delegatee, name to, name action, uint64_t chunksize);
       ACTION punish(name account, uint64_t points);
       ACTION pnshvouchers(name account, uint64_t points, uint64_t start);
       ACTION evaldemote(name to, uint64_t start_val, uint64_t chunk, uint64_t chunksize);

--- a/include/seeds.accounts.hpp
+++ b/include/seeds.accounts.hpp
@@ -9,6 +9,7 @@
 #include <tables/config_table.hpp>
 #include <tables/ban_table.hpp>
 #include <tables/config_float_table.hpp>
+#include <tables/deferred_id_table.hpp>
 #include <utils.hpp>
 
 using namespace eosio;
@@ -77,6 +78,9 @@ CONTRACT accounts : public contract {
 
       ACTION flag(name from, name to);
       ACTION removeflag(name from, name to);
+      ACTION delegateflag(name delegator, name delegatee);
+      ACTION undlgateflag(name delegator);
+      ACTION mimicflag(name delegatee, name to, uint64_t chunksize);
       ACTION punish(name account, uint64_t points);
       ACTION pnshvouchers(name account, uint64_t points, uint64_t start);
       ACTION evaldemote(name to, uint64_t start_val, uint64_t chunk, uint64_t chunksize);
@@ -373,13 +377,28 @@ CONTRACT accounts : public contract {
     typedef eosio::multi_index<"actives"_n, active_table> active_tables;
     active_tables actives;
 
+    DEFINE_DEFERRED_ID_TABLE
+    DEFINE_DEFERRED_ID_SINGLETON
+
+    TABLE delegators_table {
+      name delegator;
+      name delegatee;
+
+      uint64_t primary_key () const { return delegator.value; }
+      uint128_t by_delegatee_delegator () const { return (uint128_t(delegatee.value) << 64) + delegator.value; }
+    };
+    typedef eosio::multi_index<"delegators"_n, delegators_table,
+      indexed_by<"bydelegatee"_n,
+      const_mem_fun<delegators_table, uint128_t, &delegators_table::by_delegatee_delegator>>
+    > delegators_tables;
+
 };
 
 EOSIO_DISPATCH(accounts, (reset)(adduser)(canresident)(makeresident)(cancitizen)(makecitizen)(update)(addref)(invitevouch)(addrep)(changesize)
 (subrep)(testsetrep)(testsetrs)(testcitizen)(testresident)(testvisitor)(testremove)(testsetcbs)
 (testreward)(requestvouch)(vouch)(pnishvouched)
 (rankreps)(rankorgreps)(rankrep)(rankcbss)(rankorgcbss)(rankcbs)
-(flag)(removeflag)(punish)(pnshvouchers)(evaldemote)(bantree)
+(flag)(removeflag)(punish)(pnshvouchers)(evaldemote)(bantree)(delegateflag)(undlgateflag)(mimicflag)
 (refinfo)(unban)
 (testmvouch)
 (addcbs)

--- a/include/tables/deferred_id_table.hpp
+++ b/include/tables/deferred_id_table.hpp
@@ -1,0 +1,11 @@
+#include <eosio/eosio.hpp>
+#include <eosio/singleton.hpp>
+
+using eosio::name;
+
+#define DEFINE_DEFERRED_ID_TABLE TABLE deferred_id_table { \
+  uint64_t id; \
+};
+
+#define DEFINE_DEFERRED_ID_SINGLETON typedef singleton<"deferredids"_n, deferred_id_table> deferred_id_tables; \
+typedef eosio::multi_index<"deferredids"_n, deferred_id_table> dump_for_deferred_id;

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -229,7 +229,7 @@ namespace utils {
   }
 
   template <typename T>
-  void delete_table (const name & code, const uint64_t & scope) {
+  inline void delete_table (const name & code, const uint64_t & scope) {
 
     T table(code, scope);
     auto itr = table.begin();
@@ -241,7 +241,7 @@ namespace utils {
   }
 
   template <typename... T>
-  void send_deferred_transaction (
+  inline void send_deferred_transaction (
     const name & code,
     const permission_level & permission,
     const name & contract, 

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -229,9 +229,9 @@ namespace utils {
   }
 
   template <typename T>
-  void delete_table (const name & code, const name & scope) {
+  void delete_table (const name & code, const uint64_t & scope) {
 
-    T table(code, scope.value);
+    T table(code, scope);
     auto itr = table.begin();
 
     while (itr != table.end()) {

--- a/src/seeds.accounts.cpp
+++ b/src/seeds.accounts.cpp
@@ -10,83 +10,33 @@ void accounts::reset() {
 
   auto uitr = users.begin();
   while (uitr != users.end()) {
-    vouch_tables vouch(get_self(), uitr->account.value);
-    auto vitr = vouch.begin();
-    while (vitr != vouch.end()) {
-      vitr = vouch.erase(vitr);
-    }
+    utils::delete_table<vouch_tables>(contracts::accounts, uitr->account.value);
 
-    flag_points_tables flags(get_self(), uitr->account.value);
-    auto fitr = flags.begin();
-    while (fitr != flags.end()) {
-      fitr = flags.erase(fitr);
-    }
+    utils::delete_table<flag_points_tables>(contracts::accounts, uitr->account.value);
 
     uitr = users.erase(uitr);
   }
 
-  flag_points_tables flags(get_self(), flag_total_scope.value);
-  auto fitr = flags.begin();
-  while (fitr != flags.end()) {
-    fitr = flags.erase(fitr);
-  }
+  utils::delete_table<flag_points_tables>(contracts::accounts, flag_total_scope.value);
+  utils::delete_table<flag_points_tables>(contracts::accounts, flag_remove_scope.value);
 
-  flag_points_tables flagsremoved(get_self(), flag_remove_scope.value);
-  auto fritr = flagsremoved.begin();
-  while (fritr != flagsremoved.end()) {
-    fritr = flagsremoved.erase(fritr);
-  }
+  utils::delete_table<vouches_tables>(contracts::accounts, contracts::accounts.value);
 
-  auto vitr = vouches.begin();
-  while (vitr != vouches.end()) {
-    vitr = vouches.erase(vitr);
-  }
+  utils::delete_table<vouches_totals_tables>(contracts::accounts, contracts::accounts.value);
 
-  auto vtitr = vouchtotals.begin();
-  while (vtitr != vouchtotals.end()) {
-    vtitr = vouchtotals.erase(vtitr);
-  }
+  utils::delete_table<ref_tables>(contracts::accounts, contracts::accounts.value);
 
-  auto refitr = refs.begin();
-  while (refitr != refs.end()) {
-    refitr = refs.erase(refitr);
-  }
+  utils::delete_table<cbs_tables>(contracts::accounts, contracts::accounts.value);
+  utils::delete_table<cbs_tables>(contracts::accounts, organization_scope.value);
 
-  auto cbsitr = cbs.begin();
-  while (cbsitr != cbs.end()) {
-    cbsitr = cbs.erase(cbsitr);
-  }
+  utils::delete_table<rep_tables>(contracts::accounts, contracts::accounts.value);
+  utils::delete_table<rep_tables>(contracts::accounts, organization_scope.value);
 
-  cbs_tables cbs_t(get_self(), organization_scope.value);
-  auto cbsitr_org = cbs_t.begin();
-  while (cbsitr_org != cbs_t.end()) {
-    cbsitr_org = cbs_t.erase(cbsitr_org);
-  }
+  utils::delete_table<size_tables>(contracts::accounts, contracts::accounts.value);
 
-  auto repitr = rep.begin();
-  while (repitr != rep.end()) {
-    repitr = rep.erase(repitr);
-  }
-
-  rep_tables rep_t(get_self(), organization_scope.value);
-  auto o_repitr = rep_t.begin();
-  while (o_repitr != rep_t.end()) {
-    o_repitr = rep_t.erase(o_repitr);
-  }
-
-  auto sitr = sizes.begin();
-  while (sitr != sizes.end()) {
-    sitr = sizes.erase(sitr);
-  }
-
-  ban_tables ban(contracts::accounts, contracts::accounts.value);
-  auto banitr = ban.begin();
-  while (banitr != ban.end()) {
-    banitr = ban.erase(banitr);
-  }
+  utils::delete_table<ban_tables>(contracts::accounts, contracts::accounts.value);
 
   utils::delete_table<delegators_tables>(contracts::accounts, contracts::accounts.value);
-
 }
 
 void accounts::history_add_resident(name account) {

--- a/test/accounts.test.js
+++ b/test/accounts.test.js
@@ -1870,6 +1870,52 @@ describe('Delegate flagging', async assert => {
     ]
   })
 
+  console.log('undelegate flag')
+  await contracts.accounts.undlgateflag(thirduser, { authorization: `${firstuser}@active` })
+  await contracts.accounts.undlgateflag(fourthuser, { authorization: `${thirduser}@active` })
+
+  const delegatorsTableAfterUndelegate = await getTableRows({
+    code: accounts,
+    scope: accounts,
+    table: 'delegators',
+    json: true
+  })
+  assert({
+    given: 'undelegate flag',
+    should: 'have the correct entries in the delegators table',
+    actual: delegatorsTableAfterUndelegate.rows,
+    expected: [
+      {
+        delegator: seconduser,
+        delegatee: firstuser
+      },
+      {
+          delegator: fifthuser,
+          delegatee: fourthuser
+      }
+    ]
+  })
+
+  console.log('remove flag')
+  await contracts.accounts.removeflag(firstuser, fifthuser, { authorization: `${firstuser}@active` })
+  await sleep(4000)
+
+  const flagPointsAfterRemove = await getTableRows({
+    code: accounts,
+    scope: fifthuser,
+    table: 'flagpts',
+    json: true
+  })
+  console.log(JSON.stringify(flagPointsAfterRemove, null, 4))
+
+  assert({
+    given: 'flag delegated',
+    should: 'trigger remove flagging in the whole tree',
+    expected: [thirduser, fourthuser],
+    actual: flagPointsAfterRemove.rows.map(r => r.account)
+  })
+
+
 })
 
 describe('Enforce accounts', async assert => {


### PR DESCRIPTION
Fixes #406 

- Added flag delegation
- Added tables `delegators` in accounts

#### Note
I added two generic functions in`utils`:
- Send deferred transaction
- Delete a table (for use it in the reset function)

I only added those functions to the actions involved in this issue. I think it could help make the contracts look cleaner. Please let me know what you think, I could refactor some contracts to try or if you feel it's not needed I can remove it and change it for the normal way.

#### Modified contracts:
- [ ] Accounts

#### Other considerations
No permissions nor settings need to be updated