### PR TITLE
enforce max limits for invite campaigns

### DIFF
--- a/include/seeds.proposals.hpp
+++ b/include/seeds.proposals.hpp
@@ -164,6 +164,10 @@ CONTRACT proposals : public contract {
       name campaign_funding_type = "cmp.funding"_n;
       name milestone_type = "milestone"_n;
 
+      asset max_alliance_quantity = asset(uint64_t(3000000000), seeds_symbol);
+      asset max_invite_campaign_quantity = asset(uint64_t(3330000000), seeds_symbol);
+      asset max_max_amount_per_invite = asset(uint64_t(10000000), seeds_symbol);
+
       std::vector<name> scopes = {
         alliance_type,
         get_self(),

--- a/src/seeds.proposals.cpp
+++ b/src/seeds.proposals.cpp
@@ -998,9 +998,12 @@ void proposals::create_aux (
 
     // enforce max limit
     if (campaign_type == alliance_type) {
-      asset max_alliance_quantity =  asset(uint64_t(3000000000), seeds_symbol);
       check(quantity <= max_alliance_quantity, "Alliance grants quantity cannot be greater than 300,000 SEEDS");
     }
+  } else {
+    // enforce max on invite campaigns
+    check(quantity <= max_invite_campaign_quantity, "Invite campaign quantity cannot be greater than 333,000 SEEDS");
+    check(max_amount_per_invite <= max_max_amount_per_invite, "Invite max amount per invite is 1,000 SEEDS");
   }
 
   // funding campaigns are disabled since proposal 5
@@ -1102,6 +1105,8 @@ void proposals::createinvite (
   uint64_t max_reward = config_get("inv.max.rwrd"_n);
   check(reward.amount <= max_reward, "the reward can not be greater than " + std::to_string(max_reward));
   
+  check(max_amount_per_invite >= planted, "max amount must be >= planted");
+
   std::vector<uint64_t> perc = { 100, 0, 0, 0, 0, 0, 0};
   create_aux(creator, recipient, quantity, title, summary, description, image, url, fund, campaign_invite_type, perc, max_amount_per_invite, planted, reward);
 


### PR DESCRIPTION
implements:
https://github.com/JoinSEEDS/seeds-smart-contracts/issues/436

also logic check - planted needs to be < max invite value