### PR TITLE
Fix vote delegation

### DIFF
--- a/src/seeds.dao.cpp
+++ b/src/seeds.dao.cpp
@@ -365,12 +365,14 @@ ACTION dao::erasepartpts (const uint64_t & active_proposals) {
 
   while (pitr != participants_t.end() && counter < batch_size) {
     if (pitr->count == active_proposals && pitr->nonneutral) {
-      send_inline_action(
-        permission_level(contracts::accounts, "addrep"_n),
-        contracts::accounts, 
-        "addrep"_n,
-        std::make_tuple(pitr->account, reward_points)
-      );
+      if (reward_points > 0) {
+        send_inline_action(
+          permission_level(contracts::accounts, "addrep"_n),
+          contracts::accounts, 
+          "addrep"_n,
+          std::make_tuple(pitr->account, reward_points)
+        );
+      }
     }
     counter += 1;
     pitr = participants_t.erase(pitr);
@@ -780,7 +782,7 @@ void dao::vote_aux (const name & voter, const uint64_t & proposal_id, const uint
 
   if (paitr == participants_t.end()) {
     // add reputation for entering in the table
-    uint64_t rep_amount = uint64_t(rep * rep_multiplier);
+    uint64_t rep_amount = uint64_t(round(rep * rep_multiplier));
 
     if (rep_amount > 0) {
       send_inline_action(

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -1973,16 +1973,23 @@ ACTION proposals::delegate (name delegator, name delegatee, name scope) {
 }
 
 void proposals::send_vote_on_behalf (name voter, uint64_t id, uint64_t amount, name option) {
-  action vote_on_behalf_action(
+  action(
     permission_level{get_self(), "active"_n},
     get_self(),
     "voteonbehalf"_n,
     std::make_tuple(voter, id, amount, option)
-  );
-  transaction tx;
-  tx.actions.emplace_back(vote_on_behalf_action);
-  // tx.delay_sec = 1;
-  tx.send(voter.value, _self);
+  ).send();
+
+  // action vote_on_behalf_action(
+  //   permission_level{get_self(), "active"_n},
+  //   get_self(),
+  //   "voteonbehalf"_n,
+  //   std::make_tuple(voter, id, amount, option)
+  // );
+  // transaction tx;
+  // tx.actions.emplace_back(vote_on_behalf_action);
+  // // tx.delay_sec = 1;
+  // tx.send(voter.value, _self);
 }
 
 void proposals::send_mimic_delegatee_vote (name delegatee, name scope, uint64_t proposal_id, double percentage_used, name option) {

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -1982,13 +1982,6 @@ ACTION proposals::delegate (name delegator, name delegatee, name scope) {
 }
 
 void proposals::send_vote_on_behalf (name voter, uint64_t id, uint64_t amount, name option) {
-  // action(
-  //   permission_level{get_self(), "active"_n},
-  //   get_self(),
-  //   "voteonbehalf"_n,
-  //   std::make_tuple(voter, id, amount, option)
-  // ).send();
-
   action vote_on_behalf_action(
     permission_level{get_self(), "active"_n},
     get_self(),

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -1982,23 +1982,23 @@ ACTION proposals::delegate (name delegator, name delegatee, name scope) {
 }
 
 void proposals::send_vote_on_behalf (name voter, uint64_t id, uint64_t amount, name option) {
-  action(
-    permission_level{get_self(), "active"_n},
-    get_self(),
-    "voteonbehalf"_n,
-    std::make_tuple(voter, id, amount, option)
-  ).send();
-
-  // action vote_on_behalf_action(
+  // action(
   //   permission_level{get_self(), "active"_n},
   //   get_self(),
   //   "voteonbehalf"_n,
   //   std::make_tuple(voter, id, amount, option)
-  // );
-  // transaction tx;
-  // tx.actions.emplace_back(vote_on_behalf_action);
-  // // tx.delay_sec = 1;
-  // tx.send(voter.value, _self);
+  // ).send();
+
+  action vote_on_behalf_action(
+    permission_level{get_self(), "active"_n},
+    get_self(),
+    "voteonbehalf"_n,
+    std::make_tuple(voter, id, amount, option)
+  );
+  transaction tx;
+  tx.actions.emplace_back(vote_on_behalf_action);
+  // tx.delay_sec = 1;
+  tx.send(voter.value, _self);
 }
 
 void proposals::send_mimic_delegatee_vote (name delegatee, name scope, uint64_t proposal_id, double percentage_used, name option) {

--- a/test/proposals.test.js
+++ b/test/proposals.test.js
@@ -2066,7 +2066,9 @@ describe('delegate trust', async assert => {
 
   console.log('configure voterep2.ind to 2')
   await contracts.settings.configure('voterep2.ind', 2, { authorization: `${settings}@active` })
-
+  console.log('configure votedel.mul to 50')
+  await contracts.settings.configure('votedel.mul', 50, { authorization: `${settings}@active` })
+  
   console.log('accounts reset')
   await contracts.accounts.reset({ authorization: `${accounts}@active` })
 
@@ -2110,6 +2112,14 @@ describe('delegate trust', async assert => {
   for (let i = 0; i < users.length; i++) {
     await contracts.proposals.testsetvoice(users[i], voices[i], { authorization: `${proposals}@active` })
   }
+  const usersTable1 = await eos.getTableRows({
+    code: accounts,
+    scope: accounts,
+    table: 'users',
+    json: true,
+  })
+  const reps1 = usersTable1.rows.map(r => r.reputation)
+  console.log("reps1 " + JSON.stringify(reps1,null,2))
 
   console.log('delegate trust for campaigns')
   const scopeCampaigns = proposals
@@ -2200,6 +2210,7 @@ describe('delegate trust', async assert => {
   //console.log("campAfterDelegateVote " + JSON.stringify(campAfterDelegateVote,null,2))
 
   console.log('vote for alliances')
+
   await contracts.proposals.against(thirduser, 2, 50, { authorization: `${thirduser}@active` })
   await sleep(5000)
 
@@ -2214,6 +2225,8 @@ describe('delegate trust', async assert => {
   })
 
   const reps = usersTable.rows.map(r => r.reputation)
+
+  console.log("reps after " + JSON.stringify(reps,null,2))
 
   const voicesAfterVote = await getVoices()
 

--- a/test/proposals.test.js
+++ b/test/proposals.test.js
@@ -2112,14 +2112,6 @@ describe('delegate trust', async assert => {
   for (let i = 0; i < users.length; i++) {
     await contracts.proposals.testsetvoice(users[i], voices[i], { authorization: `${proposals}@active` })
   }
-  const usersTable1 = await eos.getTableRows({
-    code: accounts,
-    scope: accounts,
-    table: 'users',
-    json: true,
-  })
-  const reps1 = usersTable1.rows.map(r => r.reputation)
-  console.log("reps1 " + JSON.stringify(reps1,null,2))
 
   console.log('delegate trust for campaigns')
   const scopeCampaigns = proposals
@@ -2225,8 +2217,6 @@ describe('delegate trust', async assert => {
   })
 
   const reps = usersTable.rows.map(r => r.reputation)
-
-  console.log("reps after " + JSON.stringify(reps,null,2))
 
   const voicesAfterVote = await getVoices()
 

--- a/test/proposals.test.js
+++ b/test/proposals.test.js
@@ -2064,8 +2064,12 @@ describe('delegate trust', async assert => {
   console.log('settings reset')
   await contracts.settings.reset({ authorization: `${settings}@active` })
 
+  // users get 2 points for entering into the vote table
   console.log('configure voterep2.ind to 2')
   await contracts.settings.configure('voterep2.ind', 2, { authorization: `${settings}@active` })
+
+  // delegators will get 50% of the points for entering in the vote table
+  // this means voters get 2 points, and users who delegated get 1 point (50% of 2)
   console.log('configure votedel.mul to 50')
   await contracts.settings.configure('votedel.mul', 50, { authorization: `${settings}@active` })
   


### PR DESCRIPTION
Fix for: https://github.com/JoinSEEDS/seeds-smart-contracts/issues/413

HC (Human cause): Setting parameters on mainnet could cause the rep value we add for delegators to be 0. addrep fails with an error when trying to addrep with 0. Unit tests modified the values and did not test the mainnet values, so unit tests did not cover this.

Fix: 
round the value, which with the current production settings means that delegators will get 1 rep point for entering into the table
Also, check for 0 - in case the settings change such that added rep would be 0, we don't call addrep. 
