### PR TITLE
initial implementation

### DIFF
--- a/include/seeds.history.hpp
+++ b/include/seeds.history.hpp
@@ -61,7 +61,8 @@ CONTRACT history : public contract {
         ACTION migrateusers();
         ACTION migrateuser(uint64_t start, uint64_t transaction_id, uint64_t chunksize);
         ACTION testptrx(uint64_t timestamp);
-
+        ACTION testcleantx(name account);
+        ACTION cleanuserstx(uint64_t start, uint64_t chunksize);
 
     private:
       const uint64_t status_regular = 0;
@@ -93,11 +94,14 @@ CONTRACT history : public contract {
       void send_trx_cbp_reward_action(name from, name to);
       void send_add_cbs(name account, int points);
       void trx_cbp_reward(name account, name key);
+      uint64_t cleantrxpt(name account);
       
       // migration functions
       void save_migration_user_transaction(name from, name to, asset quantity, uint64_t timestamp);
       void adjust_transactions(uint64_t id, uint64_t timestamp);
       uint64_t get_deferred_id();
+
+
 
       TABLE citizen_table {
         uint64_t id;
@@ -348,4 +352,6 @@ EOSIO_DISPATCH(history,
   (cleanptrxs)
   (migrateusers)(migrateuser)
   (migrate)(testptrx)
+  (testcleantx)
+  (cleanuserstx)
 );

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -273,6 +273,24 @@ namespace utils {
 
   }
 
+  double config_float_get(name key) {
+    DEFINE_CONFIG_FLOAT_TABLE
+    DEFINE_CONFIG_FLOAT_TABLE_MULTI_INDEX
+    config_float_tables configfloat(contracts::settings, contracts::settings.value);
+
+    auto citr = configfloat.find(key.value);
+    if (citr == configfloat.end()) { 
+      check(false, ("settings: the "+key.to_string()+" parameter has not been initialized").c_str());
+    }
+    return citr->value;
+  }
+
+  uint64_t get_trx_calc_cutoff_date() {
+    uint64_t now = eosio::current_time_point().sec_since_epoch();
+    uint64_t cutoffdate = now - (utils::moon_cycle * config_float_get("cyctrx.trail"_n));
+    return cutoffdate;
+  }
+
 
 }
 

--- a/src/seeds.harvest.cpp
+++ b/src/seeds.harvest.cpp
@@ -334,8 +334,7 @@ ACTION harvest::calctotal(uint64_t startval) {
 // Calculate Transaction Points for a single account
 // Returns count of iterations
 uint32_t harvest::calc_transaction_points(name account, name type) {
-  uint64_t now = eosio::current_time_point().sec_since_epoch();
-  uint64_t cutoffdate = now - (utils::moon_cycle * config_float_get("cyctrx.trail"_n));
+  uint64_t cutoffdate = utils::get_trx_calc_cutoff_date();
 
   transaction_points_tables transactions(contracts::history, account.value);
 
@@ -350,6 +349,8 @@ uint32_t harvest::calc_transaction_points(name account, name type) {
     titr++;
     count++;
   }
+
+  // TODO: This needs to delete older transactions so we don't eternally grow
 
   if (type == name("organisation")) {
     setorgtxpt(account, total_points);

--- a/src/seeds.history.cpp
+++ b/src/seeds.history.cpp
@@ -912,3 +912,64 @@ void history::cleanptrxs () {
   }
 }
 
+void history::cleanuserstx(uint64_t start, uint64_t chunksize) {
+  require_auth(get_self());
+
+  auto uitr = start == 0 ? users.begin() : users.find(start);
+  uint64_t count = 0;
+
+  while (uitr != users.end() && count < chunksize) {
+
+    name account = uitr -> account;
+
+    count += cleantrxpt(account);
+
+    print(" c "+std::to_string(count));
+
+    uitr++;
+  }
+
+  if (uitr != users.end()) {
+    action next_execution(
+      permission_level{get_self(), "active"_n},
+      get_self(),
+      "cleanuserstx"_n,
+      std::make_tuple(uitr -> account.value, chunksize)
+    );
+
+    transaction tx;
+    tx.actions.emplace_back(next_execution);
+    tx.delay_sec = 1;
+    tx.send(get_self().value, _self);
+  } 
+
+}
+
+ACTION history::testcleantx(name account) {
+  auto count = cleantrxpt(account);
+  print("cleaned "+std::to_string(count));
+}
+
+// Clean Transaction Points for a single account
+uint64_t history::cleantrxpt(name account) {
+  uint64_t cutoffdate = utils::get_trx_calc_cutoff_date();
+
+  transaction_points_tables transactions(contracts::history, account.value);
+
+  uint64_t count = 0;
+
+  auto titr = transactions.begin();
+  while (titr != transactions.end() && titr -> timestamp < cutoffdate && count < 200) {
+    
+    titr = transactions.erase(titr);
+
+    // DEBUG
+    // print("clean " + std::to_string(cutoffdate) + " " + std::to_string(titr -> timestamp) + " ");
+    // titr++;
+
+    count++;
+  }
+
+  return count;
+}
+


### PR DESCRIPTION
adding some manual cleanup functions

these clean up user's transactions histories that are > 3 months old (or current cutoff set in the settings)

It works in conjunction with harvest, where only transactions at a certain cutoff date are counted. 