### PR TITLE
Fix cyclestats start_time and end_time using moon cycle times #412

### DIFF
--- a/include/seeds.dao.hpp
+++ b/include/seeds.dao.hpp
@@ -15,6 +15,7 @@
 #include <tables/cspoints_table.hpp>
 #include <tables/organization_table.hpp>
 #include <tables/dho_share_table.hpp>
+#include <tables/moon_phases_table.hpp>
 #include <cmath>
 
 using namespace eosio;
@@ -185,6 +186,9 @@ CONTRACT dao : public contract {
 
       DEFINE_ORGANIZATION_TABLE
       DEFINE_ORGANIZATION_TABLE_MULTI_INDEX
+
+      DEFINE_MOON_PHASES_TABLE
+      DEFINE_MOON_PHASES_TABLE_MULTI_INDEX
 
       TABLE deferred_id_table {
         uint64_t id;
@@ -377,6 +381,7 @@ CONTRACT dao : public contract {
     void init_cycle_new_stats();
     uint64_t calc_voice_needed(const uint64_t & total_voice, const uint64_t & num_proposals);
     double get_quorum(uint64_t total_proposals);
+    uint64_t get_new_moon(uint64_t timestamp);
 
 };
 

--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -9,6 +9,7 @@
 #include <tables/user_table.hpp>
 #include <tables/config_table.hpp>
 #include <tables/ban_table.hpp>
+#include <tables/moon_phases_table.hpp>
 #include <vector>
 #include <cmath>
 
@@ -239,6 +240,7 @@ CONTRACT proposals : public contract {
       uint64_t calc_voice_needed(uint64_t total_voice, uint64_t num_proposals);
       void check_values(string title, string summary, string description, string image, string url);
       bool is_banned(name account);
+      uint64_t get_new_moon(uint64_t timestamp);
 
       uint64_t config_get(name key) {
         DEFINE_CONFIG_TABLE
@@ -366,6 +368,9 @@ CONTRACT proposals : public contract {
         uint64_t by_delegatee()const { return delegatee.value; }
         uint128_t by_delegatee_delegator() const { return (uint128_t(delegatee.value) << 64) + delegator.value; }
       };
+
+      DEFINE_MOON_PHASES_TABLE
+      DEFINE_MOON_PHASES_TABLE_MULTI_INDEX
 
       TABLE cycle_stats_table {
         uint64_t propcycle; 

--- a/include/seeds.scheduler.hpp
+++ b/include/seeds.scheduler.hpp
@@ -3,6 +3,7 @@
 #include <contracts.hpp>
 #include <utils.hpp>
 #include <tables/config_table.hpp>
+#include <tables/moon_phases_table.hpp>
 
 using namespace eosio;
 using std::string;
@@ -73,14 +74,8 @@ CONTRACT scheduler : public contract {
             uint64_t by_timestamp() const { return timestamp; }
         };
 
-        TABLE moon_phases_table {
-            uint64_t timestamp;
-            time_point time;
-            string phase_name;
-            string eclipse;
-
-            uint64_t primary_key() const { return timestamp; }
-        };
+        DEFINE_MOON_PHASES_TABLE
+        DEFINE_MOON_PHASES_TABLE_MULTI_INDEX
 
         TABLE moon_ops_table {
             name id;
@@ -110,7 +105,6 @@ CONTRACT scheduler : public contract {
             const_mem_fun<operations_table, uint64_t, &operations_table::by_timestamp>>
         > operations_tables;
 
-        typedef eosio::multi_index <"moonphases"_n, moon_phases_table> moon_phases_tables;
 
         typedef eosio::multi_index <"moonops"_n, moon_ops_table,
             indexed_by<"bylastcycle"_n,

--- a/include/tables/moon_phases_table.hpp
+++ b/include/tables/moon_phases_table.hpp
@@ -1,0 +1,14 @@
+#include <eosio/eosio.hpp>
+
+using namespace eosio;
+
+#define DEFINE_MOON_PHASES_TABLE TABLE moon_phases_table { \
+      uint64_t timestamp; \
+      time_point time; \
+      string phase_name; \
+      string eclipse; \
+\
+      uint64_t primary_key() const { return timestamp; } \
+    }; \
+
+#define DEFINE_MOON_PHASES_TABLE_MULTI_INDEX typedef eosio::multi_index <"moonphases"_n, moon_phases_table> moon_phases_tables; \

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -914,13 +914,35 @@ void proposals::update_cycle() {
     cycle.set(c, get_self());
 }
 
+uint64_t proposals::get_new_moon (uint64_t timestamp) {
+
+  moon_phases_tables moonphases_t(contracts::scheduler, contracts::scheduler.value);
+
+  auto mitr = moonphases_t.lower_bound(timestamp);
+
+  while (mitr != moonphases_t.end()) {
+    if (mitr->phase_name == "New Moon") {
+      return mitr->timestamp;
+    }
+    mitr++;
+  }
+
+  return 0;
+
+}
+
 void proposals::init_cycle_new_stats () {
   cycle_table c = cycle.get();
 
+  uint64_t now = eosio::current_time_point().sec_since_epoch() - (utils::seconds_per_day * 5);
+
+  uint64_t start_time = get_new_moon(now);
+  uint64_t end_time = get_new_moon(start_time + utils::seconds_per_day);
+
   cyclestats.emplace(_self, [&](auto & item){
     item.propcycle = c.propcycle;
-    item.start_time = c.t_onperiod;
-    item.end_time = c.t_onperiod + config_get("propcyclesec"_n);
+    item.start_time = start_time;
+    item.end_time = end_time;
     // item.num_proposals = 0;
     item.num_votes = 0;
     item.total_voice_cast = 0;


### PR DESCRIPTION
- Added moon phases table to contracts proposals and dao.
- Now cycle stats for both contracts (proposals and dao) uses moon phases as start and end dates

Fixes #412 

Contracts to be deployed:
- [ ] Proposals
- [ ] Dao

No permissions nor settings need to be updated