### PR TITLE
add transferrable HPOOL tokens to pool contract

### DIFF
--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -20,6 +20,7 @@ namespace utils {
   const uint64_t proposal_cycle = moon_cycle;
 
   symbol seeds_symbol = symbol("SEEDS", 4);
+  symbol pool_symbol = symbol("HPOOL", 4);
 
   inline uint64_t linear_rank(uint64_t current, uint64_t total) { 
     /**

--- a/test/pool.test.js
+++ b/test/pool.test.js
@@ -1,7 +1,7 @@
 const { describe } = require("riteway")
-const { names, getTableRows, isLocal, initContracts, sleep, asset, getBalanceFloat } = require("../scripts/helper")
+const { names, getTableRows, isLocal, initContracts, sleep, asset, getBalanceFloat, eos } = require("../scripts/helper")
 
-const { firstuser, seconduser, thirduser, pool, accounts, settings, token, escrow } = names
+const { firstuser, seconduser, thirduser, fourthuser, pool, accounts, settings, token, escrow } = names
 
 
 describe('Pool transfer and payout', async assert => {
@@ -14,6 +14,7 @@ describe('Pool transfer and payout', async assert => {
   const contracts = await initContracts({ pool, accounts, settings, token })
 
   const users = [firstuser, seconduser, thirduser]
+  const allusers = [firstuser, seconduser, thirduser, fourthuser]
 
   const checkBalances = async ({ expected, given, should }) => {
     const balanceTable = await getTableRows({
@@ -57,7 +58,7 @@ describe('Pool transfer and payout', async assert => {
   await contracts.token.resetweekly({ authorization: `${token}@active` })
 
   console.log('get initial balances')
-  const balancesBefore = await Promise.all(users.map(user => getBalanceFloat(user)))
+  let balancesBefore = await Promise.all(users.map(user => getBalanceFloat(user)))
 
   console.log(`transfer to ${pool}`)
   await Promise.all(users.map((user, index) => contracts.token.transfer(user, escrow, `${10 * (index+1)}.0000 SEEDS`, '', { authorization: `${user}@active` })))
@@ -115,7 +116,7 @@ describe('Pool transfer and payout', async assert => {
   })
 
   console.log('get balances after')
-  const balancesAfter = await Promise.all(users.map(user => getBalanceFloat(user)))
+  let balancesAfter = await Promise.all(users.map(user => getBalanceFloat(user)))
 
   assert({
     given: 'all the payouts completed',
@@ -123,5 +124,112 @@ describe('Pool transfer and payout', async assert => {
     actual: balancesAfter.map((balanceAfter, index) => balanceAfter - balancesBefore[index]).reduce((acc, curr) => acc + curr),
     expected: 0
   })
+
+  console.log('---begin pool token tests---')
+  console.log('reset pool')
+  await contracts.pool.reset({ authorization: `${pool}@active` })
+
+  console.log('reset accounts')
+  await contracts.accounts.reset({ authorization: `${accounts}@active` })
+
+  console.log('reset settings')
+  await contracts.settings.reset({ authorization: `${settings}@active` })
+
+  console.log('reset token')
+  await contracts.token.resetweekly({ authorization: `${token}@active` })
+
+  console.log('get initial balances')
+  balancesBefore = await Promise.all(allusers.map(user => getBalanceFloat(user)))
+
+  console.log(`transfer to ${pool}`)
+  await Promise.all(users.map((user, index) => contracts.token.transfer(user, escrow, `${10 * (index+1)}.0000 SEEDS`, '', { authorization: `${user}@active` })))
+  await Promise.all(users.map((user, index) => contracts.token.transfer(escrow, pool, `${10 * (index+1)}.0000 SEEDS`, user, { authorization: `${escrow}@active` })))
+
+  assert({
+    given: 'transfered SEEDS',
+    should: 'have the correct HPOOL balances',
+    actual: await Promise.all(users.map(user => eos.getCurrencyBalance(pool, user, 'HPOOL'))),
+    expected: [ ["10.0000 HPOOL"], ["20.0000 HPOOL"], ["30.0000 HPOOL"] ]
+  })
+
+  console.log('transfer HPOOL')
+  await contracts.pool.transfer(seconduser, fourthuser, '5.0000 HPOOL', '', { authorization: `${seconduser}@active` })
+  await contracts.pool.transfer(thirduser, fourthuser, '15.0000 HPOOL', '', { authorization: `${thirduser}@active` })
+
+  await checkBalances({
+    expected: [
+      { account: firstuser, balance: '10.0000 SEEDS' },
+      { account: seconduser, balance: '15.0000 SEEDS' },
+      { account: thirduser, balance: '15.0000 SEEDS' },
+      { account: fourthuser, balance: '20.0000 SEEDS'}
+    ],
+    given: 'transfered HPOOL',
+    should: 'have the correct balances'
+  })
+
+  console.log('payout Seeds')
+  await contracts.pool.payouts('10.0000 SEEDS', { authorization: `${pool}@active` })
+  await sleep(2000)
+
+  await checkBalances({
+    expected: [
+      { account: firstuser, balance: '8.3334 SEEDS' },
+      { account: seconduser, balance: '12.5000 SEEDS' },
+      { account: thirduser, balance: '12.5000 SEEDS' },
+      { account: fourthuser, balance: '16.6667 SEEDS' }
+    ],
+    given: 'payout SEEDS',
+    should: 'have the correct balances'
+  })
+
+  console.log('transfer more HPOOL')
+  await contracts.pool.transfer(firstuser, seconduser, '8.3334 HPOOL', '', { authorization: `${firstuser}@active` })
+
+  await checkBalances({
+    expected: [
+      { account: seconduser, balance: '20.8334 SEEDS' },
+      { account: thirduser, balance: '12.5000 SEEDS' },
+      { account: fourthuser, balance: '16.6667 SEEDS' }
+    ],
+    given: 'transfer more HPOOL',
+    should: 'have the correct balances'
+  })
+
+  console.log('payout more Seeds')
+  await contracts.pool.payouts('20.0000 SEEDS', { authorization: `${pool}@active` })
+  await sleep(4000)
+
+  await checkBalances({
+    expected: [
+      { account: seconduser, balance: '12.5001 SEEDS' },
+      { account: thirduser, balance: '7.5001 SEEDS' },
+      { account: fourthuser, balance: '10.0001 SEEDS' }
+    ],
+    given: 'payout more SEEDS',
+    should: 'have the correct balances'
+  })
+
+  console.log('payout all the Seeds')
+  await contracts.pool.payouts('30.0003 SEEDS', { authorization: `${pool}@active` })
+  await sleep(2000)
+
+  await checkBalances({
+    expected: [],
+    given: 'payout all SEEDS',
+    should: 'have the correct balances'
+  })
+
+  console.log('get balances after')
+  balancesAfter = await Promise.all(allusers.map(user => getBalanceFloat(user)))
+  balancesDiff = balancesAfter.map( (balanceAfter, index) =>
+     parseFloat((balanceAfter - balancesBefore[index]).toFixed(6)) )
+
+  assert({
+    given: 'all the payouts completed',
+    should: 'have the correct Seeds balance',
+    actual: [ balancesDiff, balancesDiff.reduce((acc, curr) => acc + curr) ],
+    expected: [ [ -8.3334, 3.3334, -15, 20 ], 0 ]
+  })
+
 
 })

--- a/test/pool.test.js
+++ b/test/pool.test.js
@@ -231,5 +231,37 @@ describe('Pool transfer and payout', async assert => {
     expected: [ [ -8.3334, 3.3334, -15, 20 ], 0 ]
   })
 
+  console.log('---begin error condition checks---')
+
+  console.log('reset pool')
+  await contracts.pool.reset({ authorization: `${pool}@active` })
+
+  console.log('reset accounts')
+  await contracts.accounts.reset({ authorization: `${accounts}@active` })
+
+  console.log('reset settings')
+  await contracts.settings.reset({ authorization: `${settings}@active` })
+
+  console.log('reset token')
+  await contracts.token.resetweekly({ authorization: `${token}@active` })
+
+  console.log('get initial balances')
+  balancesBefore = await Promise.all(allusers.map(user => getBalanceFloat(user)))
+
+  console.log('bad transfer into pool')
+  let actionProperlyBlocked = true
+  try {
+    await contracts.token.transfer(firstuser, `${pool}`, '10.0000 SEEDS', '', { authorization: `${firstuser}@active` })
+    actionProperlyBlocked = false
+  } catch (err) {
+    actionProperlyBlocked = err.toString().includes('the sender is not an allowed account')
+    console.log( (actionProperlyBlocked ? "" : "un") + "expected error "+err)
+  }
+  assert({
+    given: 'trying to send user seeds to pool',
+    should: 'fail',
+    actual: actionProperlyBlocked,
+    expected: true
+  })
 
 })


### PR DESCRIPTION
This "tokenizes" deferred payouts in the pool contract. Could be part of the Rainbow project.
```
    ---begin pool token tests---
    reset pool
    reset accounts
    reset settings
    reset token
    get initial balances
    transfer to pool.seeds    ✔  Given transfered SEEDS: should have the correct HPOOL balances

    transfer HPOOL    ✔  Given transfered HPOOL: should have the correct balances
    ✔  Given transfered HPOOL: should have the correct balances

    payout Seeds    ✔  Given payout SEEDS: should have the correct balances
    ✔  Given payout SEEDS: should have the correct balances

    transfer more HPOOL    ✔  Given transfer more HPOOL: should have the correct balances
    ✔  Given transfer more HPOOL: should have the correct balances

    payout more Seeds    ✔  Given payout more SEEDS: should have the correct balances
    ✔  Given payout more SEEDS: should have the correct balances

    payout all the Seeds    ✔  Given payout all SEEDS: should have the correct balances
    ✔  Given payout all SEEDS: should have the correct balances

    get balances after    ✔  Given all the payouts completed: should have the correct Seeds balance
```