### PR TITLE
Master token list: allow updates to validation schema

### DIFF
--- a/include/seeds.tokensmaster.hpp
+++ b/include/seeds.tokensmaster.hpp
@@ -155,10 +155,19 @@ CONTRACT tokensmaster : public contract {
       */
       ACTION updwhitelist(string chain, extended_symbol token, bool add);
 
+      /**
+          * The `setschema` action executed by manager account (or by contract
+          * account prior to initialization with the `init` action) replaces
+          * the existing schema (if any) with a new one.
+          *
+          * @param schema - the JSON schema defining valid metadata
+      */
+      ACTION setschema(const string& schema);
+
 
   private:
       const uint16_t MAXJSONLENGTH = 2048;
-      string json_schema();
+      const string json_schema();
 
       TABLE config { // single table, singleton, scoped by contract account name
         string             chain;

--- a/src/seeds.tokensmaster.cpp
+++ b/src/seeds.tokensmaster.cpp
@@ -14,16 +14,14 @@ void tokensmaster::reset() {
   utils::delete_table<white_table>(get_self(), get_self().value);
   config_table configs(get_self(), get_self().value);
   configs.remove();
+  schema_table schema(get_self(), get_self().value);
+  schema.remove();
+  
 }
 
 void tokensmaster::init(string chain, name manager, bool verify) {
   require_auth(get_self());
-  schema_table schemas(get_self(), get_self().value);
-  if( !schemas.exists() ) {
-    auto schema_entry = schemas.get_or_create(get_self(), schema_row);
-    schema_entry.schema = json_schema();
-    schemas.set(schema_entry, get_self());
-  }
+  
   config_table configs(get_self(), get_self().value);
   check(!configs.exists(), "cannot re-initialize configuration");
 
@@ -34,6 +32,7 @@ void tokensmaster::init(string chain, name manager, bool verify) {
   updwhitelist("Telos", extended_symbol( symbol("SEEDS",4 ), "token.seeds"_n ), true);
   updwhitelist("Telos", extended_symbol( symbol("TLOS",4 ), "eosio.token"_n ), true);
 
+  setschema(json_schema());
   auto config_entry = configs.get_or_create(get_self(), config_row);
   check(chain.size() <= 32, "chain name too long");
   config_entry.chain = chain;
@@ -223,7 +222,21 @@ void tokensmaster::updwhitelist(string chain, extended_symbol token, bool add)
   }
 }
 
-string tokensmaster::json_schema() {
+void tokensmaster::setschema(const string& schema)
+{
+  config_table configs(get_self(), get_self().value);
+  if( configs.exists() ) {
+    require_auth( configs.get().manager );
+  } else {
+    require_auth( get_self() );
+  }
+  schema_table schemas(get_self(), get_self().value);
+  auto schema_entry = schemas.get_or_create(get_self(), schema_row);
+  schema_entry.schema = schema;
+  schemas.set(schema_entry, get_self());
+}
+
+const string tokensmaster::json_schema() {
   return 
   R"--({
     "$schema": "http://json-schema.org/draft-04/schema#",
@@ -258,18 +271,21 @@ string tokensmaster::json_schema() {
         "logo": {
             "description": "url pointing to lo-res logo image",
             "type": "string",
+            "format": "uri",
             "minLength":3,
             "maxlength":128
         },
         "logo_lg": {
             "description": "url pointing to hi-res logo image",
             "type": "string",
+            "format": "uri",
             "minLength":3,
             "maxlength":128
         },
         "bg_image": {
             "description": "url pointing to card background image",
             "type": "string",
+            "format": "uri",
             "minLength":3,
             "maxlength":128
         },
@@ -288,6 +304,7 @@ string tokensmaster::json_schema() {
         "web_link": {
             "description": "url to webpage with info about token host project",
             "type": "string",
+            "format": "uri",
             "minLength":3,
             "maxlength":128
         },


### PR DESCRIPTION
The tmastr.seeds contract maintains a list of tokens used in the Seeds ecosystem along with metadata such as logo image, name, etc. The contract also maintains a JSON schema on-chain which is used by several applications (including Light Wallet) to validate each token's metadata when generated or utilized.

This PR corrects an oversight which made the schema string immutable (we anticipate that maintenance and extension of the schema will be desirable).

This PR also includes a minor edit to the schema itself, specifying "uri" formats.

Re: https://github.com/JoinSEEDS/seeds_light_wallet/issues/1919 "Master Token List Schema",
Author is aware that use of the JSON schema in Light Wallet is controversial but this PR is a needed fix for the existing implementation independent of possible future redesign/restructuring.

@n13 