### PR TITLE
Bulk onboarding script update for invite manager

### DIFF
--- a/scripts/onboarding_script.js
+++ b/scripts/onboarding_script.js
@@ -144,6 +144,7 @@ const bulk_invite = async (sponsor, referrer, num, totalAmount) => {
 
     totalAmount = parseInt(totalAmount)
     var secrets = "Secret,Hash,Seeds (total)\n"
+    var invitelist = ""
     const fileName = 'secrets_'+num+'.csv'
     var log = []
 
@@ -204,9 +205,10 @@ const bulk_invite = async (sponsor, referrer, num, totalAmount) => {
             actions.push(inv.action)
             log.push(inv)
             secrets = secrets + inv.secret +"," + inv.hashedSecret + "," + totalAmount + "\n"
+            invitelist = invitelist +"https://joinseeds.app.link/accept-invite?invite-secret="+inv.secret+"\n"
         }
     
-        console.log("secrets: "+secrets)
+        //console.log("secrets: "+secrets)
     
         //console.log("actions: " + JSON.stringify(actions, null, 2))
     
@@ -222,7 +224,7 @@ const bulk_invite = async (sponsor, referrer, num, totalAmount) => {
     
         fs.writeFileSync(fileName, secrets)
         fs.writeFileSync('invite_log_'+num+'.json', JSON.stringify(log, null,2))
-        
+        fs.writeFileSync('invitelist_'+num+'.txt', invitelist)          
         console.log(num + " secrets written to "+fileName)
     
     } catch (err) {
@@ -309,7 +311,7 @@ const createCPUAction = (sponsor) => {
         authorization: [
             {
                 actor: harvest,
-                permission: 'active',
+                permission: 'payforcpu',
             },
             {
                 actor: sponsor,


### PR DESCRIPTION
The existing onboarding script includes a `bulk_invite` command, which generates a quantity of invites, places them on chain, and saves a file `secrets_nnn.csv` containing the secrets and hashes.

This PR adds an additional output file `invitelist_nnn.txt`  containing lines of the form
```
https://joinseeds.app.link/accept-invite?invite-secret=354a364a624d46784c546d645a6855704755613767437167517674705a684c47
```
This is consistent with the invite "export" function of the Seeds Global Passport web application, and can be imported to the invite manager at https://invites.joinseeds.earth/login

![image](https://user-images.githubusercontent.com/2141014/199619569-c5e8cf69-6858-42ac-a14a-f1ef206ba674.png)
