### PR TITLE
Feature: Expiring policy

### DIFF
--- a/include/seeds.policy.hpp
+++ b/include/seeds.policy.hpp
@@ -9,18 +9,25 @@ CONTRACT policy : public contract {
     using contract::contract;
     policy(name receiver, name code, datastream<const char*> ds)
       : contract(receiver, code, ds),
-        devicepolicy(receiver, receiver.value)
+        devicepolicy(receiver, receiver.value),
+        expiry(receiver, receiver.value)
       {}
 
     ACTION reset();
 
     ACTION create(name account, string backend_user_id, string device_id, string signature, string policy);
+    
+    ACTION createexp(name account, string backend_user_id, string device_id, string signature, string policy, uint64_t expiry_seconds);
 
     ACTION update(uint64_t id, name account, string backend_user_id, string device_id, string signature, string policy);
 
     ACTION remove(uint64_t id);
 
+    ACTION removeexp(uint64_t id);
+
   private:
+
+    void remove_aux(uint64_t id);
 
     TABLE device_policy_table {
       uint64_t id;
@@ -33,14 +40,25 @@ CONTRACT policy : public contract {
       uint64_t by_account()const { return account.value; }
     };
 
+    TABLE expiry_table {
+      uint64_t id;
+      uint64_t created_at;
+      uint64_t valid_until;
+
+      uint64_t primary_key()const { return id; }
+    };
+
     typedef eosio::multi_index<"devicepolicy"_n, device_policy_table,
       indexed_by<"byaccount"_n,
       const_mem_fun<device_policy_table, uint64_t, &device_policy_table::by_account>>
     > device_policy_tables;
 
+    typedef eosio::multi_index<"expiry"_n, expiry_table> expiry_tables;
+
     device_policy_tables devicepolicy;
+    expiry_tables expiry;
 
 
 };
 
-EOSIO_DISPATCH(policy, (create)(update)(reset)(remove));
+EOSIO_DISPATCH(policy, (create)(createexp)(update)(reset)(remove)(removeexp));

--- a/scripts/eosjs-port.js
+++ b/scripts/eosjs-port.js
@@ -39,7 +39,7 @@ async function getNonce () {
           backend_user_id: random,
           device_id: random,
           signature: "",
-          policy: ""
+          policy: "CREATED BY UNIT TEST"
         }
       }]
     }

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -791,6 +791,9 @@ var permissions = [{
 },{
   target: `${accounts.dao.account}@execute`,
   action: 'dhocalcdists'
+}, {
+  target: `${accounts.policy.account}@active`,
+  actor: `${accounts.policy.account}@eosio.code`
 }]
 
 const isTestnet = chainId == networks.telosTestnet
@@ -834,6 +837,13 @@ const config = {
 }
 
 const eos = new Eos(config, isLocal)
+
+// Use eosNoNonce for not adding a nonce to every action
+// nonce means every action has a unique nonce - an action on policy.seeds
+// The nonce makes it so no duplicate transactions are recorded by the chain
+// So it makes unit tests a lot more predictable
+// But sometimes the nonce is undesired, example, when testing policy.seeds itself
+const eosNoNonce = new Eos(config, false)
 
 setTimeout(async ()=>{
   let info = await eos.getInfo({})
@@ -931,7 +941,7 @@ function asset (quantity) {
 
 module.exports = {
   keyProvider, httpEndpoint,
-  eos, getEOSWithEndpoint, encodeName, decodeName, getBalance, getBalanceFloat, getTableRows, initContracts,
+  eos, eosNoNonce, getEOSWithEndpoint, encodeName, decodeName, getBalance, getBalanceFloat, getTableRows, initContracts,
   accounts, names, ownerPublicKey, activePublicKey, apiPublicKey, permissions, sha256, isLocal, ramdom64ByteHexString, createKeypair,
   testnetUserPubkey, getTelosBalance, fromHexString, allContractNames, allContracts, allBankAccountNames, sleep, asset, isTestnet
 }

--- a/src/seeds.policy.cpp
+++ b/src/seeds.policy.cpp
@@ -1,18 +1,28 @@
 #include <seeds.policy.hpp>
+#include <eosio/transaction.hpp>
 
-void policy::reset() {
+void policy::reset()
+{
   require_auth(_self);
 
   auto pitr = devicepolicy.begin();
-  while (pitr != devicepolicy.end()) {
+  while (pitr != devicepolicy.end())
+  {
     pitr = devicepolicy.erase(pitr);
+  }
+
+  auto eitr = expiry.begin();
+  while (eitr != expiry.end())
+  {
+    eitr = expiry.erase(eitr);
   }
 }
 
-void policy::create(name account, string backend_user_id, string device_id, string signature, string policy) {
+void policy::create(name account, string backend_user_id, string device_id, string signature, string policy)
+{
   require_auth(account);
 
-  devicepolicy.emplace(_self, [&](auto& item) {
+  devicepolicy.emplace(_self, [&](auto &item) {
     item.id = devicepolicy.available_primary_key();
     item.account = account;
     item.backend_user_id = backend_user_id;
@@ -20,34 +30,95 @@ void policy::create(name account, string backend_user_id, string device_id, stri
     item.signature = signature;
     item.policy = policy;
   });
-
 }
 
-void policy::update(uint64_t id, name account, string backend_user_id, string device_id, string signature, string policy) {
+void policy::createexp(name account, string backend_user_id, string device_id, string signature, string policy, uint64_t expiry_seconds)
+{
   require_auth(account);
 
-  auto pitr = devicepolicy.find(id);
+  check(expiry_seconds <= 60 * 60 * 24 * 7, "expiry must be < 1 week");
 
-  check(pitr != devicepolicy.end(), "policy with id not found: "+std::to_string(id) );
-  
-  devicepolicy.modify(pitr, _self, [&](auto& item) {
+  uint64_t policy_id = devicepolicy.available_primary_key();
+
+  devicepolicy.emplace(_self, [&](auto &item) {
+    item.id = policy_id;
+    item.account = account;
     item.backend_user_id = backend_user_id;
     item.device_id = device_id;
     item.signature = signature;
     item.policy = policy;
   });
-  
+
+  uint64_t now = eosio::current_time_point().sec_since_epoch();
+
+  expiry.emplace(_self, [&](auto &item) {
+    item.id = policy_id;
+    item.created_at = now;
+    item.valid_until = now + expiry_seconds;
+  });
+
+  action delete_action(
+      permission_level{get_self(), "active"_n},
+      get_self(),
+      "removeexp"_n,
+      std::make_tuple(policy_id));
+
+  transaction tx;
+  tx.actions.emplace_back(delete_action);
+  tx.delay_sec = expiry_seconds;
+  tx.send(policy_id, _self);
 }
 
-void policy::remove(uint64_t id) {
+void policy::update(uint64_t id, name account, string backend_user_id, string device_id, string signature, string policy)
+{
 
   auto pitr = devicepolicy.find(id);
 
-  check(pitr != devicepolicy.end(), "remove: policy with id not found: "+std::to_string(id) );
-  
-  require_auth(pitr -> account);
+  check(pitr != devicepolicy.end(), "policy with id not found: " + std::to_string(id));
+  check(pitr->account == account, "account cannot be changed: " + (pitr->account).to_string());
 
-  devicepolicy.erase(pitr);
-  
+  require_auth(pitr->account);
+
+  devicepolicy.modify(pitr, _self, [&](auto &item) {
+    item.backend_user_id = backend_user_id;
+    item.device_id = device_id;
+    item.signature = signature;
+    item.policy = policy;
+  });
 }
 
+void policy::remove(uint64_t id)
+{
+  auto pitr = devicepolicy.find(id);
+
+  check(pitr != devicepolicy.end(), "remove: policy with id not found: " + std::to_string(id));
+
+  require_auth(pitr->account);
+
+  remove_aux(id);
+}
+
+void policy::removeexp(uint64_t id)
+{
+  require_auth(get_self());
+
+  remove_aux(id);
+}
+
+void policy::remove_aux(uint64_t id)
+{
+
+  auto pitr = devicepolicy.find(id);
+
+  if (pitr != devicepolicy.end())
+  {
+    devicepolicy.erase(pitr);
+  }
+
+  auto eitr = expiry.find(id);
+
+  if (eitr != expiry.end())
+  {
+    expiry.erase(eitr);
+  }
+}


### PR DESCRIPTION
Expiring policy - set the expiration seconds in the Action call. 

Antonio requested this as to be able to implement authentication

## New Actions

```
createexp(name account, string backend_user_id, string device_id, string signature, string policy, uint64_t expiry_seconds);
```
This is the same as "create" only with an expiry in seconds added to it

see the last field - expiry_seconds

## New Tables

```
expiry
```

Contains these fields:
```
int id - id of the policy (foreign key into devicepolicy table)
int created_at - seconds since 1970 timestamp when the policy was created
int valid_until - seconds since 1970 timestamp when the policy expires 
 ```